### PR TITLE
Fixed Battle UI draw order and depth buffer backup

### DIFF
--- a/src/gl.h
+++ b/src/gl.h
@@ -103,7 +103,7 @@ void gl_save_state(struct driver_state *dest);
 void gl_load_state(struct driver_state *src);
 uint32_t gl_defer_draw(uint32_t primitivetype, uint32_t vertextype, struct nvertex* vertices, struct point3d* normals, uint32_t vertexcount, WORD* indices, uint32_t count, struct boundingbox* boundingbox, uint32_t clip, uint32_t mipmap);
 uint32_t gl_defer_sorted_draw(uint32_t primitivetype, uint32_t vertextype, struct nvertex *vertices, uint32_t vertexcount, WORD *indices, uint32_t count, uint32_t clip, uint32_t mipmap);
-void gl_draw_deferred(DrawOrder draworder);
+void gl_draw_deferred(bool isDrawOrderEnabled = false, DrawOrder draworder = DRAW_ORDER_0);
 void gl_set_projection_viewport_matrices();
 struct boundingbox calculateSceneAabb();
 void gl_draw_sorted_deferred();

--- a/src/gl/deferred.cpp
+++ b/src/gl/deferred.cpp
@@ -296,7 +296,7 @@ uint32_t gl_defer_sorted_draw(uint32_t primitivetype, uint32_t vertextype, struc
 }
 
 // draw deferred models
-void gl_draw_deferred(DrawOrder draworder)
+void gl_draw_deferred(bool isDrawOrderEnabled, DrawOrder draworder)
 {
 	struct driver_state saved_state;
 
@@ -316,7 +316,7 @@ void gl_draw_deferred(DrawOrder draworder)
 			continue;
 		}
 
-		if (deferred_draws[i].draworder != draworder)
+		if (isDrawOrderEnabled && deferred_draws[i].draworder != draworder)
 		{
 			continue;
 		}
@@ -348,7 +348,7 @@ void gl_draw_deferred(DrawOrder draworder)
 		deferred_draws[i].boundingbox = nullptr;
 	}
 
-	if(draworder == DRAW_ORDER_COUNT - 1) num_deferred = 0;
+	if(!isDrawOrderEnabled || draworder == DRAW_ORDER_COUNT - 1) num_deferred = 0;
 
 	nodefer = false;
 

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -606,21 +606,25 @@ void Lighting::draw(struct game_obj* game_object)
         }
     }
 
-    // Draw deferred 2D opaque models
-    gl_draw_deferred(DRAW_ORDER_0);
+	if (mode->driver_mode == MODE_FIELD)
+	{
+		// Draw deferred 2D opaque models
+		gl_draw_deferred(true, DRAW_ORDER_0);
 
-    // Draw the walkmesh for field shadows
-    if (mode->driver_mode == MODE_FIELD)
-    {
+		// Draw the walkmesh for field shadows
 		gl_set_projection_viewport_matrices();
-        drawFieldShadow();
-    }
+		drawFieldShadow();
 
-	// Draw deferred 3D opaque models
-	gl_draw_deferred(DRAW_ORDER_1);
+		// Draw deferred 3D opaque models
+		gl_draw_deferred(true, DRAW_ORDER_1);
 
-	// Draw deferred non-opaque models
-	gl_draw_deferred(DRAW_ORDER_2);
+		// Draw deferred non-opaque models
+		gl_draw_deferred(true, DRAW_ORDER_2);
+	}
+	else
+	{
+		gl_draw_deferred(false);
+	}
 };
 
 void Lighting::drawFieldShadow()

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -787,6 +787,7 @@ void Renderer::recoverDepthBuffer()
     backendViewId++;
     bgfx::blit(backendViewId, bgfx::getTexture(backendFrameBuffer, 1), 0, 0, backupDepthTexture, 0, 0, framebufferWidth, framebufferHeight);
     bgfx::touch(backendViewId);
+    backendViewId++;
 }
 
 void Renderer::drawFieldShadow()


### PR DESCRIPTION
I fixed the following bugs reported when lighting is enabled.
- Some elements of the battle UI not being drawn
- Depth buffer backup used for field shadows not working correctly in APIs other than DX11