### PR TITLE
FF7: Implemented analogue controls in fields

### DIFF
--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -208,6 +208,15 @@ enable_ffmpeg_videos = -1
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ffmpeg_video_ext = "avi"
 
+###########################
+# Controller Options
+###########################
+
+#[ANALOGUE CONTROLS]
+# This flag will enable analogue joystick input for controlling the player.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+enable_analogue_controls = false
+
 ###############################
 # MUST SET FOR VERSIONS BELOW
 # FF7 2012   FF7 STEAM

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -99,6 +99,7 @@ double speedhack_min;
 bool enable_animated_textures;
 long ff7_fps_limiter;
 bool ff7_footsteps;
+bool enable_analogue_controls;
 
 std::vector<std::string> get_string_or_array_of_strings(const toml::node_view<toml::node> &node)
 {
@@ -212,6 +213,7 @@ void read_cfg()
 	enable_animated_textures = config["enable_animated_textures"].value_or(false);
 	ff7_fps_limiter = config["ff7_fps_limiter"].value_or(FF7_LIMITER_DEFAULT);
 	ff7_footsteps = config["ff7_footsteps"].value_or(false);
+	enable_analogue_controls = config["enable_analogue_controls"].value_or(false);
 
 	// Windows x or y size can't be less then 0
 	if (window_size_x < 0) window_size_x = 0;

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -112,5 +112,6 @@ extern double speedhack_min;
 extern bool enable_animated_textures;
 extern long ff7_fps_limiter;
 extern bool ff7_footsteps;
+extern bool enable_analogue_controls;
 
 void read_cfg();


### PR DESCRIPTION
I implemented analogue controls so that the player can move in whatever direction you move the joystick.
I used the "Control Direction" parameter in the flevel: http://wiki.ffrtt.ru/index.php/FF7/Field/Triggers
This parameter defines for each field the orientation the player moves. This PR achieves analogue controls by overriding this parameter every frame so that the player moves in 256 directions instead of 8.