### PR TITLE
Feature/wav in winamp plugin + music lock patch

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -182,6 +182,7 @@ struct common_externals
 	uint get_time;
 	uint midi_init;
 	char *(*get_midi_name)(uint);
+	uint use_midi;
 	uint play_midi;
 	uint stop_midi;
 	uint cross_fade_midi;

--- a/src/externals_102_de.h
+++ b/src/externals_102_de.h
@@ -71,3 +71,4 @@ ff7_externals.wm_activateapp =                0x409CF2;
 ff7_externals.get_gamepad =                   0x41F99E;
 ff7_externals.update_gamepad_status =         0x41F7D8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9AEBE8;
+ff7_externals.music_lock_clear_fix =          0x63C030;

--- a/src/externals_102_de.h
+++ b/src/externals_102_de.h
@@ -31,6 +31,7 @@ common_externals.get_time =                   0x660340;
 common_externals.midi_init =                  0x6DE060;
 common_externals.get_midi_name = (char* (*)(uint))0x6E69B0;
 common_externals.play_midi =                  0x6DE935;
+common_externals.use_midi =                   0x6DDF83;
 common_externals.stop_midi =                  0x6DF70B;
 common_externals.cross_fade_midi =            0x6DF4CE;
 common_externals.pause_midi =                 0x6DF65B;

--- a/src/externals_102_fr.h
+++ b/src/externals_102_fr.h
@@ -71,3 +71,4 @@ ff7_externals.wm_activateapp =                0x409D02;
 ff7_externals.get_gamepad =                   0x41F9AE;
 ff7_externals.update_gamepad_status =         0x41F7E8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9AFC18;
+ff7_externals.music_lock_clear_fix =          0x63C000;

--- a/src/externals_102_fr.h
+++ b/src/externals_102_fr.h
@@ -31,6 +31,7 @@ common_externals.get_time =                   0x660310;
 common_externals.midi_init =                  0x6DE000;
 common_externals.get_midi_name = (char* (*)(uint))0x6E6950;
 common_externals.play_midi =                  0x6DE8D5;
+common_externals.use_midi =                   0x6DDF23;
 common_externals.stop_midi =                  0x6DF6AB;
 common_externals.cross_fade_midi =            0x6DF46E;
 common_externals.pause_midi =                 0x6DF5FB;

--- a/src/externals_102_sp.h
+++ b/src/externals_102_sp.h
@@ -71,3 +71,4 @@ ff7_externals.wm_activateapp =                0x409D02;
 ff7_externals.get_gamepad =                   0x41F9AE;
 ff7_externals.update_gamepad_status =         0x41F7E8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9B0678;
+ff7_externals.music_lock_clear_fix =          0x63C000;

--- a/src/externals_102_sp.h
+++ b/src/externals_102_sp.h
@@ -31,6 +31,7 @@ common_externals.get_time =                   0x660310;
 common_externals.midi_init =                  0x6DE000;
 common_externals.get_midi_name = (char* (*)(uint))0x6E6950;
 common_externals.play_midi =                  0x6DE8D5;
+common_externals.use_midi =                   0x6DDF23;
 common_externals.stop_midi =                  0x6DF6AB;
 common_externals.cross_fade_midi =            0x6DF46E;
 common_externals.pause_midi =                 0x6DF5FB;

--- a/src/externals_102_us.h
+++ b/src/externals_102_us.h
@@ -71,3 +71,4 @@ ff7_externals.wm_activateapp =                0x409CF2;
 ff7_externals.get_gamepad =                   0x41F99E;
 ff7_externals.update_gamepad_status =         0x41F7D8;
 ff7_externals.gamepad_status =        (struct ff7_gamepad_status*)0x9ADE28;
+ff7_externals.music_lock_clear_fix =          0x63C060;

--- a/src/externals_102_us.h
+++ b/src/externals_102_us.h
@@ -31,6 +31,7 @@ common_externals.get_time =                   0x660370;
 common_externals.midi_init =                  0x741780;
 common_externals.get_midi_name =      (char* (*)(uint))0x74A0D0;
 common_externals.play_midi =                  0x742055;
+common_externals.use_midi =                   0x7416A3;
 common_externals.stop_midi =                  0x742E2B;
 common_externals.cross_fade_midi =            0x742BEE;
 common_externals.pause_midi =                 0x742D7B;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1601,6 +1601,8 @@ struct ff7_externals
 	uint get_gamepad;
 	uint update_gamepad_status;
 	struct ff7_gamepad_status* gamepad_status;
