### PR TITLE
FF7 Steam Achievement Implementation

### DIFF
--- a/.vcpkg/ports/steamworkssdk/STEAMWORKSSDKConfig.cmake.in
+++ b/.vcpkg/ports/steamworkssdk/STEAMWORKSSDKConfig.cmake.in
@@ -1,0 +1,32 @@
+include(FindPackageHandleStandardArgs)
+
+if (NOT STEAMWORKSSDK_FOUND)
+	find_library(
+		STEAMWORKSSDK_LIBRARY
+		steam_api
+		PATH_SUFFIXES
+		lib
+		vendor/lib
+	)
+
+	find_path(
+		STEAMWORKSSDK_INCLUDE_DIR
+		steamworkssdk
+		PATH_SUFFIXES
+		include
+		vendor/include
+	)
+
+	add_library(STEAMWORKSSDK::STEAMWORKSSDK STATIC IMPORTED)
+
+	set_target_properties(
+		STEAMWORKSSDK::STEAMWORKSSDK
+		PROPERTIES
+		IMPORTED_LOCATION
+		"${STEAMWORKSSDK_LIBRARY}"
+		INTERFACE_INCLUDE_DIRECTORIES
+		"${STEAMWORKSSDK_INCLUDE_DIR}"
+	)
+
+	find_package_handle_standard_args(STEAMWORKSSDK DEFAULT_MSG STEAMWORKSSDK_LIBRARY STEAMWORKSSDK_INCLUDE_DIR)
+endif()

--- a/.vcpkg/ports/steamworkssdk/portfile.cmake
+++ b/.vcpkg/ports/steamworkssdk/portfile.cmake
@@ -1,0 +1,31 @@
+# For a list of common variables see https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/vcpkg_common_definitions.md
+
+# Download source packages
+
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "julianxhokaxhiu/SteamworksSDKCI"
+    HEAD_REF master
+    REF da1a0d64ff04266774886c427e744c6fc7d861b3
+    SHA512 5b325d7493b0c205e82daaac6e64ca61fbb60b19742214cd4927b375b604e4c0bbb20e61d7490b8906455410a51303aa197686edf730dec6756cdfcc8f6e3938
+)
+
+file(TO_NATIVE_PATH "${CURRENT_PACKAGES_DIR}/include/steamworkssdk" INCLUDE_PATH)
+
+file(MAKE_DIRECTORY
+    "${INCLUDE_PATH}"
+)
+
+file(GLOB 
+    HEADER_FILES
+    "${SOURCE_PATH}/steamworks_sdk/public/steam/*.h"
+)
+
+file(COPY ${SOURCE_PATH}/steamworks_sdk/redistributable_bin/steam_api.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+file(COPY ${SOURCE_PATH}/steamworks_sdk/redistributable_bin/steam_api.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+file(COPY ${HEADER_FILES} DESTINATION ${INCLUDE_PATH})
+
+# Copy cmake configuration files
+configure_file(${CMAKE_CURRENT_LIST_DIR}/STEAMWORKSSDKConfig.cmake.in ${CURRENT_PACKAGES_DIR}/share/${PORT}/STEAMWORKSSDKConfig.cmake @ONLY)

--- a/.vcpkg/ports/steamworkssdk/usage
+++ b/.vcpkg/ports/steamworkssdk/usage
@@ -1,0 +1,4 @@
+To use STEAMWORKSSDK add the following to your CMake project:
+
+    find_package(STEAMWORKSSDK REQUIRED)
+    target_link_libraries(main PRIVATE STEAMWORKSSDK::STEAMWORKSSDK)

--- a/.vcpkg/ports/steamworkssdk/vcpkg.json
+++ b/.vcpkg/ports/steamworkssdk/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "steamworkssdk",
+  "version": "1.51.0",
+  "description": "CI builds of Steamworks SDK for CMake build systems",
+  "homepage": "https://github.com/julianxhokaxhiu/SteamworksSDKCI"
+}

--- a/.vcpkg/versions/baseline.json
+++ b/.vcpkg/versions/baseline.json
@@ -27,6 +27,10 @@
     "openpsf": {
       "baseline": "1.3.0",
       "port-version": 0
+    },
+    "steamworkssdk": {
+      "baseline": "1.51.0",
+      "port-version": 0
     }
   }
 }

