### PR TITLE
Implemented linear space and image based lighting (IBL)

### DIFF
--- a/misc/FFNx.common.sh
+++ b/misc/FFNx.common.sh
@@ -1,11 +1,5 @@
 /****************************************************************************/
-//    Copyright (C) 2009 Aali132                                            //
-//    Copyright (C) 2018 quantumpencil                                      //
-//    Copyright (C) 2018 Maxime Bacoux                                      //
-//    Copyright (C) 2020 myst6re                                            //
-//    Copyright (C) 2020 Chris Rizzitello                                   //
-//    Copyright (C) 2020 John Pritchard                                     //
-//    Copyright (C) 2021 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2021 Cosmos                                             //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //
@@ -19,16 +13,12 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-$input a_position, a_texcoord0, a_color0
-$output v_color0, v_texcoord0
-
-#include <bgfx/bgfx_shader.sh>
-#include "FFNx.common.sh"
-
-void main()
+vec3 toLinear(vec3 _rgb)
 {
-	vec2 pos = 2.0*a_position.xy*u_viewTexel.xy;
-	gl_Position = vec4(pos.x - 1.0, 1.0 - pos.y, 0.0, 1.0);
-	v_texcoord0 = a_texcoord0;
-	v_color0    = vec4(toLinear(a_color0.rgb), a_color0.a);
+	return pow(abs(_rgb), vec3_splat(2.2) );
+}
+
+vec3 toGamma(vec3 _rgb)
+{
+	return pow(abs(_rgb), vec3_splat(1.0 / 2.2) );
 }

--- a/misc/FFNx.frag
+++ b/misc/FFNx.frag
@@ -6,6 +6,7 @@
 //    Copyright (C) 2020 Chris Rizzitello                                   //
 //    Copyright (C) 2020 John Pritchard                                     //
 //    Copyright (C) 2021 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2021 Cosmos                                             //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //
@@ -22,6 +23,7 @@
 $input v_color0, v_texcoord0
 
 #include <bgfx/bgfx_shader.sh>
+#include "FFNx.common.sh"
 
 SAMPLER2D(tex_0, 0);
 SAMPLER2D(tex_1, 1);
@@ -55,7 +57,7 @@ uniform vec4 FSTexFlags;
 
 void main()
 {
-	vec4 color = v_color0;
+	vec4 color = vec4(toLinear(v_color0.rgb), v_color0.a);
 
     if (isTexture)
     {
@@ -82,6 +84,7 @@ void main()
             if (isFullRange) color.rgb = instMul(jpeg_rgb_transform, yuv);
             else color.rgb = instMul(mpeg_rgb_transform, yuv);
 
+            color.rgb = toLinear(color.rgb);
             color.a = 1.0f;
         }
         else

--- a/misc/FFNx.lighting.frag
+++ b/misc/FFNx.lighting.frag
@@ -35,6 +35,8 @@ uniform vec4 FSTexFlags;
 uniform vec4 lightingSettings;
 uniform vec4 lightingDebugData;
 uniform vec4 materialData;
+uniform vec4 materialScaleData;
+uniform vec4 iblData;
 
 #define isTLVertex VSFlags.x > 0.0
 #define isFBTexture VSFlags.z > 0.0
@@ -58,20 +60,27 @@ uniform vec4 materialData;
 #define isMovie FSMiscFlags.w > 0.0
 
 // ---
-#define textureDebugOutput lightingDebugData.z
-#define TEXTURE_DEBUG_OUTPUT_DISABLED 0
-#define TEXTURE_DEBUG_OUTPUT_COLOR 1
-#define TEXTURE_DEBUG_OUTPUT_NORMAL_MAP 2
-#define TEXTURE_DEBUG_OUTPUT_ROUGHNESS 3
-#define TEXTURE_DEBUG_OUTPUT_METALNESS 4
+#define debugOutput lightingDebugData.z
+#define DEBUG_OUTPUT_DISABLED 0
+#define DEBUG_OUTPUT_COLOR 1
+#define DEBUG_OUTPUT_NORMAL 2
+#define DEBUG_OUTPUT_ROUGHNESS 3
+#define DEBUG_OUTPUT_METALLIC 4
+#define DEBUG_OUTPUT_AO 5
+#define DEBUG_OUTPUT_SPECULAR 6
+#define DEBUG_OUTPUT_IBL_SPECULAR 7
+#define DEBUG_OUTPUT_IBL_DIFFUSE 8
 
 #define isPbrTextureEnabled lightingSettings.x > 0.0
+#define isEnvironmentLightingEnabled lightingSettings.y > 0.0
+
 #define isNmlTextureLoaded FSTexFlags.x > 0.0
 #define isPbrTextureLoaded FSTexFlags.y > 0.0
+#define isIblTextureLoaded FSTexFlags.z > 0.0
 
 void main()
 {
-	vec4 color = v_color0;
+	vec4 color = vec4(toLinear(v_color0.rgb), v_color0.a);
     vec4 color_nml = vec4(0.0, 0.0, 0.0, 0.0);
     vec4 color_pbr = vec4(0.0, 0.0, 0.0, 0.0);
 
@@ -100,6 +109,7 @@ void main()
             if (isFullRange) color.rgb = instMul(jpeg_rgb_transform, yuv);
             else color.rgb = instMul(mpeg_rgb_transform, yuv);
 
+            color.rgb = toLinear(color.rgb);
             color.a = 1.0f;
         }
         else
@@ -171,53 +181,97 @@ void main()
         gl_FragColor = color;
     }
     else
