### PR TITLE
SFX fixes

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -35,6 +35,7 @@
 #include "gl.h"
 #include "movies.h"
 #include "music.h"
+#include "sfx.h"
 #include "saveload.h"
 #include "gamepad.h"
 
@@ -2065,7 +2066,8 @@ __declspec(dllexport) void *new_dll_graphics_driver(void *game_object)
 	info("Original resolution %ix%i, New resolution %ix%i\n", game_width, game_height, window_size_x, window_size_y);
 
 	// perform any additional initialization that requires the rendering environment to be set up
-	if (use_external_music) music_init();
+	music_init();
+	sfx_init();
 	if(!ff8) ff7_post_init();
 	else ff8_post_init();
 

--- a/src/common.h
+++ b/src/common.h
@@ -212,8 +212,10 @@ struct common_externals
 	uint winmain;
 	uint load_tex_file;
 	uint directsound_buffer_flags_1;
-	void (*play_sfx)(uint);
+	uint (*play_sfx)(uint);
+	uint play_sfx_on_channel;
 	uint (*set_sfx_volume)(uint, uint);
+	uint *master_sfx_volume;
 };
 
 // heap allocation wrappers

--- a/src/common.h
+++ b/src/common.h
@@ -212,6 +212,8 @@ struct common_externals
 	uint winmain;
 	uint load_tex_file;
 	uint directsound_buffer_flags_1;
+	void (*play_sfx)(uint);
+	uint (*set_sfx_volume)(uint, uint);
 };
 
 // heap allocation wrappers

--- a/src/externals_102_de.h
+++ b/src/externals_102_de.h
@@ -44,8 +44,6 @@ common_externals.font_info =          (char *)0x99EB68;
 common_externals.build_dialog_window =        0x7743B0;
 common_externals.load_tex_file =              0x688C66;
 common_externals.directsound_buffer_flags_1 = 0x6E6E3D;
-common_externals.play_sfx =                   0x000000;
-common_externals.set_sfx_volume =             0x000000;
 
 ff7_externals.chocobo_fix =                   0x70B512;
 ff7_externals.midi_fix =                      0x6E0422;
@@ -72,4 +70,3 @@ ff7_externals.get_gamepad =                   0x41F99E;
 ff7_externals.update_gamepad_status =         0x41F7D8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9AEBE8;
 ff7_externals.music_lock_clear_fix =          0x63C030;
-ff7_externals.sound_operation =               0;

--- a/src/externals_102_de.h
+++ b/src/externals_102_de.h
@@ -44,6 +44,8 @@ common_externals.font_info =          (char *)0x99EB68;
 common_externals.build_dialog_window =        0x7743B0;
 common_externals.load_tex_file =              0x688C66;
 common_externals.directsound_buffer_flags_1 = 0x6E6E3D;
+common_externals.play_sfx =                   0x000000;
+common_externals.set_sfx_volume =             0x000000;
 
 ff7_externals.chocobo_fix =                   0x70B512;
 ff7_externals.midi_fix =                      0x6E0422;

--- a/src/externals_102_de.h
+++ b/src/externals_102_de.h
@@ -72,3 +72,4 @@ ff7_externals.get_gamepad =                   0x41F99E;
 ff7_externals.update_gamepad_status =         0x41F7D8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9AEBE8;
 ff7_externals.music_lock_clear_fix =          0x63C030;
+ff7_externals.sound_operation =               0;

--- a/src/externals_102_de.h
+++ b/src/externals_102_de.h
@@ -69,4 +69,3 @@ ff7_externals.wm_activateapp =                0x409CF2;
 ff7_externals.get_gamepad =                   0x41F99E;
 ff7_externals.update_gamepad_status =         0x41F7D8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9AEBE8;
-ff7_externals.music_lock_clear_fix =          0x63C030;

--- a/src/externals_102_fr.h
+++ b/src/externals_102_fr.h
@@ -44,8 +44,6 @@ common_externals.font_info =           (char*)0x99FB98;
 common_externals.build_dialog_window =        0x774690;
 common_externals.load_tex_file =              0x688C36;
 common_externals.directsound_buffer_flags_1 = 0x6E6DDD;
-common_externals.play_sfx =    (void(*)(uint))0x6E208A;
-common_externals.set_sfx_volume = (uint(*)(uint,uint))0x6E44CB;
 
 ff7_externals.chocobo_fix =                   0x70B4B2;
 ff7_externals.midi_fix =                      0x6E03C2;