--- a/.vcpkg/versions/s-/steamworkssdk.json
+++ b/.vcpkg/versions/s-/steamworkssdk.json
@@ -1,0 +1,8 @@
+{
+  "versions": [
+    {
+      "version": "1.51.0",
+      "path": "$/ports/steamworkssdk"
+    }
+  ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ find_package(imgui CONFIG REQUIRED)
 find_package(SOLOUD REQUIRED)
 find_package(OPENPSF REQUIRED)
 find_package(tomlplusplus CONFIG REQUIRED)
+find_package(STEAMWORKSSDK CONFIG REQUIRED)
 
 set(RELEASE_NAME "FFNx")
 
@@ -118,6 +119,7 @@ target_link_libraries(
   imgui::imgui
   pugixml::pugixml
   tomlplusplus::tomlplusplus
+  STEAMWORKSSDK::STEAMWORKSSDK
   ${BX_LIBRARIES}
   ${BIMG_LIBRARIES}
   ${BGFX_LIBRARIES}

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -232,6 +232,18 @@ enable_analogue_controls = false
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 steam_game_userdata = ""
 
+###########################
+# Steam Achievement Options
+###########################
+
+#[STEAM ACHIEVEMENTS EXTENSION]
+# This flag will enable steam overlay and steam achievements (Steam MUST be running on background).
+# Files required: steam_api.dll (version 1.51+) and steam_appid.txt (containing only the unique number corresponding to the app id of the game)
+# FF7 appid is 39410
+# FF8 appid is 39150
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+enable_steam_achievements = false
+
 ########################
 ## MODDER OPTIONS
 ########################
@@ -387,6 +399,10 @@ trace_ambient = false
 # trace_gamepad - Dump in the logs only APIs that has to do with gamepad
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 trace_gamepad = false
+
+# trace_achievement - Dump in the logs only APIs that has to do with steam achievements
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+trace_achievement = false
 
 # vertex_log - Dump in the logs current engine vertex data being passed to the GPU for drawing
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -1,0 +1,458 @@
+/****************************************************************************/
+//    Copyright (C) 2021 Tang-Tang Zhou                                     //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#define N_MATERIA_SLOT 200
+#define N_STOLEN_MATERIA_SLOT 48
+#define N_EQUIP_MATERIA_PER_CHARACTER 16
+#define BATTLE_SQUARE_LOCATION_ID 0x0025
+#define FIRST_LIMIT_BREAK_CODE 0x0001
+#define FOURTH_LIMIT_BREAK_CODE 0x0200
+#define GIL_ACHIEVEMENT_VALUE 99999999
+#define TOP_LEVEL_CHARACTER 99
+
+#define YUFFIE_INDEX 5
+#define CAIT_SITH_INDEX 6
+#define VINCENT_INDEX 7
+#define YOUNG_CLOUD_ID 0x09
+#define SEPHIROTH_ID 0x0A
+
+#define MATERIA_EMPTY_SLOT 0xFF
+#define MATERIA_AP_MASTERED 0xFFFFFF
+#define BAHAMUT_ZERO_MATERIA_ID 0x58
+#define KOTR_MATERIA_ID 0x59
+
+#define DIAMOND_WEAPON_START 980
+#define DIAMOND_WEAPON_END 981
+#define RUBY_WEAPON_START 982
+#define RUBY_WEAPON_END 983
+#define EMERALD_WEAPON_START 984
+#define EMERALD_WEAPON_END 987
+#define ULTIMATE_WEAPON_START 988
+#define ULTIMATE_WEAPON_END 991
+
+// gold chocobo from https://gamefaqs.gamespot.com/pc/130791-final-fantasy-vii/faqs/13970
+#define GOLD_CHOCOBO_TYPE 0x04
+
+#include "achievement.h"
+
+SteamAchievementsFF7 g_FF7SteamAchievements;
+SteamAchievementsFF8 g_FF8SteamAchievements;
+
+void SteamAchievements::init(achievement *achievements, int nAchievements)
+{
+    this->appID = SteamUtils()->GetAppID();
+    this->isInitialized = false;
+    this->nAchievements = nAchievements;
+    this->achievementList = achievements;
+    this->requestStats();
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - Init steam achievements with appID: %d\n", __func__, this->appID);
+}
+
+bool SteamAchievements::requestStats()
+{
+    // Is Steam loaded?
+    if (NULL == SteamUserStats() || NULL == SteamUser())
+    {
+        return false;
+    }
+    // Is the user logged on?
+    if (!SteamUser()->BLoggedOn())
+    {
+        return false;
+    }
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - Request user stats sent\n", __func__);
+
+    return SteamUserStats()->RequestCurrentStats();
+}
+
+bool SteamAchievements::setAchievement(int achID)
+{
+    if (this->isInitialized)
+    {
+        if (trace_all || trace_achievement)
+            ffnx_trace("%s - Achievement %s set, Store request sent to Steam\n", __func__, this->achievementList[achID].chAchID);
+
+        // TODO reactivate when done all;
+        char buffer[128];
+        _snprintf(buffer, 128, "Achievement unlocked %s\n", this->achievementList[achID].chAchID);
+        //SteamUserStats()->SetAchievement(this->achievementList[achID].chAchID);
+        // bool success = SteamUserStats()->StoreStats();
+        if (true) //success)
+            this->achievementList[achID].isAchieved = true;
+        //return success;
+
+        // TESTING PHASE OF STEAM ACHIEVEMENTS
+        if (trace_all || trace_achievement)
+            MessageBoxA(gameHwnd, buffer, "Testing achievement unlocked", 0);
+        return true;
+    }
+
+    if (trace_all || trace_achievement)
+        ffnx_error("%s - Have not received a callback from Steam, thus, cannot send achievement\n", __func__);
+
+    return false;
+}
+
+void SteamAchievements::OnUserStatsReceived(UserStatsReceived_t *pCallback)
+{
+    if (this->appID == pCallback->m_nGameID)
+    {
+        if (k_EResultOK == pCallback->m_eResult)
+        {
+            if (trace_all || trace_achievement)
+                ffnx_trace("%s - received stats and achievements from Steam\n", __func__);
+            this->isInitialized = true;
+
+            // load achievements
+            for (int i = 0; i < this->nAchievements; ++i)
+            {
+                achievement &ach = this->achievementList[i];
+
+                SteamUserStats()->GetAchievement(ach.chAchID, &ach.isAchieved);
+                _snprintf(ach.achName, sizeof(ach.achName), "%s",
+                          SteamUserStats()->GetAchievementDisplayAttribute(ach.chAchID,
+                                                                           "name"));
+                _snprintf(ach.achDescription, sizeof(ach.achDescription), "%s",
+                          SteamUserStats()->GetAchievementDisplayAttribute(ach.chAchID,
+                                                                           "desc"));
+                
+                // TESTING PHASE STEAM ACHIEVEMENTS, set all achievement at false
+                this->achievementList[i].isAchieved = false;
+                
+                if (trace_all || trace_achievement)
+                    ffnx_trace("%s - achievement data(%s, %s, %s)\n", __func__, ach.chAchID, ach.achDescription, ach.isAchieved ? "true" : "false");
+
+                
+            }
+        }
+        else
+        {
+            if (trace_all || trace_achievement)
+                ffnx_trace("%s - RequestStats - failed, %d\n", __func__, pCallback->m_eResult);
+        }
+    }
+}
+
+void SteamAchievements::OnUserStatsStored(UserStatsStored_t *pCallback)
+{
+    if (this->appID == pCallback->m_nGameID)
+    {
+        if (k_EResultOK == pCallback->m_eResult)
+        {
+            if (trace_all || trace_achievement)
+                ffnx_info("%s - success\n", __func__);
+        }
+        else
+        {
+            if (trace_all || trace_achievement)
+                ffnx_trace("%s - failed, %d\n", __func__, pCallback->m_eResult);
+        }
+    }
+}
+
+void SteamAchievements::OnAchievementStored(UserAchievementStored_t *pCallback)
+{
+    if (this->appID == pCallback->m_nGameID)
+    {
+        if (trace_all || trace_achievement)
+            ffnx_trace("%s - Stored Achievement for Steam\n", __func__);
+    }
+}
+
+// -------------------------- STEAM ACHIEVEMENTS OF FF7 ---------------------------
+
+void SteamAchievementsFF7::init(achievement *achievements, int nAchievements)
+{
+    SteamAchievements::init(achievements, nAchievements);
+
+    this->unknownMateriaList = {0x16, 0x26, 0x2D, 0x2E, 0x2F, 0x3F, 0x42, 0x43};
+    this->unmasterableMateriaList = {0x11, 0x30, 0x49, 0x5A};
+    this->indexToFirstLimitIndex = {0, 1, 5, 3, 7, 6, 8, 2, 4};
+    this->limitBreakItemsID = {0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x1FF, 0x5D, 0x5E};
+}
+
+void SteamAchievementsFF7::initMateriaMastered(savemap *savemap)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - init materia mastered\n", __func__);
+
+    std::fill_n(this->masteredMateria, N_TYPE_MATERIA, false);
+
+    for (int i = 0; i < N_UNKNOWN_MATERIA; i++)
+    {
+        this->masteredMateria[this->unknownMateriaList[i]] = true;
+    }
+
+    for (int i = 0; i < N_MATERIA_SLOT; i++)
+    {
+        uint32_t materia = savemap->materia[i];
+        if (this->isMateriaMastered(materia))
+        {
+            masteredMateria[materia & 0xFF] = true;
+        }
+    }
+
+    for (int i = 0; i < N_STOLEN_MATERIA_SLOT; i++)
+    {
+        uint32_t materia = savemap->stolen_materia[i];
+        if (this->isMateriaMastered(materia))
+        {
+            masteredMateria[materia & 0xFF] = true;
+        }
+    }
+
+    for (int i = 0; i < N_CHARACTERS; i++)
+    {
+        for (int j = 0; j < N_EQUIP_MATERIA_PER_CHARACTER; j++)
+        {
+            uint32_t materia = savemap->chars[i].equipped_materia[j];
+            if (this->isMateriaMastered(materia))
+            {
+                masteredMateria[materia & 0xFF] = true;
+            }
+        }
+    }
+}
+
+bool SteamAchievementsFF7::isMateriaMastered(uint32_t materia)
+{
+    byte materiaId = materia & 0xFF;
+    uint32_t materiaAp = materia >> 8;
+    if (std::find(this->unmasterableMateriaList.begin(), this->unmasterableMateriaList.end(), materiaId) != this->unmasterableMateriaList.end())
+        return true;
+    return materiaId != MATERIA_EMPTY_SLOT && materiaAp == MATERIA_AP_MASTERED;
+}
+
+bool SteamAchievementsFF7::isAllMateriaMastered(bool *masteredMateria)
+{
+    bool allTrue = true;
+    for (int i = 0; i < N_TYPE_MATERIA; i++)
+    {
+        if (!masteredMateria[i])
+            return false;
+    }
+    return allTrue;
+}
+
+void SteamAchievementsFF7::setPreviousLimitUsedNumber(savemap_char *characters)
+{
+    for (int i = 0; i < N_CHARACTERS; i++)
+    {
+        this->previousUsedLimitNumber[i] = characters[i].used_n_limit_1_1;
+    }
+}
+
+void SteamAchievementsFF7::unlockBattleWonAchievement(WORD battleSceneID)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - unlock achievement for winning battle (scene ID: %d)\n", __func__, battleSceneID);
+
+    if (!this->achievementList[WON_1ST_BATTLE].isAchieved)
+        this->setAchievement(WON_1ST_BATTLE);
+
+    if (battleSceneID >= DIAMOND_WEAPON_START && battleSceneID <= DIAMOND_WEAPON_END)
+    {
+        this->setAchievement(BEAT_DIAMOND_WEAPON);
+    }
+
+    if (battleSceneID >= RUBY_WEAPON_START && battleSceneID <= RUBY_WEAPON_END)
+    {
+        this->setAchievement(BEAT_RUBY_WEAPON);
+    }
+
+    if (battleSceneID >= EMERALD_WEAPON_START && battleSceneID <= EMERALD_WEAPON_END)
+    {
+        this->setAchievement(BEAT_EMERALD_WEAPON);
+    }
+
+    if (battleSceneID >= ULTIMATE_WEAPON_START && battleSceneID <= ULTIMATE_WEAPON_END)
+    {
+        this->setAchievement(BEAT_ULTIMATE_WEAPON);
+    }
+}
+
+void SteamAchievementsFF7::unlockGilAchievement(uint32_t gilAmount)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for gil (amount: %d)\n", __func__, gilAmount);
+
+    if (!this->achievementList[GET_99999999_GILS].isAchieved && gilAmount >= GIL_ACHIEVEMENT_VALUE)
+        this->setAchievement(GET_99999999_GILS);
+}
+
+void SteamAchievementsFF7::unlockCharacterLevelAchievement(savemap_char *characters)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for character level\n", __func__);
+
+    if (this->achievementList[GET_LEVEL_99_WITH_A_CHAR].isAchieved)
+        return;
+
+    for (int i = 0; i < N_CHARACTERS; i++)
+    {
+        if (characters[i].level == TOP_LEVEL_CHARACTER)
+        {
+            this->setAchievement(GET_LEVEL_99_WITH_A_CHAR);
+            return;
+        }
+    }
+}
+
+void SteamAchievementsFF7::unlockBattleSquareAchievement(WORD battleLocationID)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for fighting in battle square (battle location id: 0x%04x)\n", __func__, battleLocationID);
+
+    if (!this->achievementList[FIGHT_IN_BATTLE_SQUARE].isAchieved && battleLocationID == BATTLE_SQUARE_LOCATION_ID)
+    {
+        this->setAchievement(FIGHT_IN_BATTLE_SQUARE);
+    }
+}
+
+void SteamAchievementsFF7::unlockGotMateriaAchievement(byte materiaID)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for getting materia (got materia ID: 0x%02x)\n", __func__, materiaID);
+
+    if (materiaID == BAHAMUT_ZERO_MATERIA_ID)
+    {
+        this->setAchievement(GET_MATERIA_BAHAMUT_ZERO);
+    }
+    else if (materiaID == KOTR_MATERIA_ID)
+    {
+        this->setAchievement(GET_MATERIA_KOTR);
+    }
+}
+
+void SteamAchievementsFF7::unlockMasterMateriaAchievement(savemap_char *characters)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for mastering materia\n", __func__);
+
+    for (int i = 0; i < N_CHARACTERS; i++)
+    {
+        if (characters[i].id == SEPHIROTH_ID || characters[i].id == YOUNG_CLOUD_ID)
+            continue;
+
+        for (int j = 0; j < N_EQUIP_MATERIA_PER_CHARACTER; j++)
+        {
+            uint32_t materia = characters[i].equipped_materia[j];
+            if (this->isMateriaMastered(materia))
+            {
+                if (trace_all || trace_achievement)
+                    ffnx_trace("%s - trying to unlock achievement for mastering materia (materia id: 0x%02x)\n", __func__, materia & 0xFF);
+                masteredMateria[materia & 0xFF] = true;
+
+                if (!this->achievementList[LEVEL_UP_MATERIA_LVL5].isAchieved)
+                    this->setAchievement(LEVEL_UP_MATERIA_LVL5);
+            }
+        }
+    }
+
+    if (!this->achievementList[MASTER_ALL_MATERIA].isAchieved && this->isAllMateriaMastered(masteredMateria))
+        this->setAchievement(MASTER_ALL_MATERIA);
+}
+
+void SteamAchievementsFF7::unlockFirstLimitBreakAchievement(savemap_char *characters)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for first limit break achievement\n", __func__);
+
+    for (int i = 0; i < N_CHARACTERS; i++)
+    {
+        if (!this->achievementList[USE_1ST_LIMIT_CLOUD + this->indexToFirstLimitIndex[i]].isAchieved && characters[i].used_n_limit_1_1 > this->previousUsedLimitNumber[i])
+        {
+            this->setAchievement(USE_1ST_LIMIT_CLOUD + this->indexToFirstLimitIndex[i]);
+        }
+    }
+}
+
+void SteamAchievementsFF7::unlockCaitSithLastLimitBreakAchievement(savemap_char *characters)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for cait sith last limit break achievement\n", __func__);
+
+    if (!this->achievementList[GET_FOURTH_CAITSITH_LAST_LIMIT].isAchieved && characters[CAIT_SITH_INDEX].learned_limit_break > FIRST_LIMIT_BREAK_CODE)
+    {
+        this->setAchievement(GET_FOURTH_CAITSITH_LAST_LIMIT);
+    }
+}
+
+void SteamAchievementsFF7::unlockLastLimitBreakAchievement(WORD usedItemID)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for last limit break achievement (used item: 0x%07x)\n", __func__, usedItemID);
+
+    for (int i = 0; i < N_CHARACTERS; i++)
+    {
+        if (i == CAIT_SITH_INDEX) //excluding cait sith
+            continue;
+
+        if (!this->achievementList[GET_FOURTH_CLOUD_LAST_LIMIT + i].isAchieved && usedItemID == this->limitBreakItemsID[i])
+        {
+            this->setAchievement(GET_FOURTH_CLOUD_LAST_LIMIT + i);
+        }
+    }
+}
+
+void SteamAchievementsFF7::unlockGoldChocoboAchievement(chocobo_slot *firstFourSlots, chocobo_slot *lastTwoSlots)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock gold chocobo achievement\n", __func__);
+
+    if (this->achievementList[GET_GOLD_CHOCOBO].isAchieved)
+        return;
+
+    for (int i = 0; i < 4; i++)
+    {
+        if (firstFourSlots[i].type == GOLD_CHOCOBO_TYPE)
+            this->setAchievement(GET_GOLD_CHOCOBO);
+    }
+
+    for (int i = 0; i < 2; i++)
+    {
+        if (lastTwoSlots[i].type == GOLD_CHOCOBO_TYPE)
+            this->setAchievement(GET_GOLD_CHOCOBO);
+    }
+}
+
+void SteamAchievementsFF7::unlockGameProgressAchievement(int achID)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock game progress achievement (%s)\n", __func__, this->achievementList[achID].chAchID);
+
+    if (!(this->achievementList[achID].isAchieved) && (achID >= DEATH_OF_AERITH && achID <= END_OF_GAME))
+        this->setAchievement(achID);
+}
+
+void SteamAchievementsFF7::unlockYuffieAndVincentAchievement(WORD phsCharacterVisibility)
+{
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock yuffie and vincent achievement (phs visibility: %d)\n", __func__, phsCharacterVisibility);
+
+    if (!this->achievementList[GET_YUFFIE_IN_TEAM].isAchieved && ((phsCharacterVisibility & (WORD)(1 << YUFFIE_INDEX)) != 0))
+    {
+        this->setAchievement(GET_YUFFIE_IN_TEAM);
+    }
+
+    if (!this->achievementList[GET_VINCENT_IN_TEAM].isAchieved && ((phsCharacterVisibility & (WORD)(1 << VINCENT_INDEX)) != 0))
+    {
+        this->setAchievement(GET_VINCENT_IN_TEAM);
+    }
+}
+
+// -------------------------- STEAM ACHIEVEMENTS OF FF8 ---------------------------