-    {
-        if(textureDebugOutput == TEXTURE_DEBUG_OUTPUT_COLOR)
+    {        
+        // Shadow UV
+        vec3 shadowUv = v_shadow0.xyz / v_shadow0.w;
+
+        // View Direction
+        vec3 viewDir = normalize(-v_position0.xyz);
+
+        // Normal
+        vec3 normal = normalize(v_normal0);
+        if(isNmlTextureLoaded && isPbrTextureEnabled) normal = perturb_normal(normal, v_position0.xyz, color_nml.rgb, v_texcoord0.xy );
+
+        // Roughness
+        float perceptualRoughness = materialData.x;
+        if(isPbrTextureLoaded && isPbrTextureEnabled) perceptualRoughness = color_pbr.r * materialScaleData.x;
+        float roughness = min(max(0.001, perceptualRoughness * perceptualRoughness), 1.0);
+
+        // Metallic
+        float metallic = materialData.y;
+        if(isPbrTextureLoaded && isPbrTextureEnabled) metallic = color_pbr.g * materialScaleData.y;
+        metallic = min(1.0, metallic);
+
+        // Specular (dielectric)
+        float specular = materialData.z;
+        if(isPbrTextureLoaded && isPbrTextureEnabled) specular = color_pbr.b * materialScaleData.z;
+        specular = min(1.0, specular);
+
+        // Ambient Occlusion
+        float ao = 1.0;
+        if(isPbrTextureLoaded && isPbrTextureEnabled) ao = color_pbr.a;
+
+        // Luminance
+        vec3 luminance = calcLuminance(color.rgb, v_position0.xyz, viewDir, normal, perceptualRoughness, roughness, metallic, specular, shadowUv);
+
+        // Indirect Luminance
+        vec3 indirectLuminance = vec3_splat(0.0);
+        vec3 specularIbl = vec3_splat(0.0);
+        vec3 diffuseIbl = vec3_splat(0.0);
+        if(isIblTextureLoaded && isEnvironmentLightingEnabled)
         {
-            gl_FragColor = color;
-        }
-        else if(textureDebugOutput == TEXTURE_DEBUG_OUTPUT_NORMAL_MAP)
-        {
-            gl_FragColor = vec4(color_nml.rgb, 1.0);
-        }
-        else if(textureDebugOutput == TEXTURE_DEBUG_OUTPUT_ROUGHNESS)
-        {
-            gl_FragColor = vec4(color_pbr.r, color_pbr.r, color_pbr.r, 1.0);
-        }
-        else if(textureDebugOutput == TEXTURE_DEBUG_OUTPUT_METALNESS)
-        {
-            gl_FragColor = vec4(color_pbr.g, color_pbr.g, color_pbr.g, 1.0);
+            // Specular IBL
+            vec3 R = mul(invViewMatrix, vec4(reflect(-viewDir, normal), 0)).xyz;
+            float iblMipCount = iblData.x;
+            float iblLod = CalcMipmapFromRoughness(roughness, iblMipCount);
+            specularIbl = textureCubeLod(tex_7, R, iblLod).rgb;
+
+            // Diffuse IBL
+            vec3 worldNormal = mul(invViewMatrix, vec4(normal, 0)).xyz;
+            diffuseIbl = textureCube(tex_8, worldNormal).rgb;
+
+            indirectLuminance = CalcIblIndirectLuminance(color.rgb, specularIbl, diffuseIbl, viewDir, normal, roughness, metallic, specular, ao);
         }
         else
         {
-            // Shadow UV
-            vec3 shadowUv = v_shadow0.xyz / v_shadow0.w;
+            indirectLuminance = CalcConstIndirectLuminance(color.rgb);
+        }
 
-            // View Direction
-            vec3 viewDir = normalize(v_position0.xyz);
-
-            // Normal
-            vec3 normal = normalize(v_normal0);
-            if(isPbrTextureEnabled) normal = perturb_normal(normal, -v_position0.xyz, color_nml.rgb, v_texcoord0.xy );
-
-            // Roughness
-            float roughness = materialData.x;
-            if(isPbrTextureEnabled) roughness = color_pbr.r * materialData.z;
-            float roughnessClamped = max(0.001, roughness);
-
-            // Metalness
-            float metalness = materialData.y;
-            if(isPbrTextureEnabled) metalness = color_pbr.g * materialData.w;
-            float metalnessClamped = min(1.0, metalness);
-
-            // Ambient Occlusion
-            float ao = 1.0;
-            if(isPbrTextureEnabled) ao = color_pbr.b;
-
-            // Luminance
-            vec3 luminance = calcLuminance(color.rgb, v_position0.xyz, viewDir, normal, roughnessClamped, metalnessClamped, ao, shadowUv);
-
-            gl_FragColor = vec4(luminance, color.a);
+        if(debugOutput == DEBUG_OUTPUT_COLOR)
+        {
+            gl_FragColor = color;
+        }
+        else if(debugOutput == DEBUG_OUTPUT_NORMAL)
+        {
+            gl_FragColor = vec4(0.5 * normal + 0.5, 1.0);
+        }
+        else if(debugOutput == DEBUG_OUTPUT_ROUGHNESS)
+        {
+            gl_FragColor = vec4(vec3_splat(perceptualRoughness), 1.0);
+        }
+        else if(debugOutput == DEBUG_OUTPUT_METALLIC)
+        {
+            gl_FragColor = vec4(vec3_splat(metallic), 1.0);
+        }
+        else if(debugOutput == DEBUG_OUTPUT_AO)
+        {
+            gl_FragColor = vec4(vec3_splat(ao), 1.0);
+        }
+        else if(debugOutput == DEBUG_OUTPUT_SPECULAR)
+        {
+            gl_FragColor = vec4(vec3_splat(specular), 1.0);
+        }
+        else if(debugOutput == DEBUG_OUTPUT_IBL_SPECULAR)
+        {
+            gl_FragColor = vec4(specularIbl, 1.0);
+        }
+        else if(debugOutput == DEBUG_OUTPUT_IBL_DIFFUSE)
+        {
+            gl_FragColor = vec4(diffuseIbl, 1.0);
+        }
+        else
+        {            
+            gl_FragColor = vec4(luminance + indirectLuminance, color.a);
         }
     }
 }

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -87,6 +87,11 @@ enable_lighting = false
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 prefer_lighting_cpu_calculations = true
 
