### PR TITLE
Refactor FF7 Steam Achievements

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -454,17 +454,23 @@ int common_create_window(HINSTANCE hInstance, struct game_obj* game_object)
 
 	// Init Steam API
 	if(enable_steam_achievements)
-	{
-		if ( !SteamAPI_Init() )
+	{	
+		if (SteamAPI_RestartAppIfNecessary((ff8) ? FF8_APPID : FF7_APPID))
+		{
+			MessageBoxA(gameHwnd, "Steam Error - Could not find steam_appid.txt containing the app ID of the game.\n", "Steam App ID Wrong", 0);
+			ffnx_error( "Steam Error - Could not find steam_appid.txt containing the app ID of the game.\n" );
+			return 1;
+		}
+		if (!SteamAPI_Init())
 		{
 			MessageBoxA(gameHwnd, "Steam Error - Steam must be running to play this game with achievements (SteamAPI_Init() failed).\n", "Steam not running error", 0);
 			ffnx_error( "Steam Error - Steam must be running to play this game with achievements (SteamAPI_Init() failed).\n" );
 			return 1;
 		}
 		if (ff8)
-			g_FF8SteamAchievements.init(g_AchievementsFF8, FF8_N_ACHIEVEMENTS);
+			g_FF8SteamAchievements.init();
 		else
-			g_FF7SteamAchievements.init(g_AchievementsFF7, FF7_N_ACHIEVEMENTS);
+			g_FF7SteamAchievements.init();
 	}
 
 	// fetch current user screen settings

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -807,11 +807,15 @@ struct savemap
 	char field_BA2;
 	char field_BA3;
 	char field_BA4[256];
-	char field_CA4[256];
-	char field_DA4[32]; 
+	char field_CA4[207];
+	char yuffie_reg_mask;
+	char field_D74[48];
+	char field_DA4[32];
 	struct chocobo_slot chocobo_slots_first[4];
 	char field_E04[160];
-	char field_EA4[256];
+	char field_EA4[80];
+	char vincent_reg_mask;
+	char field_EF5[175];
 	char field_FA4[224];
 	struct chocobo_slot chocobo_slots_last[2];
 	WORD phs_lock2;

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -557,18 +557,18 @@ DWORD ff7_sub_404D80(){ // NOT TESTED
 void ff7_sub_61C26A(int param_1){
 	((void(*)(int)) ff7_externals.sub_61C26A)(param_1);
 
-	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap->phs_visi2);
+	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
 }
 
 void ff7_sub_61C52A(){
 	((void(*)()) ff7_externals.sub_61C52A)();
 	
-	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap->phs_visi2);
+	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
 }
 
 // Does not replace a function, but a return 0; (first 5 bytes for the call and last 1 byte is RET)
 int ff7_return_0_61C812(){
-	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap->phs_visi2);
+	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
 
 	return 0;
 }


### PR DESCRIPTION
 - Remove useless inheritance between achievement classes
 - Refactor define macros into static inline constants
 - Change control flow for yuffie and vincent achievement (look for their regular mask)
 - Add popup message box when steam_appid.txt cannot be found or the file content is wrong
 - Avoid checking for stolen mastered materia if yuffie is not unlocked
 - Change testing method: from achievement popup message to steam progress notification (show up only if it is not achieved in steam)