--- a/src/achievement.h
+++ b/src/achievement.h
@@ -1,0 +1,277 @@
+/****************************************************************************/
+//    Copyright (C) 2021 Tang-Tang Zhou                                     //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#include <steamworkssdk/steam_api_common.h>
+#include <steamworkssdk/steam_api.h>
+#include <steamworkssdk/isteamutils.h>
+#include <steamworkssdk/isteamuserstats.h>
+#include <steamworkssdk/isteamuser.h>
+#include "log.h"
+
+#define N_CHARACTERS 9
+#define N_TYPE_MATERIA 91
+#define N_UNKNOWN_MATERIA 8
+
+#define _ACH_ID(id)           \
+    {                         \
+        id, #id, "", "", 0, 0 \
+    }
+
+struct achievement
+{
+    int achID;
+    const char *chAchID;
+    char achName[128];
+    char achDescription[256];
+    bool isAchieved;
+    int iconImage;
+};
+
+class SteamAchievements
+{
+protected:
+    int appID;                    // Our current AppID
+    achievement *achievementList; // Achievements data
+    int nAchievements;            // The number of Achievements
+    bool isInitialized;           // Have we called Request stats and received the callback?
+
+public:
+    SteamAchievements() : appID(0),
+                          isInitialized(false),
+                          callbackUserStatsReceived(this, &SteamAchievements::OnUserStatsReceived),
+                          callbackUserStatsStored(this, &SteamAchievements::OnUserStatsStored),
+                          callbackAchievementStored(this, &SteamAchievements::OnAchievementStored) {}
+
+    virtual void init(achievement *achievements, int nAchievements);
+
+    bool requestStats();
+    bool setAchievement(int achID);
+
+    STEAM_CALLBACK(SteamAchievements, OnUserStatsReceived, UserStatsReceived_t, callbackUserStatsReceived);
+    STEAM_CALLBACK(SteamAchievements, OnUserStatsStored, UserStatsStored_t, callbackUserStatsStored);
+    STEAM_CALLBACK(SteamAchievements, OnAchievementStored, UserAchievementStored_t, callbackAchievementStored);
+};
+
+class SteamAchievementsFF7 : public SteamAchievements
+{
+private:
+    std::vector<int> indexToFirstLimitIndex;
+    std::vector<int> unknownMateriaList;
+    std::vector<int> unmasterableMateriaList;
+    std::vector<int> limitBreakItemsID;
+    WORD previousUsedLimitNumber[N_CHARACTERS];
+    bool masteredMateria[N_TYPE_MATERIA];
+public:
+    void init(achievement *achievements, int nAchievements) override;
+    void initMateriaMastered(savemap *savemap);
+    bool isMateriaMastered(uint32_t materia);
+    bool isAllMateriaMastered(bool* masteredMateria);
+    void setPreviousLimitUsedNumber(savemap_char *characters);
+    void unlockBattleWonAchievement(WORD battleSceneID);
+    void unlockGilAchievement(uint32_t gilAmount);
+    void unlockCharacterLevelAchievement(savemap_char *characters);
+    void unlockBattleSquareAchievement(WORD battle_location_id);
+    void unlockGotMateriaAchievement(byte materia_id);
+    void unlockMasterMateriaAchievement(savemap_char *characters);
+    void unlockFirstLimitBreakAchievement(savemap_char *characters);
+    void unlockLastLimitBreakAchievement(WORD item_id);
+    void unlockCaitSithLastLimitBreakAchievement(savemap_char *characters);
+    void unlockGoldChocoboAchievement(chocobo_slot *firstFourSlots, chocobo_slot *lastTwoSlots);
+    void unlockGameProgressAchievement(int achID);
+    void unlockYuffieAndVincentAchievement(WORD phsCharacterVisibility);
+};
+
+class SteamAchievementsFF8 : public SteamAchievements
+{
+public:
+};
+
+enum Achievements
+{
+    DEATH_OF_AERITH = 0,
+    SHINRA_ANNIHILATED = 1,
+    END_OF_GAME = 2,
+    GET_99999999_GILS = 3,
+    GET_LEVEL_99_WITH_A_CHAR = 4,
+    GET_FOURTH_CLOUD_LAST_LIMIT = 5,
+    GET_FOURTH_BARRET_LAST_LIMIT = 6,
+    GET_FOURTH_TIFA_LAST_LIMIT = 7,
+    GET_FOURTH_AERITH_LAST_LIMIT = 8,
+    GET_FOURTH_REDXIII_LAST_LIMIT = 9,
+    GET_FOURTH_YUFFIE_LAST_LIMIT = 10,
+    GET_FOURTH_CAITSITH_LAST_LIMIT = 11,
+    GET_FOURTH_VINCENT_LAST_LIMIT = 12,
+    GET_FOURTH_CID_LAST_LIMIT = 13,
+    GET_MATERIA_KOTR = 14,
+    LEVEL_UP_MATERIA_LVL5 = 15,
+    GET_MATERIA_BAHAMUT_ZERO = 16,
+    BEAT_ULTIMATE_WEAPON = 17,
+    BEAT_DIAMOND_WEAPON = 18,
+    BEAT_RUBY_WEAPON = 19,
+    BEAT_EMERALD_WEAPON = 20,
+    GET_VINCENT_IN_TEAM = 21,
+    GET_YUFFIE_IN_TEAM = 22,
+    MASTER_ALL_MATERIA = 23,
+    GET_GOLD_CHOCOBO = 24,
+    WON_1ST_BATTLE = 25,
+    USE_1ST_LIMIT_CLOUD = 26,
+    USE_1ST_LIMIT_BARRET = 27,
+    USE_1ST_LIMIT_VINCENT = 28,
+    USE_1ST_LIMIT_AERITH = 29,
+    USE_1ST_LIMIT_CID = 30,
+    USE_1ST_LIMIT_TIFA = 31,
+    USE_1ST_LIMIT_YUFFIE = 32,
+    USE_1ST_LIMIT_REDXIII = 33,
+    USE_1ST_LIMIT_CAITSITH = 34,
+    FIGHT_IN_BATTLE_SQUARE = 35
+};
+
+enum AchievementsFF8
+{
+    UNLOCK_GF_QUEZACOTL = 0,
+    UNLOCK_GF_SHIVA = 1,
+    UNLOCK_GF_IFRIT = 2,
+    UNLOCK_GF_SIREN = 3,
+    UNLOCK_GF_BROTHERS = 4,
+    UNLOCK_GF_DIABLOS = 5,
+    UNLOCK_GF_CARBUNCLE = 6,
+    UNLOCK_GF_LEVIATHAN = 7,
+    UNLOCK_GF_PANDEMONA = 8,
+    UNLOCK_GF_CERBERUS = 9,
+    UNLOCK_GF_ALEXANDER = 10,
+    UNLOCK_GF_DOOMTRAIN = 11,
+    UNLOCK_GF_BAHAMUT = 12,
+    UNLOCK_GF_CACTUAR = 13,
+    UNLOCK_GF_TONBERRY = 14,
+    UNLOCK_GF_EDEN = 15,
+    DRAW_100_MAGIC = 16,
+    REACH_SEED_RANK_A = 17,
+    CARDGAME_FIRST_TIME = 18,
+    COLLECT_ALL_CARDS = 19,
+    UPGRADE_WEAPON_FIRST_TIME = 20,
+    REACH_MAX_HP = 21,
+    REACH_MAX_GIL = 22,
+    REACH_LEVEL_100 = 23,
+    FINISH_THE_GAME = 24,
+    FINISH_THE_GAME_INITIAL_LEVEL = 25,
+    CAPTURE_CHOCOBO_FIRST_TIME = 26,
+    FOUND_RAGNAROK = 27,
+    SEED_FIRST_SALARY = 28,
+    CHOCORPG_FIRST_ITEM = 29,
+    BEAT_OMEGA_WEAPON = 30,
+    OBEL_LAKE_SECRET = 31,
+    UFO = 32,
+    CARDS_CLUB_MASTER = 33,
+    LOSER = 34,
+    PROFESSIONAL = 35,
+    TIMBER_MANIACS = 36,
+    MAGAZINES_ADDICT = 37,
+    MAGIC_FINDER = 38,
+    CHICOBO_TOP_LEVEL = 39,
+    BLUE_MAGICS = 40,
+    DOG_TRICKS = 41,
+    TOTAL_KILLS_100 = 42,
+    TOTAL_KILLS_1000 = 43,
+    TOTAL_KILLS_10000 = 44
+};
+
+achievement g_AchievementsFF7[] = {
+    _ACH_ID(DEATH_OF_AERITH),
+    _ACH_ID(SHINRA_ANNIHILATED),
+    _ACH_ID(END_OF_GAME),
+    _ACH_ID(GET_99999999_GILS),
+    _ACH_ID(GET_LEVEL_99_WITH_A_CHAR),
+    _ACH_ID(GET_FOURTH_CLOUD_LAST_LIMIT),
+    _ACH_ID(GET_FOURTH_BARRET_LAST_LIMIT),
+    _ACH_ID(GET_FOURTH_TIFA_LAST_LIMIT),
+    _ACH_ID(GET_FOURTH_AERITH_LAST_LIMIT),
+    _ACH_ID(GET_FOURTH_REDXIII_LAST_LIMIT),
+    _ACH_ID(GET_FOURTH_YUFFIE_LAST_LIMIT),
+    _ACH_ID(GET_FOURTH_CAITSITH_LAST_LIMIT),
+    _ACH_ID(GET_FOURTH_VINCENT_LAST_LIMIT),
+    _ACH_ID(GET_FOURTH_CID_LAST_LIMIT),
+    _ACH_ID(GET_MATERIA_KOTR),
+    _ACH_ID(LEVEL_UP_MATERIA_LVL5),
+    _ACH_ID(GET_MATERIA_BAHAMUT_ZERO),
+    _ACH_ID(BEAT_ULTIMATE_WEAPON),
+    _ACH_ID(BEAT_DIAMOND_WEAPON),
+    _ACH_ID(BEAT_RUBY_WEAPON),
+    _ACH_ID(BEAT_EMERALD_WEAPON),
+    _ACH_ID(GET_VINCENT_IN_TEAM),
+    _ACH_ID(GET_YUFFIE_IN_TEAM),
+    _ACH_ID(MASTER_ALL_MATERIA),
+    _ACH_ID(GET_GOLD_CHOCOBO),
+    _ACH_ID(WON_1ST_BATTLE),
+    _ACH_ID(USE_1ST_LIMIT_CLOUD),
+    _ACH_ID(USE_1ST_LIMIT_BARRET),
+    _ACH_ID(USE_1ST_LIMIT_VINCENT),
+    _ACH_ID(USE_1ST_LIMIT_AERITH),
+    _ACH_ID(USE_1ST_LIMIT_CID),
+    _ACH_ID(USE_1ST_LIMIT_TIFA),
+    _ACH_ID(USE_1ST_LIMIT_YUFFIE),
+    _ACH_ID(USE_1ST_LIMIT_REDXIII),
+    _ACH_ID(USE_1ST_LIMIT_CAITSITH),
+    _ACH_ID(FIGHT_IN_BATTLE_SQUARE)};
+
+achievement g_AchievementsFF8[] = {
+    _ACH_ID(UNLOCK_GF_QUEZACOTL),
+    _ACH_ID(UNLOCK_GF_SHIVA),
+    _ACH_ID(UNLOCK_GF_IFRIT),
+    _ACH_ID(UNLOCK_GF_SIREN),
+    _ACH_ID(UNLOCK_GF_BROTHERS),
+    _ACH_ID(UNLOCK_GF_DIABLOS),
+    _ACH_ID(UNLOCK_GF_CARBUNCLE),
+    _ACH_ID(UNLOCK_GF_LEVIATHAN),
+    _ACH_ID(UNLOCK_GF_PANDEMONA),
+    _ACH_ID(UNLOCK_GF_CERBERUS),
+    _ACH_ID(UNLOCK_GF_ALEXANDER),
+    _ACH_ID(UNLOCK_GF_DOOMTRAIN),
+    _ACH_ID(UNLOCK_GF_BAHAMUT),
+    _ACH_ID(UNLOCK_GF_CACTUAR),
+    _ACH_ID(UNLOCK_GF_TONBERRY),
+    _ACH_ID(UNLOCK_GF_EDEN),
+    _ACH_ID(DRAW_100_MAGIC),
+    _ACH_ID(REACH_SEED_RANK_A),
+    _ACH_ID(CARDGAME_FIRST_TIME),
+    _ACH_ID(COLLECT_ALL_CARDS),
+    _ACH_ID(UPGRADE_WEAPON_FIRST_TIME),
+    _ACH_ID(REACH_MAX_HP),
+    _ACH_ID(REACH_MAX_GIL),
+    _ACH_ID(REACH_LEVEL_100),
+    _ACH_ID(FINISH_THE_GAME),
+    _ACH_ID(FINISH_THE_GAME_INITIAL_LEVEL),
+    _ACH_ID(CAPTURE_CHOCOBO_FIRST_TIME),
+    _ACH_ID(FOUND_RAGNAROK),
+    _ACH_ID(SEED_FIRST_SALARY),
+    _ACH_ID(CHOCORPG_FIRST_ITEM),
+    _ACH_ID(BEAT_OMEGA_WEAPON),
+    _ACH_ID(OBEL_LAKE_SECRET),
+    _ACH_ID(UFO),
+    _ACH_ID(CARDS_CLUB_MASTER),
+    _ACH_ID(LOSER),
+    _ACH_ID(PROFESSIONAL),
+    _ACH_ID(TIMBER_MANIACS),
+    _ACH_ID(MAGAZINES_ADDICT),
+    _ACH_ID(MAGIC_FINDER),
+    _ACH_ID(CHICOBO_TOP_LEVEL),
+    _ACH_ID(BLUE_MAGICS),
+    _ACH_ID(DOG_TRICKS),
+    _ACH_ID(TOTAL_KILLS_100),
+    _ACH_ID(TOTAL_KILLS_1000),
+    _ACH_ID(TOTAL_KILLS_10000)};
+
+// Global, access to Achievements object
+extern SteamAchievementsFF7 g_FF7SteamAchievements;
+extern SteamAchievementsFF8 g_FF8SteamAchievements;

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -59,6 +59,7 @@ bool trace_opcodes;
 bool trace_voice;
 bool trace_ambient;
 bool trace_gamepad;
