### PR TITLE
Fixed big log file size and bad fps when lighting is enabled

### DIFF
--- a/src/ff7/graphics.cpp
+++ b/src/ff7/graphics.cpp
@@ -359,7 +359,7 @@ void draw_single_triangle(struct nvertex *vertices)
 
 	newRenderer.isTLVertex(true);
 
-	newRenderer.draw();
+	newRenderer.drawWithoutLighting();
 }
 
 void sub_6B2720(struct indexed_primitive *ip)

--- a/src/gl/gl.cpp
+++ b/src/gl/gl.cpp
@@ -113,7 +113,7 @@ void gl_draw_movie_quad_common(uint32_t width, uint32_t height)
 	newRenderer.isTLVertex(true);
 	newRenderer.doTextureFiltering(current_state.texture_filter);
 
-	newRenderer.draw();
+	newRenderer.drawWithoutLighting();
 }
 
 // draw movie frame
@@ -280,7 +280,7 @@ void gl_draw_indexed_primitive(uint32_t primitivetype, uint32_t vertextype, stru
 	newRenderer.setPrimitiveType(RendererPrimitiveType(primitivetype));
 
 	if (!ff8 && enable_lighting) newRenderer.drawWithLighting(normals != nullptr);
-	else newRenderer.draw();
+	else newRenderer.drawWithoutLighting();
 
 	stats.vertex_count += count;
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -314,6 +314,8 @@ private:
     void recalcInternals();
     void prepareFramebuffer();
 
+    void draw();
+
     bx::DefaultAllocator defaultAllocator;
     bx::FileWriter defaultWriter;
     Overlay overlay;
@@ -333,8 +335,8 @@ public:
     void clearShadowMap();
     void drawToShadowMap();
     void drawWithLighting(bool isCastShadow);
+    void drawWithoutLighting();
     void drawFieldShadow();
-    void draw();
     void drawOverlay();
     void show();
 


### PR DESCRIPTION
The big log file size and bad fps was caused because the log was being spammed with bgfx warnings due to setting the same uniforms and texture samplers within the same draw call from the drawToShadowMap() and draw() methods. To fix this, I separated the call to setCommonUniforms() and the texture sampling binding into a new drawWithoutLighting() method. This method then calls the draw() function. Therefore all calls to the draw() function other than the lighting one have been replaced with drawWithoutLighting() but the code flow is exactly the same. To prevent calling the draw() function directly from outside the Renderer class I made it private.