+	uint music_is_locked;
+	uint music_lock_clear_fix;
 };
 
 uint ff7gl_load_group(uint group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -31,6 +31,7 @@ void music_init()
 {
 	// Add Global Focus flag to DirectSound Secondary Buffers
 	patch_code_byte(common_externals.directsound_buffer_flags_1 + 0x4, 0x80); // DSBCAPS_GLOBALFOCUS & 0x0000FF00
+	patch_code_dword(ff7_externals.music_lock_clear_fix + 2, 0xCC195C);
 
 	if (use_external_music)
 	{
@@ -46,7 +47,7 @@ void music_init()
 		else {
 			replace_function(common_externals.midi_init, midi_init);
 			replace_function(common_externals.use_midi, ff7_use_midi);
-			replace_function(common_externals.play_midi, play_midi);
+			replace_function(common_externals.play_midi, ff7_play_midi);
 			replace_function(common_externals.cross_fade_midi, cross_fade_midi);
 			replace_function(common_externals.pause_midi, pause_midi);
 			replace_function(common_externals.restart_midi, restart_midi);
@@ -116,11 +117,8 @@ uint ff8_play_midi(uint midi, uint volume, uint u1, uint u2)
 		return 0; // Error
 	}
 
-	if (use_external_music)
-	{
-		winamp_set_music_volume(volume);
-		winamp_play_music(midi_name, midi);
-	}
+	winamp_set_music_volume(volume);
+	winamp_play_music(midi_name, midi);
 
 	return 1; // Success
 }
@@ -136,34 +134,29 @@ uint ff7_use_midi(uint midi)
 	return strcmp(name, "HEART") != 0 && strcmp(name, "SATO") != 0 && strcmp(name, "SENSUI") != 0 && strcmp(name, "WIND") != 0;
 }
 
-void play_midi(uint midi)
+void ff7_play_midi(uint midi)
 {
-	if (use_external_music)
-		winamp_play_music(common_externals.get_midi_name(midi), midi);
+	winamp_play_music(common_externals.get_midi_name(midi), midi);
 }
 
 void cross_fade_midi(uint midi, uint time)
 {
-	if (use_external_music)
-		winamp_cross_fade_music(common_externals.get_midi_name(midi), midi, time);
+	winamp_cross_fade_music(common_externals.get_midi_name(midi), midi, time);
 }
 
 void pause_midi()
 {
-	if (use_external_music)
-		winamp_pause_music();
+	winamp_pause_music();
 }
 
 void restart_midi()
 {
-	if (use_external_music)
-		winamp_resume_music();
+	winamp_resume_music();
 }
 
 void stop_midi()
 {
-	if (use_external_music)
-		winamp_stop_music();
+	winamp_stop_music();
 }
 
 uint ff8_stop_midi()
@@ -182,9 +175,7 @@ uint ff8_stop_midi()
 
 uint midi_status()
 {
-	if (use_external_music)
-		return winamp_music_status();
-	return 0;
+	return winamp_music_status();
 }
 
 uint ff8_set_direct_volume(int volume)
@@ -205,33 +196,28 @@ uint ff8_set_direct_volume(int volume)
 		volume = (pow(10, (volume + 2000) / 2000.0f) / 10.0f) * 255.0f;
 	}
 	
-	if (use_external_music)
-		winamp_set_direct_volume(volume);
+	winamp_set_direct_volume(volume);
 	return 1; // Success
 }
 
 void set_master_midi_volume(uint volume)
 {
-	if (use_external_music)
-		winamp_set_master_music_volume(volume);
+	winamp_set_master_music_volume(volume);
 }
 
 void set_midi_volume(uint volume)
 {
-	if (use_external_music)
-		winamp_set_music_volume(volume);
+	winamp_set_music_volume(volume);
 }
 
 void set_midi_volume_trans(uint volume, uint step)
 {
-	if (use_external_music)
-		winamp_set_music_volume_trans(volume, step);
+	winamp_set_music_volume_trans(volume, step);
 }
 
 void set_midi_tempo(unsigned char tempo)
 {
-	if (use_external_music)
-		winamp_set_music_tempo(tempo);
+	winamp_set_music_tempo(tempo);
 }
 
 uint ff7_directsound_release()