+bool trace_achievement;
 bool vertex_log;
 bool uniform_log;
 bool show_renderer_backend;
@@ -101,6 +102,7 @@ bool enable_animated_textures;
 long ff7_fps_limiter;
 bool ff7_footsteps;
 bool enable_analogue_controls;
+bool enable_steam_achievements;
 
 std::vector<std::string> get_string_or_array_of_strings(const toml::node_view<toml::node> &node)
 {
@@ -174,6 +176,7 @@ void read_cfg()
 	trace_voice = config["trace_voice"].value_or(false);
 	trace_ambient = config["trace_ambient"].value_or(false);
 	trace_gamepad = config["trace_gamepad"].value_or(false);
+	trace_achievement = config["trace_achievement"].value_or(false);
 	vertex_log = config["vertex_log"].value_or(false);
 	uniform_log = config["uniform_log"].value_or(false);
 	show_renderer_backend = config["show_renderer_backend"].value_or(true);
@@ -216,6 +219,7 @@ void read_cfg()
 	ff7_fps_limiter = config["ff7_fps_limiter"].value_or(FF7_LIMITER_DEFAULT);
 	ff7_footsteps = config["ff7_footsteps"].value_or(false);
 	enable_analogue_controls = config["enable_analogue_controls"].value_or(false);
+	enable_steam_achievements = config["enable_steam_achievements"].value_or(false);
 
 	// Windows x or y size can't be less then 0
 	if (window_size_x < 0) window_size_x = 0;

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -72,6 +72,7 @@ extern bool trace_opcodes;
 extern bool trace_voice;
 extern bool trace_ambient;
 extern bool trace_gamepad;
+extern bool trace_achievement;
 extern bool vertex_log;
 extern bool uniform_log;
 extern bool show_renderer_backend;
@@ -114,5 +115,6 @@ extern bool enable_animated_textures;
 extern long ff7_fps_limiter;
 extern bool ff7_footsteps;
 extern bool enable_analogue_controls;
+extern bool enable_steam_achievements;
 
 void read_cfg();

--- a/src/common.h
+++ b/src/common.h
@@ -43,6 +43,12 @@
 #define VERSION_FF8_12_US_EIDOS_NV 16
 #define VERSION_FF8_12_JP          17
 
+// Steam app id of FF7 & FF8
+#define FF7_APPID 39140
+#define FF8_APPID 39150
+#define FF7_N_ACHIEVEMENTS 36
+#define FF8_N_ACHIEVEMENTS 45
+
 #define NV_VERSION (!(version & 1))
 
 // FF8 does not support BLUE text!

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -716,9 +716,9 @@ struct savemap_char
 	char flags;
 	char field_20;
 	unsigned char level_progress_bar;
-	WORD field_22;
+	WORD learned_limit_break;
 	WORD field_24;
-	WORD field_26;
+	WORD used_n_limit_1_1;
 	WORD field_28;
 	WORD field_2A;
 	WORD hp;
@@ -729,23 +729,24 @@ struct savemap_char
 	WORD max_hp;
 	WORD max_mp;
 	uint32_t current_exp;
-	uint32_t field_40;
-	uint32_t field_44;
-	uint32_t field_48;
-	uint32_t field_4C;
-	uint32_t field_50;
-	uint32_t field_54;
-	uint32_t field_58;
-	uint32_t field_5C;
-	uint32_t field_60;
-	uint32_t field_64;
-	uint32_t field_68;
-	uint32_t field_6C;
-	uint32_t field_70;
-	uint32_t field_74;
-	uint32_t field_78;
-	uint32_t field_7C;
+	uint32_t equipped_materia[16];
 	uint32_t exp_to_next_level;
+};
+
+struct chocobo_slot
+{
+	WORD sprint_speed;
+	WORD max_sprint_speed;
+	WORD speed;
+	WORD max_speed;
+	char acceleration;
+	char cooperation;
+	char intelligence;
+	char personality;
+	char p_count;
+	char n_races_won;
+	boolean is_female;
+	char type;
 };
 
 #pragma pack(push,1)