@@ -72,4 +70,3 @@ ff7_externals.get_gamepad =                   0x41F9AE;
 ff7_externals.update_gamepad_status =         0x41F7E8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9AFC18;
 ff7_externals.music_lock_clear_fix =          0x63C000;
-ff7_externals.sound_operation = (uint(*)(uint,uint,uint,uint,uint,uint))0x6DD600;

--- a/src/externals_102_fr.h
+++ b/src/externals_102_fr.h
@@ -44,6 +44,8 @@ common_externals.font_info =           (char*)0x99FB98;
 common_externals.build_dialog_window =        0x774690;
 common_externals.load_tex_file =              0x688C36;
 common_externals.directsound_buffer_flags_1 = 0x6E6DDD;
+common_externals.play_sfx =                   0x6E208A;
+common_externals.set_sfx_volume =             0x6E44CB;
 
 ff7_externals.chocobo_fix =                   0x70B4B2;
 ff7_externals.midi_fix =                      0x6E03C2;

--- a/src/externals_102_fr.h
+++ b/src/externals_102_fr.h
@@ -69,4 +69,3 @@ ff7_externals.wm_activateapp =                0x409D02;
 ff7_externals.get_gamepad =                   0x41F9AE;
 ff7_externals.update_gamepad_status =         0x41F7E8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9AFC18;
-ff7_externals.music_lock_clear_fix =          0x63C000;

--- a/src/externals_102_fr.h
+++ b/src/externals_102_fr.h
@@ -44,8 +44,8 @@ common_externals.font_info =           (char*)0x99FB98;
 common_externals.build_dialog_window =        0x774690;
 common_externals.load_tex_file =              0x688C36;
 common_externals.directsound_buffer_flags_1 = 0x6E6DDD;
-common_externals.play_sfx =                   0x6E208A;
-common_externals.set_sfx_volume =             0x6E44CB;
+common_externals.play_sfx =    (void(*)(uint))0x6E208A;
+common_externals.set_sfx_volume = (uint(*)(uint,uint))0x6E44CB;
 
 ff7_externals.chocobo_fix =                   0x70B4B2;
 ff7_externals.midi_fix =                      0x6E03C2;
@@ -72,3 +72,4 @@ ff7_externals.get_gamepad =                   0x41F9AE;
 ff7_externals.update_gamepad_status =         0x41F7E8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9AFC18;
 ff7_externals.music_lock_clear_fix =          0x63C000;
+ff7_externals.sound_operation = (uint(*)(uint,uint,uint,uint,uint,uint))0x6DD600;

--- a/src/externals_102_sp.h
+++ b/src/externals_102_sp.h
@@ -69,4 +69,3 @@ ff7_externals.wm_activateapp =                0x409D02;
 ff7_externals.get_gamepad =                   0x41F9AE;
 ff7_externals.update_gamepad_status =         0x41F7E8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9B0678;
-ff7_externals.music_lock_clear_fix =          0x63C000;

--- a/src/externals_102_sp.h
+++ b/src/externals_102_sp.h
@@ -44,8 +44,6 @@ common_externals.font_info =          (char *)0x9A05F8;
 common_externals.build_dialog_window =        0x7747A0;
 common_externals.load_tex_file =              0x688C36;
 common_externals.directsound_buffer_flags_1 = 0x6E6DDD;
-common_externals.play_sfx =                   0x000000;
-common_externals.set_sfx_volume =             0x000000;
 
 ff7_externals.chocobo_fix =                   0x70B4B2;
 ff7_externals.midi_fix =                      0x6E03C2;
@@ -72,4 +70,3 @@ ff7_externals.get_gamepad =                   0x41F9AE;
 ff7_externals.update_gamepad_status =         0x41F7E8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9B0678;
 ff7_externals.music_lock_clear_fix =          0x63C000;
-ff7_externals.sound_operation =               0;

--- a/src/externals_102_sp.h
+++ b/src/externals_102_sp.h
@@ -72,3 +72,4 @@ ff7_externals.get_gamepad =                   0x41F9AE;
 ff7_externals.update_gamepad_status =         0x41F7E8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9B0678;
 ff7_externals.music_lock_clear_fix =          0x63C000;
+ff7_externals.sound_operation =               0;

