### PR TITLE
Adding music skip configuration entries + implement opcode_musicskip and opcode_getmusicoffset

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Feel free to check the example configuration included in each FFNx release.
 
 The current supported Audio Engine layers are:
 - [SFX](misc/FFNx.SFX.toml): in-game audio sound effects ( menu cursor sound, battle sword slash sound, etc. )
-- Music: in-game audio music ( world theme, field theme, etc. )
+- [Music](misc/FFNx.music.toml): in-game audio music ( world theme, field theme, etc. )
 - Voice: in-game audio voice acting ( dialog voice acting )
 
 ## Cheat codes

--- a/misc/FFNx.music.toml
+++ b/misc/FFNx.music.toml
@@ -1,0 +1,30 @@
+# FFNx Audio Engine config file - Music layer
+
+### HOW TO: ###################################################################
+# Sections may be commented by default with an initial # character.
+# Remove the initial # character to set the entire sections block and its flags
+# -----------------------------------------------------------------------------
+# Syntax:
+# [MUSIC_NAME]
+# flag = value
+# another_flag = value
+###############################################################################
+
+### SUPPORTED FLAGS: ##########################################################
+# offset_seconds: Offset in seconds. Plays the music at this value instead of
+# from the begining.
+# no_intro_track: [FF8 Only] Name of the "no intro" music. When the "no intro"
+# version is detected, plays this music instead.
+# intro_seconds: [FF8 Only] Offset in seconds. When the "no intro" version is
+# detected, skips the beginning of the music.
+###############################################################################
+
+# Plays gar3 when gargade (GGU theme) is played but the "no intro" flag is set
+# -----------------------------------------------------------------------------
+[gargarde]
+no_intro_track = 'gar3'
+
+# Skip 20.5 seconds of hikutei (Ragnarok theme) if the "no intro" flag is set
+# -----------------------------------------------------------------------------
+[hikutei]
+intro_seconds = 20.5

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,3 +175,4 @@ install(FILES ../misc/FF8.reg DESTINATION bin OPTIONAL)
 # Additional cfg files
 install(DIRECTORY DESTINATION bin/sfx OPTIONAL)
 install(FILES ../misc/${RELEASE_NAME}.SFX.toml DESTINATION bin/sfx RENAME config.toml OPTIONAL)
+install(FILES ../misc/${RELEASE_NAME}.music.toml DESTINATION bin/music/vgmstream RENAME config.toml OPTIONAL)

--- a/src/audio.h
+++ b/src/audio.h
@@ -44,6 +44,20 @@ struct NxAudioEngineMusic
 
 class NxAudioEngine
 {
+public:
+	enum PlayFlags {
+		PlayFlagsNone = 0x0,
+		PlayFlagsIsResumable = 0x1,
+		PlayFlagsDoNotPause = 0x2
+	};
+
+	struct PlayOptions
+	{
+		SoLoud::time offsetSeconds;
+		PlayFlags flags;
+		bool noIntro;
+		uint32_t fadetime;
+	};
 private:
 	enum NxAudioEngineLayer
 	{
@@ -74,6 +88,7 @@ private:
 	float _wantedMusicVolume = 1.0f;
 
 	SoLoud::AudioSource* loadMusic(const char* name);
+	void overloadPlayArgumentsFromConfig(char* name, uint32_t *id, PlayOptions *playOptions);
 
 	// VOICE
 	SoLoud::handle _voiceHandle = NXAUDIOENGINE_INVALID_HANDLE;
@@ -90,11 +105,6 @@ private:
 	void loadConfig();
 
 public:
-	enum PlayFlags {
-		PlayFlagsNone = 0x0,
-		PlayFlagsIsResumable = 0x1,
-		PlayFlagsDoNotPause = 0x2
-	};
 
 	bool init();
 	void flush();
@@ -112,13 +122,14 @@ public:
 
 	// Music
 	bool canPlayMusic(const char* name);
-	void playMusic(const char* name, uint32_t id, uint32_t fadetime = 0, PlayFlags flags = PlayFlagsNone, uint32_t offsetSeconds = 0);
-	void playMusics(const std::vector<std::string>& names, uint32_t id, uint32_t time = 0);
+	void playMusic(char* name, uint32_t id, PlayOptions& playOptions = PlayOptions());
+	void playMusics(const std::vector<std::string>& names, uint32_t id, PlayOptions& playOptions = PlayOptions());
 	void stopMusic(uint32_t time = 0);
 	void pauseMusic(uint32_t time = 0, bool push = false);
 	void resumeMusic(uint32_t time = 0, bool pop = false);
 	bool isMusicPlaying();
 	uint32_t currentMusicId();
+	SoLoud::time getMusicPlayingTime();
 	void setMusicMasterVolume(float volume, size_t time = 0);
 	void restoreMusicMasterVolume(size_t time = 0);
 	float getMusicVolume();

--- a/src/audio/openpsf/openpsf.cpp
+++ b/src/audio/openpsf/openpsf.cpp
@@ -86,7 +86,7 @@ namespace SoLoud
 		ended = false;
 		mOffset = 0;
 		mStreamPosition = 0.0f;
-		return 0;
+		return SO_NO_ERROR;
 	}
 
 	bool OpenPsfInstance::hasEnded()

--- a/src/audio/vgmstream/vgmstream.cpp
+++ b/src/audio/vgmstream/vgmstream.cpp
@@ -100,7 +100,7 @@ namespace SoLoud
 
 		mOffset = 0;
 		mStreamPosition = 0.0f;
-		return 0;
+		return SO_NO_ERROR;
 	}
 
 	bool VGMStreamInstance::hasEnded()

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -903,6 +903,7 @@ struct ff8_externals
 	uint32_t opcode_dualmusic;
 	uint32_t opcode_choicemusic;
 	uint32_t opcode_musicskip;
+	uint32_t opcode_getmusicoffset;
 	uint32_t dmusic_segment_connect_to_dls;
 	uint32_t choice_music;
 	uint32_t load_midi_segment;

--- a/src/ff8_data.h
+++ b/src/ff8_data.h
@@ -111,6 +111,7 @@ void ff8_find_externals()
 	ff8_externals.opcode_dualmusic = common_externals.execute_opcode_table[0xBB];
 	ff8_externals.opcode_choicemusic = common_externals.execute_opcode_table[0x135];
 	ff8_externals.opcode_musicskip = common_externals.execute_opcode_table[0x144];
+	ff8_externals.opcode_getmusicoffset = common_externals.execute_opcode_table[0x16F];
 
 	ff8_externals.movie_object = (ff8_movie_obj *)get_absolute_value(common_externals.prepare_movie, 0xDB);
 


### PR DESCRIPTION
Example of a configuration file:

~~~toml
[joriku]
no_intro_track = 'joriku2'

[joriku2]
offset_seconds = 51.8

[gargarde]
no_intro_track = 'gar3'

[hikutei]
intro_seconds = 21
~~~

- no_intro_track: track name of the music without intro if "no intro" is detected (the game already do it for joriku)
- offset_seconds: play the track at this value, instead of from the begining (only useful because I don't have a proper joriku2 psf without intro for now)
- intro_seconds: how many seconds to skip when the track is played without intro