+#[EXTERNAL IBL PATH]
+# Path for external environment maps for Image Based Lighting (IBL).
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+external_ibl_path = "lighting/ibl"
+
 #########################
 # Audio Player Options
 #########################

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -41,6 +41,7 @@ std::string external_voice_path;
 std::vector<std::string> external_voice_ext;
 std::string external_ambient_path;
 std::vector<std::string> external_ambient_ext;
+std::string external_ibl_path;
 bool enable_voice_music_fade;
 long external_voice_music_fade_volume;
 bool save_textures;
@@ -157,6 +158,7 @@ void read_cfg()
 	external_voice_music_fade_volume = config["external_voice_music_fade_volume"].value_or(25);
 	external_ambient_path = config["external_ambient_path"].value_or("");
 	external_ambient_ext = get_string_or_array_of_strings(config["external_ambient_ext"]);
+	external_ibl_path = config["external_ibl_path"].value_or("");
 	save_textures = config["save_textures"].value_or(false);
 	trace_all = config["trace_all"].value_or(false);
 	trace_renderer = config["trace_renderer"].value_or(false);
@@ -346,6 +348,10 @@ void read_cfg()
 	// EXTERNAL AMBIENT EXTENSION
 	if (external_ambient_ext.empty() || external_ambient_ext.front().empty())
 		external_ambient_ext = std::vector<std::string>(1, "ogg");
