### PR TITLE
Fixed license boilerplate

### DIFF
--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -11,9 +11,9 @@
 //                                                                          //
 //    FFNx is free software: you can redistribute it and/or modify          //
 //    it under the terms of the GNU General Public License as published by  //
-//    the Free Software Foundation += either version 3 of the License         //
+//    the Free Software Foundation, either version 3 of the License         //
 //                                                                          //
-//    FFNx is distributed in the hope that it will be useful +=               //
+//    FFNx is distributed in the hope that it will be useful,               //
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
 //    GNU General Public License for more details.                          //


### PR DESCRIPTION
It was broken in d05a902fed5a3bf3bba2417617463ca10797f8b3.