### PR TITLE
Replace open_flevel_siz method with a more flexible implementation

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1601,6 +1601,11 @@ struct ff7_externals
 	struct ff7_gamepad_status* gamepad_status;
 	uint music_is_locked;
 	uint music_lock_clear_fix;
+	uint sub_4089C5;
+	uint sub_60DF96;
+	uint sub_60EEB2;
+	uint open_flevel_siz;
+	uint field_map_infos;
 };
 
 uint ff7gl_load_group(uint group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -35,6 +35,7 @@ struct ff7_gamepad_status* ff7_update_gamepad_status();
 // field
 void field_load_textures(struct ff7_game_obj *game_object, struct struc_3 *struc_3);
 void field_layer2_pick_tiles(short x_offset, short y_offset);
+uint field_open_flevel_siz();
 
 // file
 FILE *open_lgp_file(char *filename, uint mode);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -299,6 +299,12 @@ void ff7_find_externals()
 
 	ff7_externals.cleanup_game = get_absolute_value(ff7_externals.init_stuff, 0x350);
 	ff7_externals.cleanup_midi = get_relative_call(ff7_externals.cleanup_game, 0x72);
+
+	ff7_externals.sub_4089C5 = get_absolute_value(ff7_externals.init_stuff, 0x336);
+	ff7_externals.sub_60DF96 = get_relative_call(ff7_externals.sub_4089C5, 0x42B);
+	ff7_externals.sub_60EEB2 = get_relative_call(ff7_externals.sub_60DF96, 0x26);
+	ff7_externals.open_flevel_siz = get_relative_call(ff7_externals.sub_60EEB2, 0x79F);
+	ff7_externals.field_map_infos = get_absolute_value(ff7_externals.open_flevel_siz, 0xAF) - 0xBC;
 }
 
 void ff7_data()

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -105,6 +105,7 @@ struct ff7_gfx_driver *ff7_load_driver(struct ff7_game_obj *game_object)
 	replace_function(ff7_externals.field_layer2_pick_tiles, field_layer2_pick_tiles);
 	patch_code_byte(ff7_externals.field_draw_everything + 0xE2, 0x1D);
 	patch_code_byte(ff7_externals.field_draw_everything + 0x353, 0x1D);
+	replace_function(ff7_externals.open_flevel_siz, field_open_flevel_siz);
 
 	replace_function(ff7_externals.get_equipment_stats, get_equipment_stats);
 


### PR DESCRIPTION
flevel.lgp/flevel.siz contains the uncompressed sizes of the LZSed field map files.

The current implementation uses this file to allocate enough memory to uncompress the field. It adds 2000000 to this value, just to be safe.

But not matters how long is flevel.siz, the parser always read 387 entries (aka the field map count). The game initialize 1200 (see sub_60EEB2) entries of the field info structure (where the uncompressed size is stored), so we should be safe to increase this limitation.