+
+	// EXTERNAL IBL PATH
+	if (external_ibl_path.empty())
+		external_ibl_path = "lighting/ibl";
 
 	// MOD PATH
 	if (mod_path.empty())

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -54,6 +54,7 @@ extern std::string external_voice_path;
 extern std::vector<std::string> external_voice_ext;
 extern std::string external_ambient_path;
 extern std::vector<std::string> external_ambient_ext;
+extern std::string external_ibl_path;
 extern bool enable_voice_music_fade;
 extern long external_voice_music_fade_volume;
 extern bool save_textures;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -612,6 +612,8 @@ int common_create_window(HINSTANCE hInstance, struct game_obj* game_object)
 				max_texture_size = newRenderer.getCaps()->limits.maxTextureSize;
 				ffnx_info("Max texture size: %ix%i\n", max_texture_size, max_texture_size);
 
+				newRenderer.prepareEnvBrdf();
+
 				// perform any additional initialization that requires the rendering environment to be set up
 				field_init();
 				world_init();
@@ -1128,6 +1130,7 @@ uint32_t load_external_texture(void* image_data, uint32_t dataSize, struct textu
 	VOBJ(tex_header, tex_header, tex_header);
 	uint32_t texture = 0;
 	struct gl_texture_set *gl_set = VREF(texture_set, ogl.gl_set);
+	struct texture_format* tex_format = VREFP(tex_header, tex_format);
 
 	if(save_textures) return false;
 

--- a/src/gl/gl.cpp
+++ b/src/gl/gl.cpp
@@ -205,7 +205,7 @@ void gl_draw_with_lighting(struct indexed_primitive *ip, struct polygon_data *po
 
 			subtract_vector(v2, v1, &e12);
 			subtract_vector(v3, v1, &e13);
-			cross_product(&e12, &e13, &triNormal);
+			cross_product(&e13, &e12, &triNormal);
 
 			add_vector(&normals[vId0], &triNormal, &normals[vId0]);
 			add_vector(&normals[vId1], &triNormal, &normals[vId1]);

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -20,13 +20,17 @@
 
 #include <vector>
 
-enum TextureDebugOutput
+enum DebugOutput
 {
-    TEXTURE_DEBUG_OUTPUT_DISABLED = 0,
-    TEXTURE_DEBUG_OUTPUT_COLOR,
-    TEXTURE_DEBUG_OUTPUT_NORMALMAP,
-    TEXTURE_DEBUG_OUTPUT_ROUGHNESS,
-    TEXTURE_DEBUG_OUTPUT_METALNESS,
+    DEBUG_OUTPUT_DISABLED = 0,
+    DEBUG_OUTPUT_COLOR,
+    DEBUG_OUTPUT_NORMALMAP,
+    DEBUG_OUTPUT_ROUGHNESS,
+    DEBUG_OUTPUT_METALLIC,
+    DEBUG_OUTPUT_AO,
+    DEBUG_OUTPUT_SPECULAR,
+    DEBUG_OUTPUT_IBL_SPECULAR,
+    DEBUG_OUTPUT_IBL_DIFFUSE,
 };
 
 struct walkmeshEdge
@@ -48,13 +52,15 @@ struct LightingState
     float lightViewProjMatrix[16];
     float lightViewProjTexMatrix[16];
 
-    float lightingSettings[4] = { 0.0, 0.0, 0.0, 0.0 };
+    float lightingSettings[4] = { 1.0, 1.0, 1.0, 0.0 };
     float lightDirData[4] = { 0.3, -1.0, -0.3, 0.0 };
     float lightData[4] = { 1.0, 1.0, 1.0, 4.0 };
-    float ambientLightData[4] = { 1.0, 1.0, 1.0, 2.0 };
-    float materialData[4] = { 0.3, 0.3, 1.0, 1.0 };
+    float ambientLightData[4] = { 1.0, 1.0, 1.0, 1.0 };
+    float materialData[4] = { 0.7, 0.5, 0.0, 0.0 };
+    float materialScaleData[4] = { 1.0, 1.0, 1.0, 1.0 };
     float shadowData[4] = { 0.001, 0.0, 0.0, 2048.0 };
-    float fieldShadowData[4] = { 0.3, 200.0, 100.0, 0.0 };
+    float fieldShadowData[4] = { 0.1, 200.0, 100.0, 0.0 };
+    float iblData[4] = { 1.0, 0.0, 0.0, 0.0 };
 
     float lightingDebugData[4] = { 0.0, 0.0, 0.0, 0.0 };
 
@@ -85,6 +91,8 @@ private:
 private:
     void updateLightMatrices(struct boundingbox* sceneAabb);
 
+    void ff7_load_ibl();
+
     void ff7_get_field_view_matrix(struct matrix* outViewMatrix);
     void ff7_create_walkmesh(std::vector<struct nvertex>& vertices, std::vector<WORD>& indices, std::vector<struct walkmeshEdge>& edges);
 
@@ -101,8 +109,10 @@ public:
     const LightingState& getLightingState();
 
     // Lighting
-    void Lighting::setPbrTextureEnabled(bool isEnabled);
-    bool Lighting::isPbrTextureEnabled();
+    void setPbrTextureEnabled(bool isEnabled);
+    bool isPbrTextureEnabled();
+    void setEnvironmentLightingEnabled(bool isEnabled);
+    bool isEnvironmentLightingEnabled();
     void setWorldLightDir(float dirX, float dirY, float dirZ);
     struct point3d getWorldLightDir();
     void setLightIntensity(float intensity);
@@ -113,16 +123,21 @@ public:
     float getAmbientIntensity();
     void setAmbientLightColor(float r, float g, float b);
     point3d getAmbientLightColor();
+    void setIblMipCount(int mipCount);
 
     // Material
     void setRoughness(float roughness);
     float getRoughness();
-    void setMetalness(float metalness);
-    float getMetalness();
-    void setRoughnessScale(float roughness);
+    void setMetallic(float metallic);
+    float getMetallic();
+    void setSpecular(float metallic);
+    float getSpecular();
+    void setRoughnessScale(float scale);
     float getRoughnessScale();
-    void setMetalnessScale(float metalness);
-    float getMetalnessScale();
+    void setMetallicScale(float scale);
+    float getMetallicScale();
+    void setSpecularScale(float scale);
+    float getSpecularScale();
 
     // Shadow (common)
     void setShadowFaceCullingEnabled(bool isEnabled);
@@ -159,8 +174,8 @@ public:
     bool isHide2dEnabled();
     void setShowWalkmeshEnabled(bool isEnabled);
     bool isShowWalkmeshEnabled();
-    void setTextureDebugOutput(TextureDebugOutput output);
-    TextureDebugOutput GetTextureDebugOutput();
+    void setDebugOutput(DebugOutput output);
+    DebugOutput GetDebugOutput();
 };
 
 extern Lighting lighting;

--- a/src/lighting_debug.cpp
+++ b/src/lighting_debug.cpp
@@ -38,6 +38,11 @@ void lighting_debug(bool* isOpen)
     {
         lighting.setPbrTextureEnabled(isPbrTexturesEnabled);
     }
+    bool isEnvironmentLightingEnabled = lighting.isEnvironmentLightingEnabled();
+    if (ImGui::Checkbox("Enable Environment Lighting", &isEnvironmentLightingEnabled))
+    {
+        lighting.setEnvironmentLightingEnabled(isEnvironmentLightingEnabled);
+    }
     if (ImGui::CollapsingHeader("Direct Lighting", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth))
     {
         point3d lightDirVector = lighting.getWorldLightDir();
@@ -82,20 +87,30 @@ void lighting_debug(bool* isOpen)
         {
             lighting.setRoughness(roughness);
         }
-        float metalness = lighting.getMetalness();
-        if (ImGui::DragFloat("Metalness", &metalness, 0.01f, 0.0f, 1.0f))
+        float metallic = lighting.getMetallic();
+        if (ImGui::DragFloat("Metallic", &metallic, 0.01f, 0.0f, 1.0f))
         {
-            lighting.setMetalness(metalness);
+            lighting.setMetallic(metallic);
+        }
+        float specular = lighting.getSpecular();
+        if (ImGui::DragFloat("Specular", &specular, 0.01f, 0.0f, 1.0f))
+        {
+            lighting.setSpecular(specular);
         }
         float roughnessScale = lighting.getRoughnessScale();
         if (ImGui::DragFloat("Roughness Scale", &roughnessScale, 0.01f, 0.0f, 2.0f))
         {
             lighting.setRoughnessScale(roughnessScale);
         }
-        float metalnessScale = lighting.getMetalnessScale();
-        if (ImGui::DragFloat("Metalness Scale", &metalnessScale, 0.01f, 0.0f, 2.0f))
+        float metallicScale = lighting.getMetallicScale();
+        if (ImGui::DragFloat("Metallic Scale", &metallicScale, 0.01f, 0.0f, 2.0f))
         {
-            lighting.setMetalnessScale(metalnessScale);
+            lighting.setMetallicScale(metallicScale);
+        }
+        float specularScale = lighting.getSpecularScale();
+        if (ImGui::DragFloat("Specular Scale", &specularScale, 0.01f, 0.0f, 2.0f))
+        {
+            lighting.setSpecularScale(specularScale);
         }
     }
     if (ImGui::CollapsingHeader("Shadow map (common)", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth))
@@ -169,10 +184,10 @@ void lighting_debug(bool* isOpen)
     }
     if (ImGui::CollapsingHeader("Debug", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth))
     {
-        int debugOutput = lighting.GetTextureDebugOutput();
-        if (ImGui::Combo("Texture Debug Output", &debugOutput, "Disabled\0Color\0Normal Map\0Roughness\0Metalness\0\0"))
+        int debugOutput = lighting.GetDebugOutput();
+        if (ImGui::Combo("Debug Output", &debugOutput, "Disabled\0Color\0Normal\0Roughness\0Metallic\0AO\0Specular\0IBL (Specular)\0IBL (Diffuse)\0"))
         {
-            lighting.setTextureDebugOutput(static_cast<TextureDebugOutput>(debugOutput));
+            lighting.setDebugOutput(static_cast<DebugOutput>(debugOutput));
         }
         bool isHide2dEnabled = lighting.isHide2dEnabled();
         if (ImGui::Checkbox("Hide 2D", &isHide2dEnabled))

--- a/src/movies.cpp
+++ b/src/movies.cpp
@@ -6,6 +6,7 @@
 //    Copyright (C) 2020 Chris Rizzitello                                   //
 //    Copyright (C) 2020 John Pritchard                                     //
 //    Copyright (C) 2021 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2021 Cosmos                                             //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -103,6 +103,9 @@ enum RendererTextureSlot
     TEX_D,
     TEX_NML,
     TEX_PBR,
+    TEX_IBL_SPEC,
+    TEX_IBL_DIFF,
+    TEX_BRDF,
     COUNT
 };
 
