### PR TITLE
Added support for extended PBR textures

### DIFF
--- a/misc/FFNx.frag
+++ b/misc/FFNx.frag
@@ -19,7 +19,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-$input v_color0, v_texcoord0
+$input v_color0, v_texcoord0, v_texcoord1
 
 #include <bgfx/bgfx_shader.sh>
 
@@ -30,7 +30,9 @@ SAMPLER2D(tex_v, 2);
 uniform vec4 VSFlags;
 uniform vec4 FSAlphaFlags;
 uniform vec4 FSMiscFlags;
+uniform vec4 FSTexFlags;
 
+#define isTLVertex VSFlags.x > 0.0
 #define isFBTexture VSFlags.z > 0.0
 #define isTexture VSFlags.w > 0.0
 // ---
@@ -50,6 +52,9 @@ uniform vec4 FSMiscFlags;
 #define isYUV FSMiscFlags.y > 0.0
 #define modulateAlpha FSMiscFlags.z > 0.0
 #define isMovie FSMiscFlags.w > 0.0
+
+// ---
+#define isTextureExtended FSTexFlags.x > 0.0
 
 void main()
 {
@@ -84,7 +89,13 @@ void main()
         }
         else
         {
-            vec4 texture_color = texture2D(tex, v_texcoord0.xy);
+            vec2 color_uv = vec2(0.0, 0.0);
+            if(isTLVertex || !(isTextureExtended))
+                color_uv = v_texcoord0.xy;
+            else
+                color_uv = v_texcoord1.xy;
+
+            vec4 texture_color = texture2D(tex, color_uv);
 
             if (doAlphaTest)
             {

--- a/misc/FFNx.lighting.vert
+++ b/misc/FFNx.lighting.vert
@@ -14,7 +14,7 @@
 /****************************************************************************/
 
 $input a_position, a_color0, a_texcoord0, a_normal
-$output v_color0, v_texcoord0, v_position0, v_shadow0, v_normal0
+$output v_color0, v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3, v_position0, v_shadow0, v_normal0
 
 #include <bgfx/bgfx_shader.sh>
 
@@ -76,4 +76,7 @@ void main()
     gl_Position = pos;
     v_color0 = color;
     v_texcoord0 = coords;
+    v_texcoord1 = vec2(coords.x, (1.0 / 3.0) * coords.y);
+    v_texcoord2 = vec2(coords.x, (1.0 / 3.0) * coords.y + 1.0 / 3.0);
+    v_texcoord3 = vec2(coords.x, (1.0 / 3.0) * coords.y + 2.0 / 3.0);
 }

--- a/misc/FFNx.shadowmap.frag
+++ b/misc/FFNx.shadowmap.frag
@@ -13,7 +13,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-$input v_color0, v_texcoord0, v_position0, v_shadow0, v_normal0
+$input v_color0, v_texcoord0, v_texcoord1, v_position0, v_shadow0, v_normal0
 
 #include <bgfx/bgfx_shader.sh>
 
@@ -21,6 +21,7 @@ SAMPLER2D(tex, 0);
 
 uniform vec4 VSFlags;
 uniform vec4 FSAlphaFlags;
+uniform vec4 FSTexFlags;
 
 #define isTexture VSFlags.w > 0.0
 // ---
@@ -37,13 +38,21 @@ uniform vec4 FSAlphaFlags;
 #define doAlphaTest FSAlphaFlags.z > 0.0
 // ---
 
+#define isTextureExtended FSTexFlags.x > 0.0
+
 void main()
 {
 	vec4 color = v_color0;
 
     if (isTexture)
     {        
-        vec4 texture_color = texture2D(tex, v_texcoord0.xy);
+        vec2 color_uv = vec2(0.0, 0.0);
+        if(isTextureExtended)
+            color_uv = v_texcoord1.xy;
+        else
+            color_uv = v_texcoord0.xy;
+        
+        vec4 texture_color = texture2D(tex, color_uv);
 
         if (doAlphaTest)
         {

--- a/misc/FFNx.shadowmap.vert
+++ b/misc/FFNx.shadowmap.vert
@@ -14,7 +14,7 @@
 /****************************************************************************/
 
 $input a_position, a_color0, a_texcoord0, a_normal
-$output v_color0, v_texcoord0, v_position0, v_shadow0, v_normal0
+$output v_color0, v_texcoord0, v_texcoord1, v_position0, v_shadow0, v_normal0
 
 #include <bgfx/bgfx_shader.sh>
 
@@ -40,4 +40,5 @@ void main()
     gl_Position = pos;
     v_color0 = color;
     v_texcoord0 = coords;
+    v_texcoord1 = vec2(coords.x, (1.0 / 3.0) * coords.y);
 }

--- a/misc/FFNx.varying.flat.def.sc
+++ b/misc/FFNx.varying.flat.def.sc
@@ -1,7 +1,10 @@
 flat vec4 v_color0    : COLOR0    = vec4(0.0, 0.0, 0.0, 0.0);
 vec2 v_texcoord0 : TEXCOORD0 = vec2(0.0, 0.0);
-vec4 v_position0 : TEXCOORD1 = vec4(0.0, 0.0, 0.0, 0.0);
-vec4 v_shadow0 : TEXCOORD2 = vec4(0.0, 0.0, 0.0, 0.0);
+vec2 v_texcoord1 : TEXCOORD1 = vec2(0.0, 0.0);
+vec2 v_texcoord2 : TEXCOORD2 = vec2(0.0, 0.0);
+vec2 v_texcoord3 : TEXCOORD3 = vec2(0.0, 0.0);
+vec4 v_position0 : TEXCOORD4 = vec4(0.0, 0.0, 0.0, 0.0);
+vec4 v_shadow0 : TEXCOORD5 = vec4(0.0, 0.0, 0.0, 0.0);
 vec3 v_normal0 : NORMAL = vec3(0.0, 0.0, 0.0);
 
 vec4 a_position  : POSITION;

--- a/misc/FFNx.varying.smooth.def.sc
+++ b/misc/FFNx.varying.smooth.def.sc
@@ -1,7 +1,10 @@
 smooth vec4 v_color0    : COLOR0    = vec4(0.0, 0.0, 0.0, 0.0);
 vec2 v_texcoord0 : TEXCOORD0 = vec2(0.0, 0.0);
-vec4 v_position0 : TEXCOORD1 = vec4(0.0, 0.0, 0.0, 0.0);
-vec4 v_shadow0 : TEXCOORD2 = vec4(0.0, 0.0, 0.0, 0.0);
+vec2 v_texcoord1 : TEXCOORD1 = vec2(0.0, 0.0);
+vec2 v_texcoord2 : TEXCOORD2 = vec2(0.0, 0.0);
+vec2 v_texcoord3 : TEXCOORD3 = vec2(0.0, 0.0);
+vec4 v_position0 : TEXCOORD4 = vec4(0.0, 0.0, 0.0, 0.0);
+vec4 v_shadow0 : TEXCOORD5 = vec4(0.0, 0.0, 0.0, 0.0);
 vec3 v_normal0 : NORMAL = vec3(0.0, 0.0, 0.0);
 
 vec4 a_position  : POSITION;

--- a/misc/FFNx.vert
+++ b/misc/FFNx.vert
@@ -20,7 +20,7 @@
 /****************************************************************************/
 
 $input a_position, a_color0, a_texcoord0
-$output v_color0, v_texcoord0
+$output v_color0, v_texcoord0, v_texcoord1
 
 #include <bgfx/bgfx_shader.sh>
 
@@ -68,5 +68,6 @@ void main()
     gl_Position = pos;
     v_color0 = color;
     v_texcoord0 = coords;
+    v_texcoord1 = vec2(coords.x, (1.0 / 3.0) * coords.y);
 }
 

--- a/src/gl.h
+++ b/src/gl.h
@@ -77,6 +77,7 @@ struct gl_texture_set
 	uint32_t force_filter;
 	uint32_t force_zsort;
 	uint32_t is_animated;
+	uint32_t is_aspect_ratio_changed;
 };
 
 extern struct matrix d3dviewport_matrix;

--- a/src/gl/gl.cpp
+++ b/src/gl/gl.cpp
@@ -266,6 +266,15 @@ void gl_draw_indexed_primitive(uint32_t primitivetype, uint32_t vertextype, stru
 		VOBJ(texture_set, texture_set, current_state.texture_set);
 
 		if (VREF(texture_set, ogl.external)) newRenderer.isExternalTexture(true);
+
+		if (VREF(texture_set, ogl.gl_set))
+		{
+			struct gl_texture_set* gl_set = VREF(texture_set, ogl.gl_set);
+			if (gl_set->is_aspect_ratio_changed)
+				newRenderer.isExtendedTexture(true);
+			else
+				newRenderer.isExtendedTexture(false);
+		}
 	}
 
 	// OpenGL treats texture filtering as a per-texture parameter, we need it

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -686,6 +686,16 @@ const LightingState& Lighting::getLightingState()
     return lightingState;
 }
 
