### PR TITLE
Fix lots of SFX bugs (FF7)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -216,8 +216,9 @@ struct common_externals
 	uint directsound_buffer_flags_1;
 	uint (*play_sfx)(uint);
 	uint play_sfx_on_channel;
-	uint (*set_sfx_volume)(uint, uint);
+	uint (*set_sfx_volume_on_channel)(uint, uint);
 	uint *master_sfx_volume;
+	uint* dsound_volume_table;
 	IDirectInputDeviceA **keyboard_device;
 	uint get_keyboard_state;
 	uint *keyboard_connected;

--- a/src/externals_102_de.h
+++ b/src/externals_102_de.h
@@ -74,3 +74,6 @@ ff7_externals.update_gamepad_status =         0x41F7D8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9AEBE8;
 ff7_externals.call_menu_sound_slider_loop_sfx_down = 0x10AF;
 ff7_externals.call_menu_sound_slider_loop_sfx_up = 0x10F3;
+ff7_externals.sfx_play_summon =               0x6E586F;
+ff7_externals.battle_summon_leviathan_loop =  0x5B1775;
+ff7_externals.battle_limit_omnislash_loop =   0x46BA0B;

--- a/src/externals_102_fr.h
+++ b/src/externals_102_fr.h
@@ -74,3 +74,6 @@ ff7_externals.update_gamepad_status =         0x41F7E8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9AFC18;
 ff7_externals.call_menu_sound_slider_loop_sfx_down = 0x10A5;
 ff7_externals.call_menu_sound_slider_loop_sfx_up = 0x10DA;
+ff7_externals.sfx_play_summon =               0x6E580F;
+ff7_externals.battle_summon_leviathan_loop =  0x5B1785;
+ff7_externals.battle_limit_omnislash_loop =   0x46BA1B;

--- a/src/externals_102_sp.h
+++ b/src/externals_102_sp.h
@@ -74,3 +74,6 @@ ff7_externals.update_gamepad_status =         0x41F7E8;
 ff7_externals.gamepad_status = (struct ff7_gamepad_status*)0x9B0678;
 ff7_externals.call_menu_sound_slider_loop_sfx_down = 0x10AC;
 ff7_externals.call_menu_sound_slider_loop_sfx_up = 0x10E1;
+ff7_externals.sfx_play_summon =               0x6E580F;
+ff7_externals.battle_summon_leviathan_loop =  0x5B1785;
+ff7_externals.battle_limit_omnislash_loop =   0x46BA1B;

--- a/src/externals_102_us.h
+++ b/src/externals_102_us.h
@@ -74,3 +74,6 @@ ff7_externals.update_gamepad_status =         0x41F7D8;
 ff7_externals.gamepad_status =        (struct ff7_gamepad_status*)0x9ADE28;
 ff7_externals.call_menu_sound_slider_loop_sfx_down = 0x10A8;
 ff7_externals.call_menu_sound_slider_loop_sfx_up = 0x10EC;
+ff7_externals.sfx_play_summon =               0x748F8F;
+ff7_externals.battle_summon_leviathan_loop =  0x5B1775;
+ff7_externals.battle_limit_omnislash_loop =   0x46BA0B;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1642,6 +1642,11 @@ struct ff7_externals
 	uint execute_opcode;
 	uint opcode_akao;
 	uint opcode_akao2;