@@ -807,12 +808,14 @@ struct savemap
 	char field_BA3;
 	char field_BA4[256];
 	char field_CA4[256];
-	char field_DA4[256];
+	char field_DA4[32]; 
+	struct chocobo_slot chocobo_slots_first[4];
+	char field_E04[160];
 	char field_EA4[256];
-	char field_FA4[256];
+	char field_FA4[224];
+	struct chocobo_slot chocobo_slots_last[2];
 	WORD phs_lock2;
-	char field_10A6;
-	char field_10A7;
+	WORD phs_visi2;
 	char field_10A8;
 	char field_10A9;
 	char field_10AA;
@@ -1670,6 +1673,7 @@ struct ff7_externals
 	uint32_t battle_loop;
 	DWORD *battle_mode;
 	WORD *battle_location_id;
+	WORD *battle_scene_id;
 	uint32_t battle_sub_429AC0;
 	uint32_t battle_sub_42D808;
 	uint32_t battle_sub_42D992;
@@ -1912,6 +1916,20 @@ struct ff7_externals
 	char *word_CC16E8;
 	int16_t* current_triangle_id;
 	struct ff7_field_ad_object* field_current_actor;
+	uint16_t* menu_battle_end_mode;
+	uint32_t* pointer_functions_7C2980;
+	uint32_t battle_enemy_killed_sub_433BD2;
+	uint32_t battle_sub_5C7F94;
+	uint32_t menu_battle_end_sub_6C9543;
+	uint32_t menu_sub_71FF95, menu_shop_loop, get_materia_gil, menu_sub_6CBCB9;
+	uint32_t credits_main_loop;
+	uint32_t sub_404D80;
+	uint32_t sub_61C190, sub_61C113, sub_61C26A, sub_61BE95, sub_61C52A, sub_61C812;
+	uint32_t menu_sub_6CC0EA, menu_sub_6CBCF3, menu_sub_705D16, menu_sub_6CC17F;
+	uint32_t menu_decrease_item_quantity;
+	uint32_t menu_sub_6CDC09;
+	uint32_t menu_sub_7212FB;
+	uint32_t load_save_file;
 };
 
 uint32_t ff7gl_load_group(uint32_t group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7/battle.cpp
+++ b/src/ff7/battle.cpp
@@ -21,6 +21,7 @@
 
 #include "../ff7.h"
 #include "../log.h"
+#include "../achievement.h"
 
 void magic_thread_start(void (*func)())
 {
@@ -32,4 +33,27 @@ void magic_thread_start(void (*func)())
 	 * effects synchronously.
 	 */
 	func();
+}
+
+void ff7_battle_fight_fanfare()
+{
+	g_FF7SteamAchievements.unlockBattleWonAchievement(*ff7_externals.battle_scene_id);
+	
+	auto original_func = (void (*)()) ff7_externals.battle_fanfare_music;
+	original_func();
+}
+
+void ff7_load_battle_stage(int param_1, int battle_location_id, int **param_3){
+	((void(*)(int, int, int **)) ff7_externals.load_battle_stage)(param_1, battle_location_id, param_3);
+
+	g_FF7SteamAchievements.setPreviousLimitUsedNumber(ff7_externals.savemap->chars);
+	g_FF7SteamAchievements.unlockBattleSquareAchievement(battle_location_id);
+}
+
+void ff7_battle_sub_5C7F94(int param_1, int param_2){ // TESTED, but not when it truly increase the gil
+	((void(*)(int, int)) ff7_externals.battle_sub_5C7F94)(param_1, param_2);
+
+	if (trace_all || trace_achievement)
+		ffnx_trace("%s - trying to unlock achievement for gil\n", __func__);
+	g_FF7SteamAchievements.unlockGilAchievement(ff7_externals.savemap->gil);
 }

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -23,6 +23,20 @@
 
 // battle
 void magic_thread_start(void (*func)());
+void ff7_battle_fight_fanfare();
+void ff7_load_battle_stage(int param_1, int battle_location_id, int **param_3);
+void ff7_battle_sub_5C7F94(int param_1, int param_2);
+void ff7_battle_sub_6DB0EE();
+
+// menu
+void ff7_menu_battle_end_sub_6C9543();
+void ff7_menu_sub_71AAA3(int param_1);
+int ff7_get_materia_gil(uint32_t materia);
+void ff7_menu_sub_6CBCB9(int param_1);
+byte ff7_menu_sub_6CBCF3(uint32_t materia_id);
+void ff7_menu_sub_6CC17F(uint32_t materia);
+uint32_t ff7_menu_decrease_item_quantity(uint32_t item_data);
+void ff7_menu_sub_6CDC09(DWORD param_1);
 
 // misc
 uint32_t get_equipment_stats(uint32_t party_index, uint32_t type);
@@ -43,6 +57,11 @@ void *ff7_menu_sub_6FAC38(uint32_t param1, uint32_t param2, uint8_t param3, uint
 void ff7_limit_fps();
 void ff7_handle_ambient_playback();
 BOOL ff7_write_save_file(char slot);
+DWORD ff7_sub_404D80();
+void ff7_sub_61C26A(int param_1);
+void ff7_sub_61C52A();
+int ff7_return_0_61C812();
+
 
 // field
 void field_load_textures(struct ff7_game_obj *game_object, struct struc_3 *struc_3);
@@ -69,6 +88,7 @@ uint32_t get_filesize(struct ff7_file *file);
 uint32_t tell_file(struct ff7_file *file);
 void seek_file(struct ff7_file *file, uint32_t offset);
 char *make_pc_name(struct file_context *file_context, struct ff7_file *file, char *filename);
+int ff7_load_save_file(int param_1);
 
 // graphics
 void destroy_d3d2_indexed_primitive(struct indexed_primitive *ip);

--- a/src/ff7/file.cpp
+++ b/src/ff7/file.cpp
@@ -28,6 +28,7 @@
 #include "../log.h"
 #include "../hext.h"
 #include "../redirect.h"
+#include "../achievement.h"
 
 FILE *open_lgp_file(char *filename, uint32_t mode)
 {
@@ -574,4 +575,10 @@ char *make_pc_name(struct file_context *file_context, struct ff7_file *file, cha
 	while(backslash = strchr(ret, '\\')) *backslash = '/';
 
 	return ret;
+}
+
+int ff7_load_save_file(int param_1){
+	int returnValue = ((int(*)(int))ff7_externals.load_save_file)(param_1);
+	g_FF7SteamAchievements.initMateriaMastered(ff7_externals.savemap);
+	return returnValue;
 }

--- a/src/ff7/menu.cpp
+++ b/src/ff7/menu.cpp
@@ -1,0 +1,138 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 myst6re                                            //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//    Copyright (C) 2020 John Pritchard                                     //
+//    Copyright (C) 2021 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2021 Tang-Tang Zhou                                     //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#include "../ff7.h"
+#include "../log.h"
+#include "../achievement.h"
+
+void ff7_menu_battle_end_sub_6C9543()
+{
+    ((void (*)())ff7_externals.menu_battle_end_sub_6C9543)();
+
+    if(*ff7_externals.menu_battle_end_mode == 1){
+        if (trace_all || trace_achievement)
+            ffnx_trace("%s - trying to unlock achievement for first limit, cait sith, character level, and master materia\n", __func__);
+        // this could be achieved when the limit break is used, instead in this way it is achieved only after battle ending
+        g_FF7SteamAchievements.unlockFirstLimitBreakAchievement(ff7_externals.savemap->chars);
+
+        g_FF7SteamAchievements.unlockCaitSithLastLimitBreakAchievement(ff7_externals.savemap->chars);
+        g_FF7SteamAchievements.unlockCharacterLevelAchievement(ff7_externals.savemap->chars);
+        g_FF7SteamAchievements.unlockMasterMateriaAchievement(ff7_externals.savemap->chars);
+    }
+    if(*ff7_externals.menu_battle_end_mode == 3){
+        if (trace_all || trace_achievement)
+            ffnx_trace("%s - trying to unlock achievement for gil\n", __func__);
+        g_FF7SteamAchievements.unlockGilAchievement(ff7_externals.savemap->gil);
+    }
+}
+
+int ff7_get_materia_gil(uint32_t materia)
+{
+    int materiaGil = ((int (*)(uint32_t))ff7_externals.get_materia_gil)(materia);
+
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for gil\n", __func__);
+
+    g_FF7SteamAchievements.unlockGilAchievement(ff7_externals.savemap->gil + materiaGil);
+    return materiaGil;
+}
+
+void ff7_menu_sub_6CBCB9(int gilObtained)
+{ // NOT TESTED
+    if (ff7_externals.savemap->gil + gilObtained < ff7_externals.savemap->gil)
+        ff7_externals.savemap->gil = -1;
+    else
+        ff7_externals.savemap->gil = ff7_externals.savemap->gil + gilObtained;
+
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for gil\n", __func__);
+
+    g_FF7SteamAchievements.unlockGilAchievement(ff7_externals.savemap->gil);
+};
+
+byte ff7_menu_sub_6CBCF3(uint32_t materia_id)
+{
+    byte returnValue = ((byte(*)(uint32_t))ff7_externals.menu_sub_6CBCF3)(materia_id);
+
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for getting materia\n", __func__);
+
+    g_FF7SteamAchievements.unlockGotMateriaAchievement(materia_id);
+
+    return returnValue;
+}
+
+void ff7_menu_sub_6CC17F(uint32_t materia)
+{
+    ((void (*)(uint32_t))ff7_externals.menu_sub_6CC17F)(materia);
+
+    if (trace_all || trace_achievement)
+        ffnx_trace("%s - trying to unlock achievement for getting materia\n", __func__);
+
+    g_FF7SteamAchievements.unlockGotMateriaAchievement(materia & 0xFF);
+}
+
+uint32_t ff7_menu_decrease_item_quantity(uint32_t item_used)
+{
+    uint32_t item_id;
+    uint32_t prevIndex;
+    uint32_t item_quantity;
+    WORD local_c;
+    int index=0;
+
+    WORD *party_item_slots = ff7_externals.savemap->items;
+    item_id = item_used & 0x1FF;
+    item_quantity = (item_used & 0xFFFF) >> 9;
+    prevIndex = item_id;
+    
+    while (!(((WORD)party_item_slots[index] != -1) &&
+            (prevIndex = (WORD)party_item_slots[index] & 0x1ff, item_id == prevIndex)))
+    {
+        if (index >= 320)
+            return prevIndex & 0xFFFF0000 | 0xFFFF;
+        
+        prevIndex = index;
+        index = index + 1;
+    }
+    if (item_quantity < (party_item_slots[index] >> 9))
+    {
+        local_c = (WORD)(item_used | (item_quantity << 9));
+        item_id = ((party_item_slots[index] >> 9) - item_quantity) * 512 | item_id;
+        party_item_slots[index] = (WORD)item_id;
+    }
+    else
+    {
+        local_c = party_item_slots[index];
+        item_id = 0;
+        party_item_slots[index] = 0xFFFF;
+
+        g_FF7SteamAchievements.unlockLastLimitBreakAchievement(item_used & 0x1FF);
+    }
+    return item_id & 0xFFFF0000 | (uint32_t)local_c;
+}
+
+// Called when finished writing a name of a chocobo/characters
+void ff7_menu_sub_6CDC09(DWORD param_1){ // TO BE TESTED if chocobo is put in farm before naming or after naming
+    ((void (*)(DWORD))ff7_externals.menu_sub_6CDC09)(param_1);
+
+    g_FF7SteamAchievements.unlockGoldChocoboAchievement(ff7_externals.savemap->chocobo_slots_first, ff7_externals.savemap->chocobo_slots_last);
+}

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -30,6 +30,7 @@
 #include "../log.h"
 #include "../metadata.h"
 #include "../sfx.h"
+#include "../achievement.h"
 
 // MDEF fix
 uint32_t get_equipment_stats(uint32_t party_index, uint32_t type)
@@ -540,4 +541,34 @@ BOOL ff7_write_save_file(char slot)
 	metadataPatcher.apply();
 
 	return ret;
+}
+
+//#########################
+// steam achievement hooks
+//#########################
+
+// Replaced this function only in credits main loop
+DWORD ff7_sub_404D80(){ // NOT TESTED
+	g_FF7SteamAchievements.unlockGameProgressAchievement(END_OF_GAME);
+
+	return ((DWORD(*)()) ff7_externals.sub_404D80)(); 
+}
+
+void ff7_sub_61C26A(int param_1){
+	((void(*)(int)) ff7_externals.sub_61C26A)(param_1);
+
+	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap->phs_visi2);
+}
+
+void ff7_sub_61C52A(){
+	((void(*)()) ff7_externals.sub_61C52A)();
+	
+	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap->phs_visi2);
+}
+
+// Does not replace a function, but a return 0; (first 5 bytes for the call and last 1 byte is RET)
+int ff7_return_0_61C812(){
+	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap->phs_visi2);
+
+	return 0;
 }

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -160,7 +160,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_sub_42D992 = get_relative_call(ff7_externals.battle_sub_42D808, 0x30);
 	ff7_externals.battle_sub_42DAE5 = get_relative_call(ff7_externals.battle_sub_42D992, 0x7E);
 	ff7_externals.battle_fight_end = get_relative_call(ff7_externals.battle_sub_42D992, 0xB7);
