### PR TITLE
Music: fix crash when a file cannot be opened by vgmstream

### DIFF
--- a/src/audio.h
+++ b/src/audio.h
@@ -87,6 +87,15 @@ public:
 		float wantedMusicVolume;
 	};
 
+	struct NxAudioEngineMusicAudioSource
+	{
+		NxAudioEngineMusicAudioSource(SoLoud::handle handle, SoLoud::AudioSource* audioSource) :
+			handle(handle),
+			audioSource(audioSource) {}
+		SoLoud::handle handle;
+		SoLoud::AudioSource* audioSource;
+	};
+
 	struct NxAudioEngineVoice
 	{
 		NxAudioEngineVoice() :
@@ -141,11 +150,13 @@ private:
 	// MUSIC
 	NxAudioEngineMusic _musics[2];
 	std::stack<NxAudioEngineMusic> _musicStack; // For resuming
+	std::list<NxAudioEngineMusicAudioSource> _audioSourcesToDeleteLater;
 
 	float _previousMusicMasterVolume = -1.0f;
 	float _musicMasterVolume = -1.0f;
 	SoLoud::time _lastVolumeFadeEndTime = 0.0;
 
+	void cleanOldAudioSources();
 	SoLoud::AudioSource* loadMusic(const char* name, bool isFullPath = false, const char* format = nullptr);
 	void overloadPlayArgumentsFromConfig(char* name, uint32_t *id, MusicOptions *MusicOptions);
 	void backupMusic(int channelSource);


### PR DESCRIPTION
To reproduce: read a psf file with the psf plugin unloaded (if you don't have configured a hebios, it is unloaded for example).

```
[00000003] ERROR: NxAudioEngine::loadMusic: Cannot load E:\Documents\Square Enix\FINAL FANTASY VII\satsuki\FF7SYW/music/psf/pre.minipsf with vgmstream
[00000003] TRACE: *** Exception 0xc0000005, address 0x784b220 ***
[00000003] TRACE: SymInit: Symbol-SearchPath: '.;E:\Documents\Square Enix\FINAL FANTASY VII\satsuki\FF7SYW;E:\Documents\Square Enix\FINAL FANTASY VII\satsuki\FF7SYW;C:\WINDOWS;C:\WINDOWS\system32;SRV*C:\websymbols*https://msdl.microsoft.com/download/symbols;', symOptions: 530, UserName: 'myst6re'
[00000003] TRACE: OS-Version: 6.2.9200 () 0x100-0x1
[00000003] TRACE: E:\Documents\Square Enix\FINAL FANTASY VII\satsuki\FF7SYW\FF7.exe:FF7.exe (00400000), size: 11870208 (result: 0), SymType: '-nosymbols-', PDB: 'E:\Documents\Square Enix\FINAL FANTASY VII\satsuki\FF7SYW\FF7.exe'
[00000003] TRACE: C:\WINDOWS\SYSTEM32\ntdll.dll:ntdll.dll (77BC0000), size: 1716224 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\ntdll.dll', fileVersion: 6.2.19041.1110
[00000003] TRACE: C:\WINDOWS\System32\KERNEL32.DLL:KERNEL32.DLL (763F0000), size: 983040 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\KERNEL32.DLL', fileVersion: 6.2.19041.1151
[00000003] TRACE: C:\WINDOWS\System32\KERNELBASE.dll:KERNELBASE.dll (77890000), size: 2179072 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\KERNELBASE.dll', fileVersion: 6.2.19041.1151
[00000003] TRACE: C:\WINDOWS\SYSTEM32\apphelp.dll:apphelp.dll (792D0000), size: 651264 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\apphelp.dll', fileVersion: 6.2.19041.928
[00000003] TRACE: C:\WINDOWS\SYSTEM32\AcLayers.DLL:AcLayers.DLL (7A0C0000), size: 2637824 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\AcLayers.DLL', fileVersion: 6.2.19041.1023
[00000003] TRACE: C:\WINDOWS\System32\msvcrt.dll:msvcrt.dll (75FD0000), size: 782336 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\msvcrt.dll', fileVersion: 7.0.19041.546
[00000003] TRACE: C:\WINDOWS\System32\USER32.dll:USER32.dll (776F0000), size: 1662976 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\USER32.dll', fileVersion: 6.2.19041.1151
[00000003] TRACE: C:\WINDOWS\System32\win32u.dll:win32u.dll (75A70000), size: 98304 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\win32u.dll', fileVersion: 6.2.19041.1151
[00000003] TRACE: C:\WINDOWS\System32\GDI32.dll:GDI32.dll (75C80000), size: 143360 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\GDI32.dll', fileVersion: 6.2.19041.746
[00000003] TRACE: C:\WINDOWS\System32\gdi32full.dll:gdi32full.dll (774A0000), size: 901120 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\gdi32full.dll', fileVersion: 6.2.19041.1110
[00000003] TRACE: C:\WINDOWS\System32\msvcp_win.dll:msvcp_win.dll (75EA0000), size: 503808 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\msvcp_win.dll', fileVersion: 6.2.19041.789
[00000003] TRACE: C:\WINDOWS\System32\ucrtbase.dll:ucrtbase.dll (75CB0000), size: 1179648 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\ucrtbase.dll', fileVersion: 6.2.19041.789
[00000003] TRACE: C:\WINDOWS\System32\SHELL32.dll:SHELL32.dll (76920000), size: 5976064 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\SHELL32.dll', fileVersion: 6.2.19041.1151
[00000003] TRACE: C:\WINDOWS\System32\SHLWAPI.dll:SHLWAPI.dll (75E50000), size: 282624 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\SHLWAPI.dll', fileVersion: 6.2.19041.1023
[00000003] TRACE: C:\WINDOWS\System32\OLEAUT32.dll:OLEAUT32.dll (76350000), size: 614400 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\OLEAUT32.dll', fileVersion: 6.2.19041.985
[00000003] TRACE: C:\WINDOWS\System32\combase.dll:combase.dll (76090000), size: 2625536 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\combase.dll', fileVersion: 6.2.19041.1081
[00000003] TRACE: C:\WINDOWS\System32\RPCRT4.dll:RPCRT4.dll (75A90000), size: 782336 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\RPCRT4.dll', fileVersion: 6.2.19041.1081
[00000003] TRACE: C:\WINDOWS\System32\SETUPAPI.dll:SETUPAPI.dll (77060000), size: 4440064 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\SETUPAPI.dll', fileVersion: 6.2.19041.1151
[00000003] TRACE: C:\WINDOWS\System32\cfgmgr32.dll:cfgmgr32.dll (75F90000), size: 241664 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\cfgmgr32.dll', fileVersion: 6.2.19041.1151
[00000003] TRACE: C:\WINDOWS\System32\bcrypt.dll:bcrypt.dll (76680000), size: 102400 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\bcrypt.dll', fileVersion: 6.2.19041.1023
[00000003] TRACE: C:\WINDOWS\SYSTEM32\MPR.dll:MPR.dll (50300000), size: 102400 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\MPR.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\sfc.dll:sfc.dll (66680000), size: 12288 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\sfc.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\WINSPOOL.DRV:WINSPOOL.DRV (5F2A0000), size: 446464 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\WINSPOOL.DRV', fileVersion: 6.2.19041.1023
[00000003] TRACE: C:\WINDOWS\SYSTEM32\sfc_os.DLL:sfc_os.DLL (519E0000), size: 61440 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\sfc_os.DLL', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\AcGenral.DLL:AcGenral.DLL (7A350000), size: 2428928 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\AcGenral.DLL', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\System32\sechost.dll:sechost.dll (75DD0000), size: 479232 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\sechost.dll', fileVersion: 6.2.19041.906
[00000003] TRACE: C:\WINDOWS\System32\ole32.dll:ole32.dll (76EE0000), size: 929792 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\ole32.dll', fileVersion: 6.2.19041.746
[00000003] TRACE: C:\WINDOWS\System32\ADVAPI32.dll:ADVAPI32.dll (76530000), size: 499712 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\ADVAPI32.dll', fileVersion: 6.2.19041.1052
[00000003] TRACE: C:\WINDOWS\SYSTEM32\UxTheme.dll:UxTheme.dll (75180000), size: 475136 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\UxTheme.dll', fileVersion: 6.2.19041.1081
[00000003] TRACE: C:\WINDOWS\SYSTEM32\WINMM.dll:WINMM.dll (675E0000), size: 163840 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\WINMM.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\samcli.dll:samcli.dll (502E0000), size: 86016 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\samcli.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\MSACM32.dll:MSACM32.dll (51280000), size: 102400 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\MSACM32.dll', fileVersion: 6.2.19041.1
[00000003] TRACE: C:\WINDOWS\SYSTEM32\VERSION.dll:VERSION.dll (759D0000), size: 32768 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\VERSION.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\USERENV.dll:USERENV.dll (64450000), size: 151552 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\USERENV.dll', fileVersion: 6.2.19041.572
[00000003] TRACE: C:\WINDOWS\SYSTEM32\dwmapi.dll:dwmapi.dll (73BB0000), size: 155648 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\dwmapi.dll', fileVersion: 6.2.19041.746
[00000003] TRACE: C:\WINDOWS\SYSTEM32\urlmon.dll:urlmon.dll (6A740000), size: 1736704 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\urlmon.dll', fileVersion: 11.0.19041.1151
[00000003] TRACE: C:\WINDOWS\SYSTEM32\SspiCli.dll:SspiCli.dll (73B80000), size: 135168 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\SspiCli.dll', fileVersion: 6.2.19041.906
[00000003] TRACE: C:\WINDOWS\SYSTEM32\winmmbase.dll:winmmbase.dll (51900000), size: 118784 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\winmmbase.dll', fileVersion: 6.2.19041.1
[00000003] TRACE: C:\WINDOWS\SYSTEM32\iertutil.dll:iertutil.dll (6A410000), size: 2273280 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\iertutil.dll', fileVersion: 11.0.19041.1081
[00000003] TRACE: C:\WINDOWS\System32\shcore.dll:shcore.dll (77B20000), size: 552960 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\shcore.dll', fileVersion: 6.2.19041.1023
[00000003] TRACE: C:\WINDOWS\SYSTEM32\srvcli.dll:srvcli.dll (6BE40000), size: 118784 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\srvcli.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\netutils.dll:netutils.dll (6A640000), size: 45056 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\netutils.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\System32\IMM32.DLL:IMM32.DLL (76320000), size: 151552 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\IMM32.DLL', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\OPENGL32.dll:OPENGL32.dll (7B850000), size: 1060864 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\OPENGL32.dll', fileVersion: 6.2.19041.1081
[00000003] TRACE: C:\WINDOWS\SYSTEM32\DSOUND.dll:DSOUND.dll (77EA0000), size: 520192 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\DSOUND.dll', fileVersion: 6.2.19041.1
[00000003] TRACE: C:\WINDOWS\SYSTEM32\DINPUT.dll:DINPUT.dll (500A0000), size: 155648 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\DINPUT.dll', fileVersion: 6.2.19041.1
[00000003] TRACE: C:\WINDOWS\SYSTEM32\powrprof.dll:powrprof.dll (662C0000), size: 278528 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\powrprof.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\GLU32.dll:GLU32.dll (50060000), size: 258048 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\GLU32.dll', fileVersion: 6.2.19041.1081
[00000003] TRACE: C:\WINDOWS\SYSTEM32\DDRAW.dll:DDRAW.dll (7C050000), size: 954368 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\DDRAW.dll', fileVersion: 6.2.19041.1
[00000003] TRACE: C:\WINDOWS\SYSTEM32\kernel.appcore.dll:kernel.appcore.dll (75200000), size: 61440 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\kernel.appcore.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\dxgi.dll:dxgi.dll (67510000), size: 798720 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\dxgi.dll', fileVersion: 6.2.19041.964
[00000003] TRACE: C:\WINDOWS\SYSTEM32\DCIMAN32.dll:DCIMAN32.dll (502D0000), size: 28672 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\DCIMAN32.dll', fileVersion: 6.2.19041.1165
[00000003] TRACE: C:\WINDOWS\SYSTEM32\UMPDC.dll:UMPDC.dll (662B0000), size: 53248 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\UMPDC.dll'
[00000003] TRACE: C:\WINDOWS\SYSTEM32\inputhost.dll:inputhost.dll (7C930000), size: 970752 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\inputhost.dll', fileVersion: 6.2.19041.906
[00000003] TRACE: C:\WINDOWS\SYSTEM32\CoreMessaging.dll:CoreMessaging.dll (73950000), size: 634880 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\CoreMessaging.dll', fileVersion: 6.2.19041.867
[00000003] TRACE: C:\WINDOWS\System32\WS2_32.dll:WS2_32.dll (765B0000), size: 405504 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\WS2_32.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\PROPSYS.dll:PROPSYS.dll (73AB0000), size: 794624 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\PROPSYS.dll', fileVersion: 7.0.19041.1023
[00000003] TRACE: C:\WINDOWS\SYSTEM32\wintypes.dll:wintypes.dll (735C0000), size: 897024 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\wintypes.dll', fileVersion: 6.2.19041.1081
[00000003] TRACE: C:\WINDOWS\SYSTEM32\CoreUIComponents.dll:CoreUIComponents.dll (736D0000), size: 2613248 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\CoreUIComponents.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\System32\bcryptPrimitives.dll:bcryptPrimitives.dll (76620000), size: 389120 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\bcryptPrimitives.dll', fileVersion: 6.2.19041.1023
[00000003] TRACE: C:\WINDOWS\SYSTEM32\ntmarta.dll:ntmarta.dll (736A0000), size: 167936 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\ntmarta.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: E:\Documents\7th-Heaven\SeventhHeavenUI\bin\Release\EasyHook32.dll:EasyHook32.dll (500D0000), size: 303104 (result: 0), SymType: '-exported-', PDB: 'E:\Documents\7th-Heaven\SeventhHeavenUI\bin\Release\EasyHook32.dll', fileVersion: 2.7.7097.0
[00000003] TRACE: C:\WINDOWS\System32\PSAPI.DLL:PSAPI.DLL (77680000), size: 24576 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\PSAPI.DLL', fileVersion: 6.2.19041.546
[00000003] TRACE: E:\Documents\7th-Heaven\SeventhHeavenUI\bin\Release\EasyLoad32.dll:EasyLoad32.dll (50030000), size: 40960 (result: 0), SymType: '-nosymbols-', PDB: 'E:\Documents\7th-Heaven\SeventhHeavenUI\bin\Release\EasyLoad32.dll', fileVersion: 2.7.7097.0
[00000003] TRACE: C:\WINDOWS\SYSTEM32\mscoree.dll:mscoree.dll (75120000), size: 335872 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\mscoree.dll', fileVersion: 6.2.19041.1
[00000003] TRACE: C:\Windows\Microsoft.NET\Framework\v4.0.30319\mscoreei.dll:mscoreei.dll (75090000), size: 577536 (result: 0), SymType: '-exported-', PDB: 'C:\Windows\Microsoft.NET\Framework\v4.0.30319\mscoreei.dll', fileVersion: 4.8.4180.0
[00000003] TRACE: C:\Windows\Microsoft.NET\Framework\v4.0.30319\clr.dll:clr.dll (72E00000), size: 8065024 (result: 0), SymType: '-exported-', PDB: 'C:\Windows\Microsoft.NET\Framework\v4.0.30319\clr.dll', fileVersion: 4.8.4400.0
[00000003] TRACE: C:\WINDOWS\SYSTEM32\ucrtbase_clr0400.dll:ucrtbase_clr0400.dll (74480000), size: 700416 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\ucrtbase_clr0400.dll', fileVersion: 14.10.25028.0
[00000003] TRACE: C:\WINDOWS\SYSTEM32\VCRUNTIME140_CLR0400.dll:VCRUNTIME140_CLR0400.dll (74530000), size: 81920 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\VCRUNTIME140_CLR0400.dll', fileVersion: 14.10.25028.0
[00000003] TRACE: C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\mscorlib\e4a1c9189d2b01f018b953e46c80d120\mscorlib.ni.dll:mscorlib.ni.dll (719F0000), size: 21028864 (result: 0), SymType: '-nosymbols-', PDB: 'C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\mscorlib\e4a1c9189d2b01f018b953e46c80d120\mscorlib.ni.dll', fileVersion: 4.8.4400.0
[00000003] TRACE: C:\WINDOWS\SYSTEM32\CRYPTSP.dll:CRYPTSP.dll (718C0000), size: 77824 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\CRYPTSP.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\system32\rsaenh.dll:rsaenh.dll (71890000), size: 192512 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\system32\rsaenh.dll', fileVersion: 6.2.19041.1052
[00000003] TRACE: C:\WINDOWS\SYSTEM32\CRYPTBASE.dll:CRYPTBASE.dll (71880000), size: 40960 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\CRYPTBASE.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\Windows\Microsoft.NET\Framework\v4.0.30319\clrjit.dll:clrjit.dll (71960000), size: 565248 (result: 0), SymType: '-exported-', PDB: 'C:\Windows\Microsoft.NET\Framework\v4.0.30319\clrjit.dll', fileVersion: 4.8.4400.0
[00000003] TRACE: C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System\68e52ded8d0e73920808d8880ed14efd\System.ni.dll:System.ni.dll (70E20000), size: 10838016 (result: 0), SymType: '-nosymbols-', PDB: 'C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System\68e52ded8d0e73920808d8880ed14efd\System.ni.dll', fileVersion: 4.8.4360.0
[00000003] TRACE: C:\WINDOWS\SYSTEM32\windows.storage.dll:windows.storage.dll (75240000), size: 6324224 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\windows.storage.dll', fileVersion: 6.2.19041.1151
[00000003] TRACE: C:\WINDOWS\SYSTEM32\Wldp.dll:Wldp.dll (75210000), size: 147456 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\Wldp.dll', fileVersion: 6.2.19041.662
[00000003] TRACE: C:\WINDOWS\SYSTEM32\profapi.dll:profapi.dll (6BD00000), size: 98304 (result: 0), SymType: '-nosymbols-', PDB: 'C:\WINDOWS\SYSTEM32\profapi.dll', fileVersion: 6.2.19041.844
[00000003] TRACE: C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Runt73a1fc9d#\c1442da6f04ac57b5067b1bbdc574a09\System.Runtime.Remoting.ni.dll:System.Runtime.Remoting.ni.dll (5C890000), size: 851968 (result: 0), SymType: '-nosymbols-', PDB: 'C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Runt73a1fc9d#\c1442da6f04ac57b5067b1bbdc574a09\System.Runtime.Remoting.ni.dll', fileVersion: 4.8.4084.0
[00000003] TRACE: C:\WINDOWS\system32\mswsock.dll:mswsock.dll (64CC0000), size: 335872 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\system32\mswsock.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Core\62fe5fc1b5bafb28a19a2754318abf00\System.Core.ni.dll:System.Core.ni.dll (6F5E0000), size: 8486912 (result: 0), SymType: '-nosymbols-', PDB: 'C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Core\62fe5fc1b5bafb28a19a2754318abf00\System.Core.ni.dll', fileVersion: 4.8.4390.0
[00000003] TRACE: C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Configuration\96b2b7229c43d2712ff1bf4906a723f6\System.Configuration.ni.dll:System.Configuration.ni.dll (6C610000), size: 1073152 (result: 0), SymType: '-nosymbols-', PDB: 'C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Configuration\96b2b7229c43d2712ff1bf4906a723f6\System.Configuration.ni.dll', fileVersion: 4.8.4190.0
[00000003] TRACE: C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Xml\5a5dc2f9e9c66b74d361d490c1f4357b\System.Xml.ni.dll:System.Xml.ni.dll (6BE90000), size: 7815168 (result: 0), SymType: '-nosymbols-', PDB: 'C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Xml\5a5dc2f9e9c66b74d361d490c1f4357b\System.Xml.ni.dll', fileVersion: 4.8.4084.0
[00000003] TRACE: C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Drawing\6727d7bc35e330366d2e1724c31588d2\System.Drawing.ni.dll:System.Drawing.ni.dll (70C70000), size: 1716224 (result: 0), SymType: '-nosymbols-', PDB: 'C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Drawing\6727d7bc35e330366d2e1724c31588d2\System.Drawing.ni.dll', fileVersion: 4.8.4390.0
[00000003] TRACE: C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Windows.Forms\1832a65f299e4b6bb21796f03a62cbef\System.Windows.Forms.ni.dll:System.Windows.Forms.ni.dll (6FE00000), size: 15118336 (result: 0), SymType: '-nosymbols-', PDB: 'C:\WINDOWS\assembly\NativeImages_v4.0.30319_32\System.Windows.Forms\1832a65f299e4b6bb21796f03a62cbef\System.Windows.Forms.ni.dll', fileVersion: 4.8.4400.0
[00000003] TRACE: E:\Documents\Square Enix\FINAL FANTASY VII\satsuki\FF7SYW\FFNx.dll:FFNx.dll (06B10000), size: 39628800 (result: 0), SymType: 'PDB', PDB: '.\FFNx.pdb'
[00000003] TRACE: C:\WINDOWS\SYSTEM32\MFPlat.DLL:MFPlat.DLL (5FA20000), size: 1544192 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\MFPlat.DLL', fileVersion: 6.2.19041.746
[00000003] TRACE: C:\WINDOWS\SYSTEM32\DINPUT8.dll:DINPUT8.dll (7C390000), size: 225280 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\DINPUT8.dll', fileVersion: 6.2.19041.1
[00000003] TRACE: C:\WINDOWS\SYSTEM32\WSOCK32.dll:WSOCK32.dll (60A10000), size: 32768 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\WSOCK32.dll', fileVersion: 6.2.19041.1
[00000003] TRACE: C:\WINDOWS\SYSTEM32\Secur32.dll:Secur32.dll (74590000), size: 40960 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\Secur32.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\XINPUT9_1_0.dll:XINPUT9_1_0.dll (50020000), size: 28672 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\XINPUT9_1_0.dll', fileVersion: 6.2.19041.1
[00000003] TRACE: C:\WINDOWS\SYSTEM32\dbghelp.dll:dbghelp.dll (7A620000), size: 1605632 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\dbghelp.dll', fileVersion: 6.2.19041.1052
[00000003] TRACE: C:\WINDOWS\SYSTEM32\dbgcore.DLL:dbgcore.DLL (7C710000), size: 155648 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\dbgcore.DLL', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\RTWorkQ.DLL:RTWorkQ.DLL (5F970000), size: 163840 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\RTWorkQ.DLL', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\System32\MSCTF.dll:MSCTF.dll (77580000), size: 868352 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\MSCTF.dll', fileVersion: 6.2.19041.1081
[00000003] TRACE: C:\WINDOWS\SYSTEM32\textinputframework.dll:textinputframework.dll (739F0000), size: 757760 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\textinputframework.dll', fileVersion: 6.2.19041.1151
[00000003] TRACE: C:\WINDOWS\SYSTEM32\nvapi.dll:nvapi.dll (7A940000), size: 6373376 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\nvapi.dll', fileVersion: 30.0.14.7111
[00000003] TRACE: C:\WINDOWS\SYSTEM32\msasn1.dll:msasn1.dll (68B70000), size: 57344 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\msasn1.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\cryptnet.dll:cryptnet.dll (6A670000), size: 155648 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\cryptnet.dll', fileVersion: 6.2.19041.906
[00000003] TRACE: C:\WINDOWS\System32\CRYPT32.dll:CRYPT32.dll (766A0000), size: 1052672 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\CRYPT32.dll', fileVersion: 6.2.19041.844
[00000003] TRACE: C:\WINDOWS\SYSTEM32\d3d11.dll:d3d11.dll (65F20000), size: 1966080 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\d3d11.dll', fileVersion: 6.2.19041.746
[00000003] TRACE: C:\WINDOWS\SYSTEM32\d3d9.dll:d3d9.dll (73E60000), size: 1634304 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\d3d9.dll', fileVersion: 6.2.19041.928
[00000003] TRACE: C:\WINDOWS\SYSTEM32\dxgidebug.dll:dxgidebug.dll (7AF60000), size: 241664 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\dxgidebug.dll', fileVersion: 6.2.19041.1
[00000003] TRACE: C:\WINDOWS\System32\DriverStore\FileRepository\nv_dispi.inf_amd64_4a746d937e6a7240\nvldumd.dll:nvldumd.dll (68C40000), size: 892928 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\DriverStore\FileRepository\nv_dispi.inf_amd64_4a746d937e6a7240\nvldumd.dll', fileVersion: 30.0.14.7111
[00000003] TRACE: C:\WINDOWS\System32\WINTRUST.DLL:WINTRUST.DLL (764E0000), size: 290816 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\WINTRUST.DLL', fileVersion: 6.2.19041.1151
[00000003] TRACE: C:\WINDOWS\System32\imagehlp.dll:imagehlp.dll (77660000), size: 102400 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\imagehlp.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\System32\DriverStore\FileRepository\nv_dispi.inf_amd64_4a746d937e6a7240\nvwgf2um.dll:nvwgf2um.dll (0E290000), size: 33648640 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\DriverStore\FileRepository\nv_dispi.inf_amd64_4a746d937e6a7240\nvwgf2um.dll', fileVersion: 30.0.14.7111
[00000003] TRACE: C:\WINDOWS\SYSTEM32\dxcore.dll:dxcore.dll (68BB0000), size: 180224 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\dxcore.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\dcomp.dll:dcomp.dll (66100000), size: 1462272 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\dcomp.dll', fileVersion: 6.2.19041.1023
[00000003] TRACE: C:\WINDOWS\SYSTEM32\XInput1_4.dll:XInput1_4.dll (50010000), size: 53248 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\XInput1_4.dll', fileVersion: 6.2.19041.844
[00000003] TRACE: C:\WINDOWS\SYSTEM32\DEVOBJ.dll:DEVOBJ.dll (519B0000), size: 176128 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\DEVOBJ.dll', fileVersion: 6.2.19041.1151
[00000003] TRACE: C:\WINDOWS\System32\clbcatq.dll:clbcatq.dll (75B50000), size: 516096 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\clbcatq.dll', fileVersion: 2001.12.10941.16384
[00000003] TRACE: C:\Windows\System32\deviceaccess.dll:deviceaccess.dll (7B4D0000), size: 196608 (result: 0), SymType: '-exported-', PDB: 'C:\Windows\System32\deviceaccess.dll', fileVersion: 6.2.19041.746
[00000003] TRACE: C:\WINDOWS\SYSTEM32\HID.DLL:HID.DLL (50000000), size: 40960 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\HID.DLL', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\System32\MMDevApi.dll:MMDevApi.dll (51870000), size: 438272 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\System32\MMDevApi.dll', fileVersion: 6.2.19041.1023
[00000003] TRACE: C:\WINDOWS\SYSTEM32\AUDIOSES.DLL:AUDIOSES.DLL (512B0000), size: 1269760 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\AUDIOSES.DLL', fileVersion: 6.2.19041.1023
[00000003] TRACE: C:\WINDOWS\SYSTEM32\resourcepolicyclient.dll:resourcepolicyclient.dll (597A0000), size: 61440 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\resourcepolicyclient.dll', fileVersion: 6.2.19041.546
[00000003] TRACE: C:\WINDOWS\SYSTEM32\msadp32.acm:msadp32.acm (77D80000), size: 36864 (result: 0), SymType: '-exported-', PDB: 'C:\WINDOWS\SYSTEM32\msadp32.acm', fileVersion: 6.2.19041.1
[00000003] TRACE: 0784B220 (FFNx): (filename not available): reset_vgmstream
[00000003] TRACE: 06E437AB (FFNx): (filename not available): SoLoud::VGMStream::createInstance
[00000003] TRACE: 079ABA33 (FFNx): (filename not available): SoLoud::Soloud::play
[00000003] TRACE: 079ABC5A (FFNx): (filename not available): SoLoud::Soloud::playBackground
[00000003] TRACE: 06E2576E (FFNx): (filename not available): NxAudioEngine::playMusic
[00000003] TRACE: 06E70431 (FFNx): (filename not available): play_music
[00000003] TRACE: 06E6F95D (FFNx): (filename not available): ff7_play_midi
[00000003] TRACE: 00740E35 (FF7): (filename not available): (function-name not available)
[00000003] TRACE: 007A70FB (FF7): (filename not available): (function-name not available)
[00000003] TRACE: 007A7764 (FF7): (filename not available): (function-name not available)
[00000003] TRACE: 007A7AF0 (FF7): (filename not available): (function-name not available)
[00000003] TRACE: 0067DD90 (FF7): (filename not available): (function-name not available)
[00000003] TRACE: 0040B832 (FF7): (filename not available): (function-name not available)
[00000003] TRACE: 7640FA29 (KERNEL32): (filename not available): BaseThreadInitThunk
[00000003] TRACE: 77C27A7E (ntdll): (filename not available): RtlGetAppContainerNamedObjectPath
[00000003] TRACE: 77C27A4E (ntdll): (filename not available): RtlGetAppContainerNamedObjectPath
[00000003] ERROR: Unhandled Exception. See dumped information above.
```