--- a/src/externals_102_sp.h
+++ b/src/externals_102_sp.h
@@ -44,6 +44,8 @@ common_externals.font_info =          (char *)0x9A05F8;
 common_externals.build_dialog_window =        0x7747A0;
 common_externals.load_tex_file =              0x688C36;
 common_externals.directsound_buffer_flags_1 = 0x6E6DDD;
+common_externals.play_sfx =                   0x000000;
+common_externals.set_sfx_volume =             0x000000;
 
 ff7_externals.chocobo_fix =                   0x70B4B2;
 ff7_externals.midi_fix =                      0x6E03C2;

--- a/src/externals_102_us.h
+++ b/src/externals_102_us.h
@@ -72,3 +72,4 @@ ff7_externals.get_gamepad =                   0x41F99E;
 ff7_externals.update_gamepad_status =         0x41F7D8;
 ff7_externals.gamepad_status =        (struct ff7_gamepad_status*)0x9ADE28;
 ff7_externals.music_lock_clear_fix =          0x63C060;
+ff7_externals.sound_operation =               0;

--- a/src/externals_102_us.h
+++ b/src/externals_102_us.h
@@ -44,6 +44,8 @@ common_externals.font_info =          (char *)0x99DDA8;
 common_externals.build_dialog_window =        0x6E97E0;
 common_externals.load_tex_file =              0x688C96;
 common_externals.directsound_buffer_flags_1 = 0x74A55D;
+common_externals.play_sfx =                   0x000000;
+common_externals.set_sfx_volume =             0x000000;
 
 ff7_externals.chocobo_fix =                   0x76EC32;
 ff7_externals.midi_fix =                      0x743B42;

--- a/src/externals_102_us.h
+++ b/src/externals_102_us.h
@@ -44,8 +44,6 @@ common_externals.font_info =          (char *)0x99DDA8;
 common_externals.build_dialog_window =        0x6E97E0;
 common_externals.load_tex_file =              0x688C96;
 common_externals.directsound_buffer_flags_1 = 0x74A55D;
-common_externals.play_sfx =                   0x000000;
-common_externals.set_sfx_volume =             0x000000;
 
 ff7_externals.chocobo_fix =                   0x76EC32;
 ff7_externals.midi_fix =                      0x743B42;
@@ -72,4 +70,3 @@ ff7_externals.get_gamepad =                   0x41F99E;
 ff7_externals.update_gamepad_status =         0x41F7D8;
 ff7_externals.gamepad_status =        (struct ff7_gamepad_status*)0x9ADE28;
 ff7_externals.music_lock_clear_fix =          0x63C060;
-ff7_externals.sound_operation =               0;

--- a/src/externals_102_us.h
+++ b/src/externals_102_us.h
@@ -69,4 +69,3 @@ ff7_externals.wm_activateapp =                0x409CF2;
 ff7_externals.get_gamepad =                   0x41F99E;
 ff7_externals.update_gamepad_status =         0x41F7D8;
 ff7_externals.gamepad_status =        (struct ff7_gamepad_status*)0x9ADE28;
-ff7_externals.music_lock_clear_fix =          0x63C060;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1632,7 +1632,6 @@ struct ff7_externals
 	uint field_map_infos;
 	uint sound_operation;
 	struct ff7_field_sfx_state* sound_states;
-	uint menu_sub_1;
 	uint menu_sound_slider_loop;
 	uint menu_start;
 	uint battle_clear_sound_flags;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1624,6 +1624,7 @@ struct ff7_externals
 	uint update_gamepad_status;
 	struct ff7_gamepad_status* gamepad_status;
 	uint music_is_locked;
+	uint field_initialize_variables;
 	uint music_lock_clear_fix;
 	uint sub_60DF96;
 	uint sub_60EEB2;
@@ -1635,6 +1636,7 @@ struct ff7_externals
 	uint menu_sound_slider_loop;
 	uint menu_start;
 	uint battle_clear_sound_flags;
+	uint swirl_sound_effect;
 };
 
 uint ff7gl_load_group(uint group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1444,6 +1444,30 @@ struct ff7_gfx_driver
 	gfx_field_EC *field_EC;
 };
 
