### PR TITLE
Rename use_external_movie => enable_ffmpeg_videos

### DIFF
--- a/misc/FFNx.cfg
+++ b/misc/FFNx.cfg
@@ -83,7 +83,7 @@
 # This flag will enable/disable the support of FFMpeg layer to reproduce movies in-game.
 # By default this flag is enabled for FF7 1998, FF7/FF8 Steam edition and disabled for FF8 2000 edition.
 # It is suggested to keep the default behavior unless you really know what are you doing.
-#use_external_movie = yes
+#enable_ffmpeg_videos = yes
 
 # external video extension
 # This flag will allow you to customize the video extension to be used. By default is avi.

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -28,7 +28,7 @@
 
 // configuration variables with their default values
 char *mod_path = nullptr;
-cfg_bool_t use_external_movie = cfg_bool_t(true);
+cfg_bool_t enable_ffmpeg_videos = cfg_bool_t(true);
 char* external_movie_ext = nullptr;
 long use_external_music = FFNX_MUSIC_NONE;
 char* external_music_path = nullptr;
@@ -79,7 +79,7 @@ char* direct_mode_path = nullptr;
 
 cfg_opt_t opts[] = {
 		CFG_SIMPLE_STR("mod_path", &mod_path),
-		CFG_SIMPLE_BOOL("use_external_movie", &use_external_movie),
+		CFG_SIMPLE_BOOL("enable_ffmpeg_videos", &enable_ffmpeg_videos),
 		CFG_SIMPLE_STR("external_movie_ext", &external_movie_ext),
 		CFG_SIMPLE_INT("use_external_music", &use_external_music),
 		CFG_SIMPLE_STR("external_music_path", &external_music_path),
@@ -148,7 +148,7 @@ void read_cfg()
 {
 	cfg_t* cfg;
 
-	use_external_movie = cfg_bool_t(!ff8);
+	enable_ffmpeg_videos = cfg_bool_t(!ff8);
 
 	if (_access(FFNX_CFG_FILE, 0) == 0)
 	{

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -28,7 +28,7 @@
 #include "log.h"
 
 extern char *mod_path;
-extern cfg_bool_t use_external_movie;
+extern cfg_bool_t enable_ffmpeg_videos;
 extern char* external_movie_ext;
 extern long use_external_music;
 extern char* external_music_path;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2254,7 +2254,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 			patch_code_dword(offset3, (DWORD)dotemuMciSendCommandA);
 
 			// Steam edition contains movies unpacked
-			use_external_movie = cfg_bool_t(true);
+			enable_ffmpeg_videos = cfg_bool_t(true);
 		}
 
 		// Apply hext patching

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -434,5 +434,5 @@ struct ff8_gfx_driver *ff8_load_driver(struct ff8_game_obj *game_object)
 
 void ff8_post_init()
 {
-	if(use_external_movie) movie_init();
+	if(enable_ffmpeg_videos) movie_init();
 }


### PR DESCRIPTION
Change the var use_external_movie => enable_ffmpeg_videos
this User facing change is pre-cursor to a configuration clean up i plan to do later. The config option was changed to more clearly reflect what it does.