### PR TITLE
Fix inconsistent sfx volume

### DIFF
--- a/src/sfx.h
+++ b/src/sfx.h
@@ -31,3 +31,4 @@ void sfx_menu_force_channel_5_volume(uint volume, uint channel);
 void sfx_menu_play_sound_down(uint id);
 void sfx_menu_play_sound_up(uint id);
 void sfx_clear_sound_locks();
+void sfx_fix_volume_values(char* log);


### PR DESCRIPTION
There is two volume levels: the one (per channel) from the original game (from 0 to 127) and a master level (only in the PC version) which can be modified via the configuration menu.

The final volume is computed like this: master * volume[channel] / 100.

The set_sfx_volume (on channel) method has a bad behavior: it set the sfx state with the result of this volume, but everytime the state is used, the computation above is computed... again!

Instead of removing computations when the state is used, I chose to force the value of the state in set_sfx_volume directly.