+struct ff7_field_sfx_state {
+	uint u1;
+	uint volume1;
+	uint volume2;
+	uint u2;
+	uint u3;
+	uint u4;
+	uint pan1;
+	uint pan2;
+	uint u5;
+	uint u6;
+	uint u7;
+	uint u8;
+	uint u9;
+	uint u10;
+	uint u11;
+	uint frequency;
+	uint sound_id;
+	IDirectSoundBuffer* buffer1;
+	IDirectSoundBuffer* buffer2;
+	uint is_looped;
+	uint u12;
+};
+
 // --------------- end of FF7 imports ---------------
 
 // memory addresses and function pointers from FF7.exe
@@ -1606,6 +1630,7 @@ struct ff7_externals
 	uint sub_60EEB2;
 	uint open_flevel_siz;
 	uint field_map_infos;
+	uint(*sound_operation)(uint, uint, uint, uint, uint, uint);
 };
 
 uint ff7gl_load_group(uint group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1625,12 +1625,16 @@ struct ff7_externals
 	struct ff7_gamepad_status* gamepad_status;
 	uint music_is_locked;
 	uint music_lock_clear_fix;
-	uint sub_4089C5;
 	uint sub_60DF96;
 	uint sub_60EEB2;
 	uint open_flevel_siz;
 	uint field_map_infos;
-	uint(*sound_operation)(uint, uint, uint, uint, uint, uint);
+	uint sound_operation;
+	struct ff7_field_sfx_state* sound_states;
+	uint menu_sub_1;
+	uint menu_sound_slider_loop;
+	uint menu_start;
+	uint battle_clear_sound_flags;
 };
 
 uint ff7gl_load_group(uint group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -279,6 +279,11 @@ void ff7_find_externals()
 		ff7_externals.set_default_input_settings_save = get_relative_call(ff7_externals.menu_sub_71894B, 0x188);
 	}
 
+	ff7_externals.menu_sub_1 = get_relative_call(ff7_externals.menu_sub_6CDA83, 0xDE);
+	uint temp = get_absolute_value(ff7_externals.menu_sub_1, 0x2EC);
+	ff7_externals.menu_sound_slider_loop = get_absolute_value(temp, 0x20);
+	ff7_externals.menu_start = get_absolute_value(main_loop, 0x627);
+
 	ff7_externals.keyboard_name_input = get_relative_call(ff7_externals.menu_sub_718DBE, 0x99);
  	ff7_externals.restore_input_settings = get_relative_call(ff7_externals.menu_sub_719B81, 0x80);
  	
@@ -300,11 +305,20 @@ void ff7_find_externals()
 	ff7_externals.cleanup_game = get_absolute_value(ff7_externals.init_stuff, 0x350);
 	ff7_externals.cleanup_midi = get_relative_call(ff7_externals.cleanup_game, 0x72);
 
-	ff7_externals.sub_4089C5 = get_absolute_value(ff7_externals.init_stuff, 0x336);
-	ff7_externals.sub_60DF96 = get_relative_call(ff7_externals.sub_4089C5, 0x42B);
+	ff7_externals.sub_60DF96 = get_relative_call(ff7_externals.init_game, 0x42B);
 	ff7_externals.sub_60EEB2 = get_relative_call(ff7_externals.sub_60DF96, 0x26);
 	ff7_externals.open_flevel_siz = get_relative_call(ff7_externals.sub_60EEB2, 0x79F);
 	ff7_externals.field_map_infos = get_absolute_value(ff7_externals.open_flevel_siz, 0xAF) - 0xBC;
+
+	ff7_externals.sound_operation = get_relative_call(ff7_externals.enter_main, 0xE4);
+	common_externals.play_sfx_on_channel = get_relative_call(ff7_externals.sound_operation, 0x2AB);
+	common_externals.set_sfx_volume = (uint(*)(uint, uint))get_relative_call(ff7_externals.sound_operation, 0x3B3);
+	info("%X\n", common_externals.set_sfx_volume);
+	common_externals.play_sfx = (uint(*)(uint))get_relative_call(ff7_externals.sound_operation, 0x703);
+	ff7_externals.sound_states = (ff7_field_sfx_state*)get_absolute_value(common_externals.play_sfx_on_channel, 0x28);
+	common_externals.master_sfx_volume = (uint*)get_absolute_value(common_externals.play_sfx_on_channel, 0x342);
+
+	ff7_externals.battle_clear_sound_flags = get_relative_call(ff7_externals.battle_sub_429AC0, 0x6C);
 }
 
 void ff7_data()

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -204,9 +204,11 @@ void ff7_find_externals()
 
 	ff7_externals.party_member_to_char_map = (uint *)get_absolute_value(ff7_externals.menu_draw_party_member_stats, 0x14);
 