-	ff7_externals.battle_fanfare_music = get_relative_call(ff7_externals.battle_fight_end, 0x25);
+	ff7_externals.battle_fanfare_music = get_relative_call(ff7_externals.battle_fight_end, 0x25); 
 	ff7_externals.battle_sub_427C22 = get_relative_call(ff7_externals.battle_sub_42DAE5, 0xF);
 	ff7_externals.battle_sub_6CE8B3 = get_relative_call(battle_main_loop, 0x368);
 	ff7_externals.battle_sub_6DB0EE = get_relative_call(ff7_externals.battle_sub_6CE8B3, 0xD9);
@@ -239,6 +239,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 
 	ff7_externals.battle_sub_437DB0 = get_absolute_value(ff7_externals.battle_loop, 0x8D);
 	ff7_externals.sub_5CB2CC = get_relative_call(ff7_externals.battle_sub_437DB0, 0x43);
+	ff7_externals.battle_scene_id = (WORD*)get_absolute_value(ff7_externals.battle_sub_437DB0, 0x1FD);
 
 	ff7_externals.play_midi = (void (*)(uint32_t))common_externals.play_midi;
 	common_externals.master_midi_volume = (DWORD *)get_absolute_value(common_externals.set_master_midi_volume, 0x46);
@@ -524,7 +525,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.sub_408074 = get_relative_call(main_loop, 0x681);
 	ff7_externals.sub_60BB58 = get_relative_call(ff7_externals.sub_63C17F, 0x16F);
 	common_externals.update_field_entities = get_relative_call(ff7_externals.sub_60BB58, 0x3A); // 0x60C94D
