### PR TITLE
Set plugin if music path is set

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2122,6 +2122,19 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 
 		_strlwr(parentName);
 
+		if (external_music_path != nullptr)
+		{
+			if (_access(external_music_path, 0) != -1)
+			{
+				use_external_music = FFNX_MUSIC_WINAMP;
+			}
+
+			else
+			{
+				external_music_path == nullptr;
+			}
+		}
+
 		if (!ff8 &&
 			(
 				strstr(parentName, "ff7.exe") != NULL ||


### PR DESCRIPTION
If the user has set a path check if we can open that path and we if can ensure our plugin is set correctly .. This happens before our other checks so our defaults will now acts as a fallback as an added bonus.