+	ff7_externals.menu_start = get_absolute_value(main_loop, 0x627);
 	ff7_externals.menu_sub_6CB56A = get_relative_call(ff7_externals.menu_sub_6CDA83, 0xDE);
 	ff7_externals.menu_subs_call_table = (uint *)get_absolute_value(ff7_externals.menu_sub_6CB56A, 0x2EC);
 	ff7_externals.status_menu_sub = ff7_externals.menu_subs_call_table[5];
+	ff7_externals.menu_sound_slider_loop = ff7_externals.menu_subs_call_table[8];
 	ff7_externals.draw_status_limit_level_stats = get_relative_call(ff7_externals.status_menu_sub, 0x8E);
 
 	ff7_externals.get_kernel_text = (char* (*)(uint, uint, uint))get_relative_call(ff7_externals.draw_status_limit_level_stats, 0x10C);
@@ -280,11 +282,6 @@ void ff7_find_externals()
 		
 		ff7_externals.set_default_input_settings_save = get_relative_call(ff7_externals.menu_sub_71894B, 0x188);
 	}
-
-	ff7_externals.menu_sub_1 = get_relative_call(ff7_externals.menu_sub_6CDA83, 0xDE);
-	uint temp = get_absolute_value(ff7_externals.menu_sub_1, 0x2EC);
-	ff7_externals.menu_sound_slider_loop = get_absolute_value(temp, 0x20);
-	ff7_externals.menu_start = get_absolute_value(main_loop, 0x627);
 
 	ff7_externals.keyboard_name_input = get_relative_call(ff7_externals.menu_sub_718DBE, 0x99);
  	ff7_externals.restore_input_settings = get_relative_call(ff7_externals.menu_sub_719B81, 0x80);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -70,6 +70,7 @@ void ff7_find_externals()
 	uint worldmap_main_loop;
 	uint cdcheck_main_loop;
 	uint coaster_main_loop;
+	uint swirl_main_loop;
 	uint movie_module;
 	uint file_module;
 
@@ -91,7 +92,8 @@ void ff7_find_externals()
 	common_externals._mode = (word *)get_absolute_value(main_loop, 0x8C);
 
 	ff7_set_main_loop(MODE_GAMEOVER, get_absolute_value(main_loop, 0x1FE));
-	ff7_set_main_loop(MODE_SWIRL, get_absolute_value(main_loop, 0x25B));
+	swirl_main_loop = get_absolute_value(main_loop, 0x25B);
+	ff7_set_main_loop(MODE_SWIRL, swirl_main_loop);
 	cdcheck_main_loop = get_absolute_value(main_loop, 0x397);
 	ff7_set_main_loop(MODE_CDCHECK, cdcheck_main_loop);
 	ff7_set_main_loop(MODE_CREDITS, get_absolute_value(main_loop, 0x4CA));
@@ -313,12 +315,15 @@ void ff7_find_externals()
 	ff7_externals.sound_operation = get_relative_call(ff7_externals.enter_main, 0xE4);
 	common_externals.play_sfx_on_channel = get_relative_call(ff7_externals.sound_operation, 0x2AB);
 	common_externals.set_sfx_volume = (uint(*)(uint, uint))get_relative_call(ff7_externals.sound_operation, 0x3B3);
-	info("%X\n", common_externals.set_sfx_volume);
 	common_externals.play_sfx = (uint(*)(uint))get_relative_call(ff7_externals.sound_operation, 0x703);
 	ff7_externals.sound_states = (ff7_field_sfx_state*)get_absolute_value(common_externals.play_sfx_on_channel, 0x28);
 	common_externals.master_sfx_volume = (uint*)get_absolute_value(common_externals.play_sfx_on_channel, 0x342);
 
 	ff7_externals.battle_clear_sound_flags = get_relative_call(ff7_externals.battle_sub_429AC0, 0x6C);