@@ -255,6 +258,10 @@ private:
     bgfx::TextureHandle shadowMapTexture = BGFX_INVALID_HANDLE;
     bgfx::FrameBufferHandle shadowMapFrameBuffer = BGFX_INVALID_HANDLE;
 
+    bgfx::TextureHandle specularIblTexture = BGFX_INVALID_HANDLE;
+    bgfx::TextureHandle diffuseIblTexture = BGFX_INVALID_HANDLE;
+    bgfx::TextureHandle envBrdfTexture = BGFX_INVALID_HANDLE;
+
     std::vector<Vertex> vertexBufferData;
     bgfx::DynamicVertexBufferHandle vertexBufferHandle = BGFX_INVALID_HANDLE;
 
@@ -322,6 +329,9 @@ public:
     void init();
     void reset();
     void prepareShadowMap();
+    void prepareSpecularIbl(char* fullpath = nullptr);
+    void prepareDiffuseIbl(char* fullpath = nullptr);
+    void prepareEnvBrdf();
     void shutdown();
 
     void clearShadowMap();
@@ -349,9 +359,10 @@ public:
     void setClearFlags(bool doClearColor = false, bool doClearDepth = false);
     void setBackgroundColor(float r = 0.0f, float g = 0.0f, float b = 0.0f, float a = 0.0f);
 
