### PR TITLE
Fixed field shadows being drawn over the light overlay

### DIFF
--- a/src/gl.h
+++ b/src/gl.h
@@ -92,7 +92,7 @@ void gl_save_state(struct driver_state *dest);
 void gl_load_state(struct driver_state *src);
 uint32_t gl_defer_draw(uint32_t primitivetype, uint32_t vertextype, struct nvertex* vertices, struct point3d* normals, uint32_t vertexcount, WORD* indices, uint32_t count, struct boundingbox* boundingbox, uint32_t clip, uint32_t mipmap);
 uint32_t gl_defer_sorted_draw(uint32_t primitivetype, uint32_t vertextype, struct nvertex *vertices, uint32_t vertexcount, WORD *indices, uint32_t count, uint32_t clip, uint32_t mipmap);
-void gl_draw_deferred();
+void gl_draw_deferred(bool isDrawOpaqueOnly);
 struct boundingbox calculateSceneAabb();
 void gl_draw_sorted_deferred();
 void gl_check_deferred(struct texture_set *texture_set);

--- a/src/gl/deferred.cpp
+++ b/src/gl/deferred.cpp
@@ -291,7 +291,7 @@ uint32_t gl_defer_sorted_draw(uint32_t primitivetype, uint32_t vertextype, struc
 }
 
 // draw deferred models
-void gl_draw_deferred()
+void gl_draw_deferred(bool isDrawOpaqueOnly)
 {
 	struct driver_state saved_state;
 
@@ -304,11 +304,14 @@ void gl_draw_deferred()
 
 	nodefer = true;
 
-	stats.deferred += num_deferred;
-
 	for (int i = 0; i < num_deferred; ++i)
 	{
 		if (deferred_draws[i].vertices == nullptr)
+		{
+			continue;
+		}
+
+		if (isDrawOpaqueOnly && deferred_draws[i].state.blend_mode != 4)
 		{
 			continue;
 		}
@@ -328,6 +331,8 @@ void gl_draw_deferred()
 			deferred_draws[i].mipmap
 		);
 
+		++stats.deferred;
+
 		driver_free(deferred_draws[i].vertices);
 		deferred_draws[i].vertices = nullptr;
 		driver_free(deferred_draws[i].indices);
@@ -338,7 +343,7 @@ void gl_draw_deferred()
 		deferred_draws[i].boundingbox = nullptr;
 	}
 
-	num_deferred = 0;
+	if(!isDrawOpaqueOnly) num_deferred = 0;
 
 	nodefer = false;
 

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -625,14 +625,17 @@ void Lighting::draw(struct game_obj* game_object)
         }
     }
 
-    // Draw deferred models
-    gl_draw_deferred();
+    // Draw deferred opaque models
+    gl_draw_deferred(true);
 
     // Draw the walkmesh for field shadows
     if (mode->driver_mode == MODE_FIELD)
     {
         drawFieldShadow();
     }
+
+	// Draw deferred non-opaque models
+	gl_draw_deferred(false);
 };
 
 void Lighting::drawFieldShadow()


### PR DESCRIPTION
This is the fix for the problem reported by Kaldarasha about the field shadows being drawn over the light overlay found in some places such as the Forgotten City. I fixed it by drawing first the opaque objects, then the field shadows, then non-opaque objects.