+	ff7_externals.swirl_sound_effect = get_relative_call(swirl_main_loop, 0x8B);
+
+	ff7_externals.field_initialize_variables = get_relative_call(ff7_externals.field_sub_60DCED, 0x178);
+	ff7_externals.music_lock_clear_fix = ff7_externals.field_initialize_variables + 0x2B8;
 }
 
 void ff7_data()

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -27,10 +27,8 @@
 
 void music_init()
 {
-	// Add Global Focus flag to DirectSound Secondary Buffers
-	patch_code_byte(common_externals.directsound_buffer_flags_1 + 0x4, 0x80); // DSBCAPS_GLOBALFOCUS & 0x0000FF00
-
 	if (!ff8) {
+		// Fix music stop issue in FF7
 		patch_code_dword(ff7_externals.music_lock_clear_fix + 2, 0xCC195C);
 	}
 

--- a/src/sfx.cpp
+++ b/src/sfx.cpp
@@ -1,0 +1,96 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2020 myst6re                                            //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#include <windows.h>
+
+#include "sfx.h"
+#include "patch.h"
+
+uint sfx_volumes[5];
+
+void sfx_init()
+{
+	// Add Global Focus flag to DirectSound Secondary Buffers
+	patch_code_byte(common_externals.directsound_buffer_flags_1 + 0x4, 0x80); // DSBCAPS_GLOBALFOCUS & 0x0000FF00
+
+	if (!ff8) {
+		// On volume change in main menu initialization
+		replace_call(0x758215, sfx_menu_force_channel_5_volume);
+		// On SFX volume change in config menu
+		replace_call(0x74DF4A, sfx_menu_play_sound_down);
+		replace_call(0x74DF7F, sfx_menu_play_sound_up);
+		// Fix escape sound not played more than once
+		replace_function(0x41FA80, sfx_clear_sound_locks);
+	}
+}
+
+void sfx_remember_volumes()
+{
+	for (int i = 0; i <= 4; ++i) {
+		uint* current_channel_volume = (uint*)0xDBDC24;
+		sfx_volumes[i] = current_channel_volume[i * 0x15];
+	}
+}
+
+void sfx_menu_force_channel_5_volume(uint volume, uint channel)
+{
+	// Original call (set channel 5 volume to maximum)
+	common_externals.set_sfx_volume(volume, channel);
+	// Added by FFNx
+	sfx_remember_volumes();
+}
+
+void sfx_menu_play_sound_down(uint id)
+{
+	// Added by FFNx
+	sfx_update_volume(-1);
+	// Original call (curor sound)
+	common_externals.play_sfx(id);
+}
+
+void sfx_menu_play_sound_up(uint id)
+{
+	// Added by FFNx
+	sfx_update_volume(1);
+	// Original call (curor sound)
+	common_externals.play_sfx(id);
+}
+
+void sfx_update_volume(int modifier)
+{
+	info("sfx_update_volume\n");
+
+	// Set master sfx volume
+	int* sfx_volume = (int*)0xDC349C;
+	int* sfx_tmp_volume = (int*)0xF3AE28;
+
+	*sfx_volume = *sfx_tmp_volume + modifier;
+
+	// Update sfx volume in real-time for all channel
+	for (int channel = 1; channel <= 5; ++channel) {
+		common_externals.set_sfx_volume(sfx_volumes[channel - 1], channel);
+	}
+}
+
+void sfx_clear_sound_locks()
+{
+	// The last uint wasn't reset by the original sub
+	memset((void*)0x9AFCE8, 0, 5 * sizeof(uint));
+}

--- a/src/sfx.cpp
+++ b/src/sfx.cpp
@@ -42,9 +42,9 @@ void sfx_init()
 		// Fix escape sound not played more than once
 		replace_function(ff7_externals.battle_clear_sound_flags, sfx_clear_sound_locks);
 		// On stop sound in battle swirl
-		replace_call(0x40805D, sfx_operation_battle_swirl_stop_sound);
+		replace_call(ff7_externals.swirl_sound_effect + 0x26, sfx_operation_battle_swirl_stop_sound);
 		// On resume music after a battle
-		replace_call(0x63BE33, sfx_operation_resume_music);
+		replace_call(ff7_externals.field_initialize_variables + 0xEB, sfx_operation_resume_music);
 	}
 }
 

