### PR TITLE
speedhack changes only once per actual gamepad button press

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -282,6 +282,7 @@ void get_userdata_path(PCHAR buffer, size_t bufSize, bool isSavegameFile);
 void speedhack_incr();
 void speedhack_decr();
 void speedhack_reset();
+bool speedhack_pressed;
 
 
 #if defined(__cplusplus)

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -99,6 +99,7 @@ int ff7_get_gamepad()
 struct ff7_gamepad_status* ff7_update_gamepad_status()
 {
 	if (!gamepad.Refresh()) return 0;
+	
 
 	ff7_externals.gamepad_status->pos_x = gamepad.leftStickX;
 	ff7_externals.gamepad_status->pos_y = gamepad.leftStickY;
@@ -135,16 +136,27 @@ struct ff7_gamepad_status* ff7_update_gamepad_status()
 		ff7_externals.gamepad_status->dpad_up &&
 		ff7_externals.gamepad_status->button7 &&
 		ff7_externals.gamepad_status->button8
-		)
-		speedhack_incr();
+		) {
+		if (!speedhack_pressed) {
+			speedhack_incr();
+			speedhack_pressed = true;
+		}
+	}
 	// Decrease in-game speed on R3
 	else if (
 		ff7_externals.gamepad_status->dpad_down &&
 		ff7_externals.gamepad_status->button7 &&
 		ff7_externals.gamepad_status->button8
-		)
-		speedhack_decr();
-    
+		) {
+		if (!speedhack_pressed) {
+			speedhack_decr();
+			speedhack_pressed = true;
+		}
+	}
+	else {
+		speedhack_pressed = false;
+	}
+
     return ff7_externals.gamepad_status;
 }
 


### PR DESCRIPTION
Problem for me was that when I pressed the "speedhack speed up please" combo on gamepad for a bit, the speed already went from 1x to like 5x. If I pressed it abit longer it went from 1x->8x->1x again. 

It triggered too often IMO:

With this PR it only changes once per actual button press. That means if you press the gamepad buttons and hold them it will only add/decrement the increment value from the cfg once.

I only needed to change this for the gamepad input management. On keyboard it works fine without change needed. You press keyboard once and hold for a bit but it doesnt increment further unless you hold buttons for more than a sec or so.