-	ff7_externals.sub_630734 = get_relative_call(ff7_externals.open_field_file, 0xCF);
+	ff7_externals.sub_630734 = get_relative_call(ff7_externals.open_field_file, 0xCF); // This is the same function of read_field_file already defined
 
 	common_externals.current_field_id = (WORD*)get_absolute_value(ff7_externals.sub_408074, 0x41); // 0xCC15D0
 	common_externals.previous_field_id = (WORD*)get_absolute_value(ff7_externals.sub_408074, 0x4F); // 0xCC0DEC
@@ -537,6 +538,43 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.current_triangle_id = (int16_t *)((char *)ff7_externals.word_CC16E8 + 136 * ff7_externals.modules_global_object->field_model_id);
 
 	ff7_externals.field_current_actor = (struct ff7_field_ad_object*)get_absolute_value(common_externals.execute_opcode_table[0xA8], 0x1C6);
+
+	//ff7 achievement related externals
+	uint32_t sub_434347 = get_relative_call(ff7_externals.battle_loop, 0x484);
+	uint32_t* pointer_functions_7C2980 = (uint32_t*)get_absolute_value(sub_434347, 0x19C);
+	ff7_externals.battle_enemy_killed_sub_433BD2 = pointer_functions_7C2980[0];
+	ff7_externals.battle_sub_5C7F94 = get_relative_call(ff7_externals.battle_enemy_killed_sub_433BD2, 0x2AF);
+	ff7_externals.menu_battle_end_sub_6C9543 = get_relative_call(ff7_externals.menu_sub_6CDA83, 0x20);
+	ff7_externals.menu_battle_end_mode = (uint16_t*)get_absolute_value(ff7_externals.menu_battle_end_sub_6C9543, 0x2C);
+	uint32_t menu_sub_6CBD54 = get_relative_call(ff7_externals.menu_sub_6CDA83, 0xC1);
+	ff7_externals.menu_sub_71FF95 = get_relative_call(menu_sub_6CBD54, 0x7);
+	ff7_externals.menu_shop_loop = get_relative_call(ff7_externals.menu_sub_71FF95, 0x84);
+	ff7_externals.get_materia_gil = get_relative_call(ff7_externals.menu_shop_loop, 0x327B);
+	ff7_externals.menu_sub_6CBCB9 = get_relative_call(ff7_externals.menu_shop_loop, 0x353B);
+	
+	ff7_externals.credits_main_loop = credits_main_loop;
+	ff7_externals.sub_404D80 = get_relative_call(ff7_externals.credits_main_loop, 0x211);
+
+	uint32_t* pointer_functions_9055A0 = (uint32_t*)get_absolute_value(common_externals.update_field_entities, 0x464);
+	ff7_externals.sub_61C190 = pointer_functions_9055A0[10];
+	ff7_externals.sub_61C113 = pointer_functions_9055A0[202];
+	ff7_externals.sub_61C26A = get_relative_call(ff7_externals.sub_61C113, 0x4B);
+	ff7_externals.sub_61BE95 = pointer_functions_9055A0[200];
+	ff7_externals.sub_61C52A = get_relative_call(ff7_externals.sub_61BE95, 0x12C);
+	ff7_externals.sub_61C812 = pointer_functions_9055A0[205];
+
+	ff7_externals.menu_sub_6CC0EA = get_relative_call(ff7_externals.menu_shop_loop, 0x30FE);
+	ff7_externals.menu_sub_6CBCF3 = get_relative_call(ff7_externals.menu_sub_6CC0EA, 0x43);
+	ff7_externals.menu_sub_705D16 = ff7_externals.menu_subs_call_table[4];
+	ff7_externals.menu_sub_6CC17F = get_relative_call(ff7_externals.menu_sub_705D16, 0x1729);
+
+	ff7_externals.menu_decrease_item_quantity = get_relative_call(ff7_externals.menu_shop_loop, 0x351D);
+	ff7_externals.menu_sub_6CDC09 = get_relative_call(ff7_externals.menu_sub_718DBE, 0x37F);
+
+	uint32_t menu_sub_6CBD65 = get_relative_call(ff7_externals.menu_sub_6CDA83, 0x54);
+	uint32_t menu_sub_722393 = get_relative_call(menu_sub_6CBD65, 0x4);
+	ff7_externals.menu_sub_7212FB = get_relative_call(menu_sub_722393, 0x8B);
+	ff7_externals.load_save_file = get_relative_call(ff7_externals.menu_sub_7212FB, 0xE9D);
 }
 
 void ff7_data(struct ff7_game_obj* game_object)

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -225,6 +225,43 @@ void ff7_init_hooks(struct game_obj *_game_object)
 				break;
 		}
 	}