@@ -249,14 +235,12 @@ uint ff7_directsound_release()
 
 void music_cleanup()
 {
-	if (use_external_music)
-		winamp_music_cleanup();
+	winamp_music_cleanup();
 }
 
 uint remember_playing_time()
 {
-	if (use_external_music)
-		winamp_remember_playing_time();
+	winamp_remember_playing_time();
 	return 0;
 }
 

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -45,6 +45,7 @@ void music_init()
 		}
 		else {
 			replace_function(common_externals.midi_init, midi_init);
+			replace_function(common_externals.use_midi, ff7_use_midi);
 			replace_function(common_externals.play_midi, play_midi);
 			replace_function(common_externals.cross_fade_midi, cross_fade_midi);
 			replace_function(common_externals.pause_midi, pause_midi);
@@ -122,6 +123,17 @@ uint ff8_play_midi(uint midi, uint volume, uint u1, uint u2)
 	}
 
 	return 1; // Success
+}
+
+uint ff7_use_midi(uint midi)
+{
+	char* name = common_externals.get_midi_name(midi);
+
+	if (winamp_can_play(name)) {
+		return 1;
+	}
+
+	return strcmp(name, "HEART") != 0 && strcmp(name, "SATO") != 0 && strcmp(name, "SENSUI") != 0 && strcmp(name, "WIND") != 0;
 }
 
 void play_midi(uint midi)

--- a/src/music.h
+++ b/src/music.h
@@ -28,6 +28,7 @@ void music_init();
 uint midi_init(uint unknown);
 uint ff7_directsound_release();
 void music_cleanup();
+uint ff7_use_midi(uint midi);
 void play_midi(uint midi);
 uint ff8_play_midi(uint midi, uint volume, uint u1, uint u2);
 void cross_fade_midi(uint midi, uint time);

--- a/src/music.h
+++ b/src/music.h
@@ -29,7 +29,7 @@ uint midi_init(uint unknown);
 uint ff7_directsound_release();
 void music_cleanup();
 uint ff7_use_midi(uint midi);
-void play_midi(uint midi);
+void ff7_play_midi(uint midi);
 uint ff8_play_midi(uint midi, uint volume, uint u1, uint u2);
 void cross_fade_midi(uint midi, uint time);
 void pause_midi();

--- a/src/winamp/music.cpp
+++ b/src/winamp/music.cpp
@@ -57,6 +57,11 @@ void winamp_apply_volume()
 	}
 }
 
+void build_filename(char* filename, char* midi, char* ext)
+{
+	sprintf(filename, "%s/%s/%s.%s", basedir, external_music_path, midi, ext);
+}
+
 void winamp_load_song(char* midi, uint id, bool crossfade)
 {
 	char filename[MAX_PATH];
@@ -82,7 +87,7 @@ void winamp_load_song(char* midi, uint id, bool crossfade)
 		return;
 	}
 	
-	sprintf(filename, "%s/%s/%s.%s", basedir, external_music_path, midi, external_music_ext);
+	build_filename(filename, midi, external_music_ext);
 	
 	winamp_apply_volume();
 
@@ -304,6 +309,15 @@ void winamp_music_init()
 	winampRenderHandle = (HANDLE)_beginthreadex(nullptr, 0, &winamp_render_thread, nullptr, 0, &winampRenderThreadID);
 
 	info("Winamp music plugin loaded using %s and %s\n", in_type, out_type);
+}
+
+bool winamp_can_play(char* midi)
+{
+	char filename[MAX_PATH];
+
+	build_filename(filename, midi, external_music_ext);
+
+	return _access(filename, 0) == 0;
 }
 
 // start playing some music, <midi> is the name of the MIDI file without the .mid extension

--- a/src/winamp/music.h
+++ b/src/winamp/music.h
@@ -13,6 +13,7 @@
 #include "out_directsound.h"
 
 void winamp_music_init();
+bool winamp_can_play(char* midi);
 void winamp_play_music(char* midi, uint id);
 void winamp_stop_music();
 void winamp_cross_fade_music(char* midi, uint id, int time);


### PR DESCRIPTION
Adding ability to replace the wav files (FF7 only)

Fix a music bug in the game: the "lock music" instruction is cleared on field changes, but "lock music" should be persistent across fields. This fixes:
- music stop bug in the first scene with Reno and Aerith
- Battle music restarted after the fight against Rufus
- Underneath the rotting pizza intervention after the movie with Sephiroth in fire
- more scenes I haven't tested involving MUSCLCK opcode (in space for example)

Possible consequence: if fields scripts does not unlock music correctly, a music could be played for too long in wrong scenes.