+void Lighting::setPbrTextureEnabled(bool isEnabled)
+{
+	lightingState.lightingSettings[0] = isEnabled;
+}
+
+bool Lighting::isPbrTextureEnabled()
+{
+	return lightingState.lightingSettings[0];
+}
+
 void Lighting::setWorldLightDir(float dirX, float dirY, float dirZ)
 {
     lightingState.worldLightRot.x = dirX;
@@ -766,6 +776,26 @@ void Lighting::setMetalness(float metalness)
 float Lighting::getMetalness()
 {
     return lightingState.materialData[1];
+}
+
+void Lighting::setRoughnessScale(float roughness)
+{
+	lightingState.materialData[2] = roughness;
+}
+
+float Lighting::getRoughnessScale()
+{
+	return lightingState.materialData[2];
+}
+
+void Lighting::setMetalnessScale(float metalness)
+{
+	lightingState.materialData[3] = metalness;
+}
+
+float Lighting::getMetalnessScale()
+{
+	return lightingState.materialData[3];
 }
 
 void Lighting::setShadowFaceCullingEnabled(bool isEnabled)
@@ -907,4 +937,14 @@ void Lighting::setShowWalkmeshEnabled(bool isEnabled)
 bool Lighting::isShowWalkmeshEnabled()
 {
     return lightingState.lightingDebugData[1];
+}
+
+void Lighting::setTextureDebugOutput(TextureDebugOutput output)
+{
+	lightingState.lightingDebugData[2] = output;
+}
+
+TextureDebugOutput Lighting::GetTextureDebugOutput()
+{
+	return static_cast<TextureDebugOutput>(lightingState.lightingDebugData[2]);
 }

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -20,6 +20,15 @@
 
 #include <vector>
 
+enum TextureDebugOutput
+{
+    TEXTURE_DEBUG_OUTPUT_DISABLED = 0,
+    TEXTURE_DEBUG_OUTPUT_COLOR,
+    TEXTURE_DEBUG_OUTPUT_NORMALMAP,
+    TEXTURE_DEBUG_OUTPUT_ROUGHNESS,
+    TEXTURE_DEBUG_OUTPUT_METALNESS,
+};
+
 struct walkmeshEdge
 {
     int v0;                      // edge vertex index 0
@@ -39,10 +48,11 @@ struct LightingState
     float lightViewProjMatrix[16];
     float lightViewProjTexMatrix[16];
 
+    float lightingSettings[4] = { 1.0, 0.0, 0.0, 0.0 };
     float lightDirData[4] = { 0.3, -1.0, -0.3, 0.0 };
     float lightData[4] = { 1.0, 1.0, 1.0, 4.0 };
     float ambientLightData[4] = { 1.0, 1.0, 1.0, 2.0 };
-    float materialData[4] = { 0.3, 0.3, 0.0, 0.0 };
+    float materialData[4] = { 0.3, 0.3, 1.0, 1.0 };
     float shadowData[4] = { 0.001, 0.0, 0.0, 2048.0 };
     float fieldShadowData[4] = { 0.3, 200.0, 100.0, 0.0 };
 
@@ -91,6 +101,8 @@ public:
     const LightingState& getLightingState();
 
     // Lighting
+    void Lighting::setPbrTextureEnabled(bool isEnabled);
+    bool Lighting::isPbrTextureEnabled();
     void setWorldLightDir(float dirX, float dirY, float dirZ);
     struct point3d getWorldLightDir();
     void setLightIntensity(float intensity);
@@ -107,6 +119,10 @@ public:
     float getRoughness();
     void setMetalness(float metalness);
     float getMetalness();
+    void setRoughnessScale(float roughness);
+    float getRoughnessScale();
+    void setMetalnessScale(float metalness);
+    float getMetalnessScale();
 
     // Shadow (common)
     void setShadowFaceCullingEnabled(bool isEnabled);
@@ -143,6 +159,8 @@ public:
     bool isHide2dEnabled();
     void setShowWalkmeshEnabled(bool isEnabled);
     bool isShowWalkmeshEnabled();
+    void setTextureDebugOutput(TextureDebugOutput output);
+    TextureDebugOutput GetTextureDebugOutput();
 };
 
 extern Lighting lighting;

--- a/src/lighting_debug.cpp
+++ b/src/lighting_debug.cpp
@@ -33,6 +33,11 @@ void lighting_debug(bool* isOpen)
     {
         enable_lighting = isLightingEnabled;
     }
+    bool isPbrTexturesEnabled = lighting.isPbrTextureEnabled();
+    if (ImGui::Checkbox("Enable PBR Textures", &isPbrTexturesEnabled))
+    {
+        lighting.setPbrTextureEnabled(isPbrTexturesEnabled);
+    }
     if (ImGui::CollapsingHeader("Direct Lighting", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth))
     {
         point3d lightDirVector = lighting.getWorldLightDir();
@@ -81,6 +86,16 @@ void lighting_debug(bool* isOpen)
         if (ImGui::DragFloat("Metalness", &metalness, 0.01f, 0.0f, 1.0f))
         {
             lighting.setMetalness(metalness);
+        }
+        float roughnessScale = lighting.getRoughnessScale();
+        if (ImGui::DragFloat("Roughness Scale", &roughnessScale, 0.01f, 0.0f, 2.0f))
+        {
+            lighting.setRoughnessScale(roughnessScale);
+        }
+        float metalnessScale = lighting.getMetalnessScale();
+        if (ImGui::DragFloat("Metalness Scale", &metalnessScale, 0.01f, 0.0f, 2.0f))
+        {
+            lighting.setMetalnessScale(metalnessScale);
         }
     }
     if (ImGui::CollapsingHeader("Shadow map (common)", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth))
@@ -154,6 +169,11 @@ void lighting_debug(bool* isOpen)
     }
     if (ImGui::CollapsingHeader("Debug", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth))
     {
+        int debugOutput = lighting.GetTextureDebugOutput();
+        if (ImGui::Combo("Texture Debug Output", &debugOutput, "Disabled\0Color\0Normal Map\0Roughness\0Metalness\0\0"))
+        {
+            lighting.setTextureDebugOutput(static_cast<TextureDebugOutput>(debugOutput));
+        }
         bool isHide2dEnabled = lighting.isHide2dEnabled();
         if (ImGui::Checkbox("Hide 2D", &isHide2dEnabled))
         {

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -107,9 +107,18 @@ void Renderer::setCommonUniforms()
     };
     if (uniform_log) trace("%s: FSMiscFlags XYZW(isMovieFullRange %f, isMovieYUV %f, modulateAlpha %f, isMovie %f)\n", __func__, internalState.FSMiscFlags[0], internalState.FSMiscFlags[1], internalState.FSMiscFlags[2], internalState.FSMiscFlags[3]);
 
+    internalState.FSTexFlags = {
+        (float)internalState.bIsExtendedTexture,
+        NULL,
+        NULL,
+        NULL
+    };
+    if (uniform_log) trace("%s: FSTexFlags XYZW(bIsExtendedTexture %f, NULL, NULL, NULL)\n", __func__, internalState.FSTexFlags[0]);
+
     setUniform("VSFlags", bgfx::UniformType::Vec4, internalState.VSFlags.data());
     setUniform("FSAlphaFlags", bgfx::UniformType::Vec4, internalState.FSAlphaFlags.data());
     setUniform("FSMiscFlags", bgfx::UniformType::Vec4, internalState.FSMiscFlags.data());
+    setUniform("FSTexFlags", bgfx::UniformType::Vec4, internalState.FSTexFlags.data());
 
     setUniform("d3dViewport", bgfx::UniformType::Mat4, internalState.d3dViewMatrix);
     setUniform("d3dProjection", bgfx::UniformType::Mat4, internalState.d3dProjectionMatrix);
@@ -123,6 +132,7 @@ void Renderer::setLightingUniforms()
 {
     auto lightingState = lighting.getLightingState();
 
+    setUniform("lightingSettings", bgfx::UniformType::Vec4, lightingState.lightingSettings);
     setUniform("lightDirData", bgfx::UniformType::Vec4, lightingState.lightDirData);
     setUniform("lightData", bgfx::UniformType::Vec4, lightingState.lightData);
     setUniform("ambientLightData", bgfx::UniformType::Vec4, lightingState.ambientLightData);
@@ -344,6 +354,7 @@ void Renderer::resetState()
     doModulateAlpha();
     doTextureFiltering();
     isExternalTexture();
+    isExtendedTexture();
     setStencilFunc();
     setStencilOp();
     setStencilRef();
@@ -1556,6 +1567,11 @@ void Renderer::doTextureFiltering(bool flag)
 void Renderer::isExternalTexture(bool flag)
 {
     internalState.bIsExternalTexture = flag;
+}
+
+void Renderer::isExtendedTexture(bool flag)
+{
+    internalState.bIsExtendedTexture = flag;
 }
 
 void Renderer::setAlphaRef(RendererAlphaFunc func, float ref)

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -199,12 +199,14 @@ private:
         bool bIsMovieFullRange = false;
         bool bIsMovieYUV = false;
         bool bIsExternalTexture = false;
+        bool bIsExtendedTexture = false;
 
         float backendProjMatrix[16];
 
         std::vector<float> VSFlags;
         std::vector<float> FSAlphaFlags;
         std::vector<float> FSMiscFlags;
+        std::vector<float> FSTexFlags;
 
         float d3dViewMatrix[16];
         float d3dProjectionMatrix[16];
@@ -376,7 +378,8 @@ public:
     void doModulateAlpha(bool flag = false);
     void doTextureFiltering(bool flag = false);
     void isExternalTexture(bool flag = false);
-
+    void isExtendedTexture(bool flag = false);
+    
     // Alpha mode emulation
     void setAlphaRef(RendererAlphaFunc func = RendererAlphaFunc::ALWAYS, float ref = 0.0f);
     void doAlphaTest(bool flag = false);


### PR DESCRIPTION
Added support for extended PBR textures (normal map, roughness, metalness, AO). This is achieved by extending the textures vertically to three times their original height. The first region contains the original texture, the second contains the normal map (RGB channels, alpha unused), the third region contains the other parameters (R: roughness, G: metalness, B: AO, A unused). These extended textures will be provided in IRO mods.

The core FFNx was slightly changed to make it work with the extended textures mods even when lighting is off (otherwise the uvs would be broken and cause the extended textures to show as colors).