### PR TITLE
Add Errors with Tips and gitignore Clion.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,3 +391,7 @@ MigrationBackup/
 
 # Distribution directory
 .dist
+
+# Clion
+#.idea/
+cmake-build*/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# we don't use this file for this project.
+/deployment.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+SUPERBUILD

--- a/.idea/FFNx.iml
+++ b/.idea/FFNx.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/FFNx.iml" filepath="$PROJECT_DIR$/.idea/FFNx.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,14 @@
 
 cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW)
+if(DEFINED CMAKE_BUILD_TYPE AND CMAKE_BUILD_TYPE) # Azure and multi-configuration generators don't set CMAKE_BUILD_TYPE
+	if (NOT CMAKE_BUILD_TYPE MATCHES Release AND NOT CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
+		message(FATAL_ERROR "You selected `${CMAKE_BUILD_TYPE}` mode. Only `Release` and `RelWithDebInfo` are supported.\nAdd -DCMAKE_BUILD_TYPE=Release or -DCMAKE_BUILD_TYPE=RelWithDebInfo to your cmake command line.")
+	endif()
+endif()
+if (NOT DEFINED _DLL_VERSION OR NOT _DLL_VERSION)
+	message(FATAL_ERROR "_DLL_VERSION must be set to continue building with cmake. \nExample: Add -D_DLL_VERSION=devel to your cmake command line.")
+endif ()
 
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
 set(CMAKE_SHARED_LINKER_FLAGS


### PR DESCRIPTION
There is not really a clion project file. Because Clion's settings will be different for everyone. As adding visual studio's compiler is a manual process. So these changes are more for helping future users.
## Errors
These are fatal errors to stop them as soon as possible. Provide some tips how to fix the issue. I think devel is a good value `_DLL_VERSION`.

added this to CMakeLists.txt
```cmake
if(DEFINED CMAKE_BUILD_TYPE AND CMAKE_BUILD_TYPE) # Azure and multi-configuration generators don't set CMAKE_BUILD_TYPE
	if (NOT CMAKE_BUILD_TYPE MATCHES Release AND NOT CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
		message(FATAL_ERROR "You selected `${CMAKE_BUILD_TYPE}` mode. Only `Release` and `RelWithDebInfo` are supported.\nAdd -DCMAKE_BUILD_TYPE=Release or -DCMAKE_BUILD_TYPE=RelWithDebInfo to your cmake command line.")
	endif()
endif()
if (NOT DEFINED _DLL_VERSION OR NOT _DLL_VERSION)
	message(FATAL_ERROR "_DLL_VERSION must be set to continue building with cmake. \nExample: Add -D_DLL_VERSION=devel to your cmake command line.")
endif ()
```
## Git ignore
Just to prevent clion from filling up the repo. Clion pretty much just uses these folders. `.idea` stores the IDE settings, and `cmake-build*/` stores all the cmake build data. Though this is just the defaults, users can customize settings. Though for visual studio compiler there is only one generator supported.

added this to .gitignore - 
```
# Clion
.idea/
cmake-build*/
```