+	//###############################
+	// steam achievement unlock calls
+	//###############################
+	if(enable_steam_achievements)
+	{
+		replace_call_function(ff7_externals.battle_fight_end + 0x25, ff7_battle_fight_fanfare);
+		replace_call_function(ff7_externals.battle_sub_42A0E7 + 0x78, ff7_load_battle_stage);
+
+		// GIL
+		replace_call_function(ff7_externals.battle_enemy_killed_sub_433BD2 + 0x2AF, ff7_battle_sub_5C7F94); 
+		replace_call_function(ff7_externals.menu_sub_6CDA83 + 0x20, ff7_menu_battle_end_sub_6C9543);
+		replace_call_function(ff7_externals.menu_shop_loop + 0x327B, ff7_get_materia_gil);
+		replace_function(ff7_externals.menu_sub_6CBCB9, ff7_menu_sub_6CBCB9);
+
+		// GAME PROGRESS
+		replace_call_function(ff7_externals.credits_main_loop + 0x211, ff7_sub_404D80);
+
+		// PHS VISIBILITY
+		replace_call_function(ff7_externals.sub_61C113 + 0x4B, ff7_sub_61C26A);
+		replace_call_function(ff7_externals.sub_61C190 + 0x41, ff7_sub_61C26A);
+		replace_call_function(ff7_externals.sub_61BE95 + 0x12C, ff7_sub_61C52A);
+		replace_call_function(ff7_externals.sub_61C812 + 0xEF, ff7_return_0_61C812);
+
+		// MATERIA GOT
+		replace_call_function(ff7_externals.menu_sub_6CC0EA + 0x43, ff7_menu_sub_6CBCF3);
+		replace_call_function(ff7_externals.menu_sub_705D16 + 0x1729, ff7_menu_sub_6CC17F);
+		replace_call_function(ff7_externals.menu_sub_705D16 + 0x1819, ff7_menu_sub_6CC17F);
+
+		// LAST LIMIT BREAK
+		replace_function(ff7_externals.menu_decrease_item_quantity, ff7_menu_decrease_item_quantity);
+
+		// GOLD CHOCOBO
+		replace_call_function(ff7_externals.menu_sub_718DBE + 0x37F, ff7_menu_sub_6CDC09);
+
+		// INITIALIZATION AT LOAD SAVE FILE
+		replace_call_function(ff7_externals.menu_sub_7212FB + 0xE9D, ff7_load_save_file);
+	}
 }
 
 struct ff7_gfx_driver *ff7_load_driver(void* _game_object)

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -10,7 +10,8 @@
         "openpsf",
         "soloud",
         "stackwalker",
-        "vgmstream"
+        "vgmstream",
+        "steamworkssdk"
       ]
     }
   ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,7 +35,8 @@
     "soloud",
     "stackwalker",
     "tomlplusplus",
-    "vgmstream"
+    "vgmstream",
+    "steamworkssdk"
   ],
   "overrides": [
     {
@@ -86,6 +87,11 @@
     {
       "name": "vgmstream",
       "version": "1.0.0",
+      "port-version": 0
+    },
+    {
+      "name": "steamworkssdk",
+      "version": "1.51.0",
       "port-version": 0
     }
   ]


### PR DESCRIPTION
## FF7 Steam Achievement Implementation

### Implementation of all 36 achievement of FF7 with SteamworksSDK v1.51:

- Added SteamworksSDK package via vcpkg (https://github.com/julianxhokaxhiu/SteamworksSDKCI)
- Added binary variables in cfg and toml for enabling steam achievement and tracing steam achievement
- Added achievement class to handle all the achievements
- List of implemented achievements in groups:
1. **Game progress achievement** (finish disk 1, finish disk 2, finish the game): the first two are implemented by looking at the required disk when getting CD (e.g. inserted disk = 1 and required disk = 2, then it unlock finish disk 1 achievement), while the last one when credits starts
2. **Money Gil achievement**: implemented when party gil money in savemap increases (e.g. at the end of each battle, when selling item/materia, ...)
3. **Level 99 achievement**: unlock at the end of each battle when EXP is increased (check the savemap->chars)
4. **Last limit break achievement**: unlock when using the item related to fourth limit break (only when the item quantity goes from 1 to 0) except for cait sith which is checked at the end of each battle
5. **Bahamut ZERO and KOTR materia achievement**: trying to unlock whenever a new materia is obtained 
6. **Materia mastered achievement**: implemented at the end of each battle when the AP of each equipped materia is increased. For the achievement of all materia mastered, it exclude the unknown materia (https://wiki.ffrtt.ru/index.php?title=FF7/Savemap#Save_Materia_List) and for the 4 materia that are unmasterable (i.e. underwater, master summon, master command, master magic), it just only check if it is obtained
7. **Beat Weapons**: at battle fanfare, it checks if the battle scene ID is the one related to the Ultima, Ruby, Emerald, and Diamond weapon
8. **Getting character in party**: for Yuffie and Vincent, whenever PHS visibility changes, it checks if the bit of Yuffie and Vincent is at 1
9. **Gold chocobo achievement**: looks into all the chocobo slot of savemap when finishing naming the a chocobo or a character (_need to be tested if this memory is changed before naming or after naming_)
10. **Win 1st battle achievement**: checked at the end of each battle
11. **Use 1st limit break**: the variable in savemap, that contains the number of times limit 1-1 is used, update only at the end of the battle; thus, this is unlocked at the end of battle if the number of times limit 1-1 has increased from the start of the battle
12. **Fight in battle square**: checked at the start of the battle, by looking at the battle location ID. If this coincide to battle square, then it is achieved

## Testing
For testing purpose, **every achievement unlocked will not be sent to steam**, but only a popup message window will show up telling that the achievement has been unlocked (it also prints it into the log of FFNx). Moreover, for testing, at every start of the game, all achievements are reset, so they can be tested continuously even if you have already unlocked it in steam.

Most of these achievements has to be tested, primarily:

- [x] Game progress achievement (Tested only end of part 2, but the other should work as well)
- [x] Money GIL achievement from battle, killing enemy that has money, selling item, and selling materia
- [x] Level 99 should work even if I did not test it by reaching level 99
- [x] Last limit achievement (all 9 except cait sith) needs to be tested (I have tested only cloud, I assume the other works)
- [x] Last limit achievement (cait sith) needs to be tested
- [x] Materia KOTR achievement (tested in round island)
- [x] Bahamut ZERO in Cosmo Canyon
- [x] Bahamut ZERO in Bone Village (not really tested, but seen through the same chest with Phoenix Materia)
- [x] All materia mastered achievement
- [x] Single materia mastered achievement
- [x] Beat diamond weapon
- [x] Beat ultimate weapon
- [x] Beat emerald weapon
- [x] Beat ruby weapon
- [x] Yuffie and Vincent has to be tested
- [x] Gold chocobo obtained from Kalm village
- [x] Gold chocobo obtained through breeding
- [x] Fight in battle square has to be tested

## File requirements in the folder of FF7
- **[steam_api.dll](https://github.com/julianxhokaxhiu/SteamworksSDKCI/blob/master/steamworks_sdk/redistributable_bin/steam_api.dll)**: DLL file of steam API with version 1.51+ 
- **[steam_appid.txt](https://github.com/julianxhokaxhiu/FFNx/files/7360032/steam_appid.txt)**: a TXT file containing only the APP ID of FF7 which is 39140

## How to activate steam achievements
- Add the required files in the folder of FF7
- Set to true the _enable_steam_achievements_ variable in FFNx.toml
- [Optional] Set also to true the _trace_achievement_ for logging the messages related to achievements
- Steam must be running, otherwise FF7 will not open if steam achievements are enabled

## FAQ
- If the game crashes once launched from 7Heaven without any log information, then the problem is, probably, in the `steam_api.dll`. You need to have the version 1.51+