--- a/src/sfx.cpp
+++ b/src/sfx.cpp
@@ -35,12 +35,12 @@ void sfx_init()
 
 	if (!ff8) {
 		// On volume change in main menu initialization
-		replace_call(0x758215, sfx_menu_force_channel_5_volume);
+		replace_call(ff7_externals.menu_start + 0x17, sfx_menu_force_channel_5_volume);
 		// On SFX volume change in config menu
-		replace_call(0x74DF4A, sfx_menu_play_sound_down);
-		replace_call(0x74DF7F, sfx_menu_play_sound_up);
+		replace_call(ff7_externals.menu_sound_slider_loop + 0x10A5, sfx_menu_play_sound_down);
+		replace_call(ff7_externals.menu_sound_slider_loop + 0x10DA, sfx_menu_play_sound_up);
 		// Fix escape sound not played more than once
-		replace_function(0x41FA80, sfx_clear_sound_locks);
+		replace_function(ff7_externals.battle_clear_sound_flags, sfx_clear_sound_locks);
 		// On stop sound in battle swirl
 		replace_call(0x40805D, sfx_operation_battle_swirl_stop_sound);
 		// On resume music after a battle
@@ -68,7 +68,7 @@ uint sfx_operation_battle_swirl_stop_sound(uint type, uint param1, uint param2, 
 {
 	if (trace_all || trace_music) info("Battle swirl stop sound\n");
 
-	ff7_field_sfx_state* sfx_state = (ff7_field_sfx_state*)0xDBDC20;
+	ff7_field_sfx_state* sfx_state = ff7_externals.sound_states;
 
 	for (int i = 0; i < 5; ++i) {
 		sfx_buffers[i] = nullptr;
@@ -80,38 +80,46 @@ uint sfx_operation_battle_swirl_stop_sound(uint type, uint param1, uint param2, 
 		}
 	}
 
-	return ff7_externals.sound_operation(type, param1, param2, param3, param4, param5);
+	return ((uint(*)(uint, uint, uint, uint, uint, uint))ff7_externals.sound_operation)(type, param1, param2, param3, param4, param5);
 }
 
 uint sfx_operation_resume_music(uint type, uint param1, uint param2, uint param3, uint param4, uint param5)
 {
 	if (trace_all || trace_music) info("Field resume music after battle\n");
 
-	ff7_field_sfx_state* sfx_state = (ff7_field_sfx_state*)0xDBDC20;
+	ff7_field_sfx_state* sfx_state = ff7_externals.sound_states;
 
 	for (int i = 0; i < 5; ++i) {
 		if (sfx_buffers[i] != nullptr) {
 			if (sfx_state[i].buffer1 == sfx_buffers[i]) {
-				// Play sound on channel
-				((uint(*)(uint, uint, uint))(0x6E19E0))(sfx_state[i].pan1, sfx_state[i].sound_id, i + 1);
+				((uint(*)(uint, uint, uint))common_externals.play_sfx_on_channel)(sfx_state[i].pan1, sfx_state[i].sound_id, i + 1);
 			}
 			else if (sfx_state[i].buffer2 == sfx_buffers[i]) {
-				((uint(*)(uint, uint, uint))(0x6E19E0))(sfx_state[i].pan2, sfx_state[i].sound_id, i + 1);
+				((uint(*)(uint, uint, uint))common_externals.play_sfx_on_channel)(sfx_state[i].pan2, sfx_state[i].sound_id, i + 1);
 			}
 
 			sfx_buffers[i] = nullptr;
 		}
 	}
 
-	return ff7_externals.sound_operation(type, param1, param2, param3, param4, param5);
+	return ((uint(*)(uint, uint, uint, uint, uint, uint))ff7_externals.sound_operation)(type, param1, param2, param3, param4, param5);
 }
 
 void sfx_remember_volumes()
 {
-	ff7_field_sfx_state* sfx_state = (ff7_field_sfx_state*)0xDBDC20;
+	if (trace_all || trace_music) info("Remember SFX volumes (master: %i)\n", *common_externals.master_sfx_volume);
 
-	for (int i = 0; i <= 4; ++i) {
+	ff7_field_sfx_state* sfx_state = ff7_externals.sound_states;
+
+	for (int i = 0; i < 5; ++i) {
 		sfx_volumes[i] = sfx_state[i].buffer1 != nullptr ? sfx_state[i].volume1 : sfx_state[i].volume2;
+		sfx_volumes[i] = floor(sfx_volumes[i] * 100 / float(*common_externals.master_sfx_volume) + 0.9f);
+
+		if (sfx_volumes[i] > 127) {
+			sfx_volumes[i] = 127;
+		}
+
+		if (trace_all || trace_music) info("SFX volume channel #%i: %i\n", i, sfx_volumes[i]);
 	}
 }
 
@@ -121,6 +129,21 @@ void sfx_menu_force_channel_5_volume(uint volume, uint channel)
 	common_externals.set_sfx_volume(volume, channel);
 	// Added by FFNx
 	sfx_remember_volumes();
+}
+
+void sfx_update_volume(int modifier)
+{
+	if (trace_all || trace_music) info("Update SFX volumes %d\n", modifier);
+
+	// Set master sfx volume
+	BYTE** sfx_tmp_volume = (BYTE**)(ff7_externals.menu_sound_slider_loop + 0x264);
+
+	*common_externals.master_sfx_volume = **sfx_tmp_volume + modifier;
+
+	// Update sfx volume in real-time for all channel
+	for (int channel = 1; channel <= 5; ++channel) {
+		common_externals.set_sfx_volume(sfx_volumes[channel - 1], channel);
+	}
 }
 
 void sfx_menu_play_sound_down(uint id)
@@ -139,22 +162,9 @@ void sfx_menu_play_sound_up(uint id)
 	common_externals.play_sfx(id);
 }
 
-void sfx_update_volume(int modifier)
-{
-	// Set master sfx volume
-	int* sfx_volume = (int*)0xDC349C;
-	int* sfx_tmp_volume = (int*)0xF3AE28;
-
-	*sfx_volume = *sfx_tmp_volume + modifier;
-
-	// Update sfx volume in real-time for all channel
-	for (int channel = 1; channel <= 5; ++channel) {
-		common_externals.set_sfx_volume(sfx_volumes[channel - 1], channel);
-	}
-}
-
 void sfx_clear_sound_locks()
 {
+	uint** flags = (uint**)(ff7_externals.battle_clear_sound_flags + 5);
 	// The last uint wasn't reset by the original sub
-	memset((void*)0x9AFCE8, 0, 5 * sizeof(uint));
+	memset((void*)*flags, 0, 5 * sizeof(uint));
 }

--- a/src/sfx.h
+++ b/src/sfx.h
@@ -1,0 +1,30 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2020 myst6re                                            //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#pragma once
+
+#include "types.h"
+
+void sfx_init();
+void sfx_menu_force_channel_5_volume(uint volume, uint channel);
+void sfx_menu_play_sound_down(uint id);
+void sfx_menu_play_sound_up(uint id);
+void sfx_update_volume(int modifier);
+void sfx_clear_sound_locks();

--- a/src/sfx.h
+++ b/src/sfx.h
@@ -23,6 +23,8 @@
 #include "types.h"
 
 void sfx_init();
+uint sfx_operation_battle_swirl_stop_sound(uint type, uint param1, uint param2, uint param3, uint param4, uint param5);
+uint sfx_operation_resume_music(uint type, uint param1, uint param2, uint param3, uint param4, uint param5);
 void sfx_menu_force_channel_5_volume(uint volume, uint channel);
 void sfx_menu_play_sound_down(uint id);
 void sfx_menu_play_sound_up(uint id);

--- a/src/sfx.h
+++ b/src/sfx.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <math.h>
+
 #include "types.h"
 
 void sfx_init();
@@ -28,5 +30,4 @@ uint sfx_operation_resume_music(uint type, uint param1, uint param2, uint param3
 void sfx_menu_force_channel_5_volume(uint volume, uint channel);
 void sfx_menu_play_sound_down(uint id);
 void sfx_menu_play_sound_up(uint id);
-void sfx_update_volume(int modifier);
 void sfx_clear_sound_locks();

--- a/src/winamp/music.cpp
+++ b/src/winamp/music.cpp
@@ -488,7 +488,7 @@ void winamp_set_music_volume_trans(int volume, int frames)
 {
 	if (trace_all || trace_music) trace("set volume trans: %i (%i)\n", volume, frames);
 
-	frames /= 2; // 60 FPS on the original game, our thread has ~30 ticks per second
+	// 30 frames = 1 second
 
 	EnterCriticalSection(&winamp_mutex);
 	


### PR DESCRIPTION
This PR mainly fixes game SFX bugs.

Changelog:
 - When you modify the SFX volume in the game (config menu), now it is updated dynamically without restart
 - Ambient sounds are resumed after a battle (for example the alarm in the first reactor)
 - Escape sound is now played everytime, not only the first time
 - Fixing music volume fade timing (my fault)
 - Apply theses fixes and other SFX fixes even if external_music is not enabled