+	uint opcode_gameover;
+	uint sfx_play_summon;
+	uint sfx_fill_buffer_from_audio_dat;
+	uint battle_summon_leviathan_loop;
+	uint battle_limit_omnislash_loop;
 };
 
 uint ff7gl_load_group(uint group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -314,8 +314,10 @@ void ff7_find_externals()
 
 	ff7_externals.sound_operation = get_relative_call(ff7_externals.enter_main, 0xE4);
 	common_externals.play_sfx_on_channel = get_relative_call(ff7_externals.sound_operation, 0x2AB);
-	common_externals.set_sfx_volume = (uint(*)(uint, uint))get_relative_call(ff7_externals.sound_operation, 0x3B3);
+	common_externals.set_sfx_volume_on_channel = (uint(*)(uint, uint))get_relative_call(ff7_externals.sound_operation, 0x3B3);
+	common_externals.dsound_volume_table = (uint*)get_absolute_value(uint(common_externals.set_sfx_volume_on_channel), 0xCC);
 	common_externals.play_sfx = (uint(*)(uint))get_relative_call(ff7_externals.sound_operation, 0x703);
+	ff7_externals.sfx_fill_buffer_from_audio_dat = get_relative_call(uint(common_externals.play_sfx), 0x4D);
 	ff7_externals.sound_states = (ff7_field_sfx_state*)get_absolute_value(common_externals.play_sfx_on_channel, 0x28);
 	common_externals.master_sfx_volume = (uint*)get_absolute_value(common_externals.play_sfx_on_channel, 0x342);
 
@@ -327,9 +329,11 @@ void ff7_find_externals()
 	ff7_externals.field_init_event_sub_63BCA7 = get_relative_call(ff7_externals.field_initialize_variables, 0x29D);
 	ff7_externals.field_init_event = get_relative_call(ff7_externals.field_init_event_sub_63BCA7, 0x8);
 	ff7_externals.execute_opcode = get_relative_call(ff7_externals.field_init_event, 0x80);
+
 	common_externals.execute_opcode_table = (uint*)get_absolute_value(ff7_externals.execute_opcode, 0x10D);
 	ff7_externals.opcode_akao2 = common_externals.execute_opcode_table[0xDA];
 	ff7_externals.opcode_akao = common_externals.execute_opcode_table[0xF2];
+	ff7_externals.opcode_gameover = common_externals.execute_opcode_table[0xFF];
 }
 
 void ff7_data()

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -34,6 +34,8 @@ void music_init()
 		// Fix Cid speech music stop
 		replace_call(ff7_externals.opcode_akao + 0xEA, music_sound_operation_fix);
 		replace_call(ff7_externals.opcode_akao2 + 0xE8, music_sound_operation_fix);
+		// Fix Game Over music in field
+		common_externals.execute_opcode_table[0xFF] = uint((void *)opcode_gameover_music_fix);
 	}
 
 	if (use_external_music)
@@ -282,4 +284,13 @@ bool needs_resume(uint old_mode, uint new_mode, char* old_midi, char* new_midi)
 	return ((new_mode == MODE_WORLDMAP || new_mode == MODE_AFTER_BATTLE) && !is_wm_theme(old_midi) && is_wm_theme(new_midi))
 		|| ((old_mode == MODE_BATTLE || old_mode == MODE_SWIRL) && (new_mode == MODE_FIELD || new_mode == MODE_AFTER_BATTLE))
 		|| new_mode == MODE_CARDGAME;
+}
+
+uint opcode_gameover_music_fix()
+{
+	const uint stop_sounds = 0xF1;
+	((uint(*)(uint, uint, uint, uint, uint, uint))ff7_externals.sound_operation)(stop_sounds, 0, 0, 0, 0, 0);
+	const uint play_music = 0x14, midi_id = 0x3A;
+	((uint(*)(uint, uint, uint, uint, uint, uint))ff7_externals.sound_operation)(play_music, midi_id, 0, 0, 0, 0);
+	return ((uint(*)())ff7_externals.opcode_gameover)();
 }

--- a/src/music.h
+++ b/src/music.h
@@ -44,3 +44,4 @@ void set_midi_tempo(unsigned char tempo);
 uint remember_playing_time();
 uint music_sound_operation_fix(uint type, uint param1, uint param2, uint param3, uint param4, uint param5);
 bool needs_resume(uint old_mode, uint new_mode, char* old_midi, char* new_midi);
+uint opcode_gameover_music_fix();

--- a/src/sfx.h
+++ b/src/sfx.h
@@ -33,3 +33,5 @@ void sfx_menu_play_sound_down(uint id);
 void sfx_menu_play_sound_up(uint id);
 void sfx_clear_sound_locks();
 void sfx_fix_volume_values(char* log);
+int sfx_play_battle_specific(IDirectSoundBuffer* buffer, uint flags);
+uint sfx_fix_omnislash_sound_loading(int sound_id, int dsound_buffer);


### PR DESCRIPTION
- Play music in Game Over Screen when the timer reached zero in the first mission
- Fix summon sfx volume (user SFX volume wasn't applied)
- Fix Leviathan sound stopped early
- Fix Omnislash sound not loaded