### PR TITLE
Clean up cfg style to be more readable

### DIFF
--- a/misc/FFNx.cfg
+++ b/misc/FFNx.cfg
@@ -20,7 +20,6 @@
 #########################
 
 #[RENDERING BACKEND]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Available choices are:
 # - OpenGL ( default )
 # - Direct3D11 ( valid alternative for OpenGL)
@@ -30,13 +29,11 @@
 #renderer_backend = OpenGL
 
 #[FULLSCREEN]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # If off, it will run in window mode.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #fullscreen = no
 
 #[RESOLUTION]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Resolution of the game.
 # Default (value = 0):
 # - Window mode will use 640x480
@@ -46,7 +43,6 @@
 #window_size_y = 0
 
 #[INTERNAL RESOLUTION SCALE]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # The scale is in multiples of 640x480
 # The scale factor is used to render internally at a larger size then the display, this will then be downscaled to the games current resolution
 # This is required to avoid visual glitches that may happen when the game is not rendered in a 4:3 aspect ratio
@@ -55,7 +51,6 @@
 #internal_resolution_scale = 4
 
 #[PRESERVE ASPECT]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Preserve original game aspect ratio of (4:3) by adding black bars on the left and right side (if needed)
 # When off the game will be stretched to fit the window's aspect ratio; Be aware the game may look wrong though.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -67,14 +62,12 @@
 
 
 # [REFRESH RATE]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Screen refresh rate.
 # Default is 0 = use current screen refresh rate
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #refresh_rate = 0
 
 #[LINEAR FILTERING]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Allow the usage of linear filtering for textures.
 # Please note: some things look slightly better with this option on, but alot of textures just lose their detail.
 # This option only affects low-res textures, high-res replacements will still be filtered where appropriate.
@@ -82,7 +75,6 @@
 #linear_filter = no
 
 #[ANTIALIASING]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Enable antialiasing filtering, this is done in the last pass when downsampling from the current supersampled rendering ( based on internal_resolution_scale logic )
 # Available choices are:
 # - 0: Disabled ( Default )
@@ -95,7 +87,6 @@
 #enable_antialiasing = 0
 
 #[ANISOTROPIC]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Enable anisotropic filtering, for high-res textures and overall rendering
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #enable_anisotropic = yes
@@ -105,7 +96,6 @@
 #########################
 
 #[USE EXTERNAL MUSIC]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # This flag will enable/disable the support of an enhanced music layer to reproduce music in-game.
 # If you leave out the default configuration
 # FFNx will autodetect your environment and will set it to the best available option.
@@ -113,7 +103,6 @@
 #use_external_music = yes
 
 # [EXTERNAL MUSIC PATH]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Path of the external music files
 # Will try to load from this path before using the default for your Version of the game
 # Defaults:
@@ -124,7 +113,6 @@
 #external_music_path =
 
 # [EXTERNAL MUSIC EXTENSION]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # The type of file to search for. By default is ogg.
 # Supported extensions: 
 # - https://github.com/losnoco/vgmstream#supported-file-types
@@ -134,7 +122,6 @@
 
 
 # [EXTERNAL WINAMP PLUGIN SUPPORT]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # These flags will allow you to make use of compatible in_* and out_* DLL plugins you were used to load on Winamp itself.
 # Through these flags you can for example decide to use an input plugin to play something FFNx never though about ( like MINIPSF files )
 # and output the sound data to your custom plugin which may add custom reverb and much more.
@@ -149,7 +136,6 @@
 ###########################
 
 #[ENABLE FFMPEG VIDEOS]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # This flag will enable/disable the support of FFMpeg layer to reproduce movies in-game.
 # Default Value depends on game version.
 # - FF7 1998 - yes
@@ -160,7 +146,6 @@
 #enable_ffmpeg_videos = yes
 
 #[FFMPEG VIDEO FILE EXTENSION]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # The type of file that the ffmpeg layer will search for. Default is avi.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #ffmpeg_video_ext = avi
@@ -171,7 +156,6 @@
 # FF7 2012   FF7 STEAM
 # FF8 2013   FF8 STEAM
 ###############################
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # The folder name in your game Documents path ( for eg. for FF7 is "C:\Users\JohnDoe\Documents\Square Enix\FINAL FANTASY VII Steam\user_XXXXXXX")
 # Use this only if you have MORE THAN ONE user_* directories. If not, just leave this commented as the driver will autodetect the directory.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -182,7 +166,6 @@
 ########################
 
 #[TEXTURE PATH]
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Mod directory where textures will be loaded from
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #mod_path = mods/Textures
@@ -209,7 +192,7 @@
 
 
 ##########################
-## DEBUGGING OPTIONS 
+## DEBUGGING OPTIONS
 # These options are mostly useful for developers or people reporting crashes.
 # Please do enable them only when required.
 ##########################


### PR DESCRIPTION
Removed the 
#~~~~~~~~~~~~~~~ 
before the description. these lines are now only after the description and before the option. This should make it easier to see where the option goes more easily