-    uint32_t createTexture(uint8_t* data, size_t width, size_t height, int stride = 0, RendererTextureType type = RendererTextureType::BGRA, bool generateMips = false);
-    uint32_t createTexture(char* filename, uint32_t* width, uint32_t* height);
-    uint32_t createTextureLibPng(char* filename, uint32_t* width, uint32_t* height);
+    uint32_t createTexture(uint8_t* data, size_t width, size_t height, int stride = 0, RendererTextureType type = RendererTextureType::BGRA, bool isSrgb = true);
+    uint32_t createTexture(char* filename, uint32_t* width, uint32_t* height, uint32_t* mipCount, bool isSrgb = true);
+    bgfx::TextureHandle createTextureHandle(char* filename, uint32_t* width, uint32_t* height, uint32_t* mipCount, bool isSrgb = true);
+    uint32_t createTextureLibPng(char* filename, uint32_t* width, uint32_t* height, bool isSrgb = true);
     bool saveTexture(char* filename, uint32_t width, uint32_t height, void* data);
     void deleteTexture(uint16_t texId);
     void useTexture(uint16_t texId, uint32_t slot = 0);

--- a/src/saveload.cpp
+++ b/src/saveload.cpp
@@ -6,6 +6,7 @@
 //    Copyright (C) 2020 Chris Rizzitello                                   //
 //    Copyright (C) 2020 John Pritchard                                     //
 //    Copyright (C) 2021 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2021 Cosmos                                             //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //
@@ -92,16 +93,19 @@ void save_texture(void *data, uint32_t dataSize, uint32_t width, uint32_t height
 		ffnx_warning("Save texture skipped because the file [ %s ] already exists.\n", filename);
 }
 
-uint32_t load_texture_helper(char* name, uint32_t* width, uint32_t* height, bool useLibPng)
+uint32_t load_texture_helper(char* name, uint32_t* width, uint32_t* height, bool useLibPng, bool isSrgb)
 {
 	uint32_t ret = 0;
 
 	normalize_path(name);
 
 	if (useLibPng)
-		ret = newRenderer.createTextureLibPng(name, width, height);
+		ret = newRenderer.createTextureLibPng(name, width, height, isSrgb);
 	else
-		ret = newRenderer.createTexture(name, width, height);
+	{
+		uint32_t mipCount = 0;
+		ret = newRenderer.createTexture(name, width, height, &mipCount, isSrgb);
+	}
 
 	if (ret)
 	{
@@ -147,7 +151,7 @@ uint32_t load_texture(void* data, uint32_t dataSize, char* name, uint32_t palett
 				break;
 			}
 
-			ret = load_texture_helper(filename, width, height, mod_ext[idx] == "png");
+			ret = load_texture_helper(filename, width, height, mod_ext[idx] == "png", true);
 
 			if (trace_all)
 			{
@@ -192,7 +196,7 @@ uint32_t load_texture(void* data, uint32_t dataSize, char* name, uint32_t palett
 					if (stat(filename, &dummy) == 0)
 					{
 						if (gl_set->additional_textures.count(it.first)) newRenderer.deleteTexture(gl_set->additional_textures[it.first]);
-						gl_set->additional_textures[it.first] = load_texture_helper(filename, width, height, mod_ext[idx] == "png");
+						gl_set->additional_textures[it.first] = load_texture_helper(filename, width, height, mod_ext[idx] == "png", false);
 						break;
 					}
 					else if (trace_all || show_missing_textures)

--- a/src/video/movies.cpp
+++ b/src/video/movies.cpp
@@ -379,7 +379,8 @@ void upload_yuv_texture(uint8_t **planes, int *strides, uint32_t num, uint32_t b
 		tex_width,
 		tex_height,
 		upload_width,
-		RendererTextureType::YUV
+		RendererTextureType::YUV,
+		false
 	);
 }
 


### PR DESCRIPTION
This PR contains the following changes:
- Changed lighting so that it is done correctly in linear space instead of gamma space (SRGB). This requires a change to a RGBA16 framebuffer. Final SRGB conversion is done by adding the SRGB flag to the swap buffer. Textures that represent colors are set with the SRGB flag so it is converted to linear space by the GPU.
- Added functionality to load external environment maps for image base lighting (IBL).
- Added specular pbr parameter to control specular reflection of non-metallic materials
- Various shader code fixes