### PR TITLE
FF7Achievement: Fix crash due to bug in PHS visibility related hook

### DIFF
--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -441,20 +441,15 @@ void SteamAchievementsFF7::unlockGameProgressAchievement(int achID)
 void SteamAchievementsFF7::unlockYuffieAndVincentAchievement(savemap *savemap)
 {
     if (trace_all || trace_achievement)
-        ffnx_trace("%s - trying to unlock yuffie and vincent achievement (yuffie_reg: 0x%02x, vincent_reg: 0x%02x)\n", \
-                    __func__, savemap->yuffie_reg_mask, savemap->vincent_reg_mask);
+        ffnx_trace("%s - trying to unlock yuffie and vincent achievement (yuffie_reg: 0x%02x, vincent_reg: 0x%02x, phs_visi: %d)\n", \
+                    __func__, savemap->yuffie_reg_mask, savemap->vincent_reg_mask, savemap->phs_visi2);
 
     // old method with phs ((phsCharacterVisibility & (WORD)(1 << YUFFIE_INDEX)) != 0) [didn't tested]
     if (!this->steamManager.isAchieved(GET_YUFFIE_IN_TEAM) && isYuffieUnlocked(savemap->yuffie_reg_mask))
-    {
-        this->initMateriaMastered(savemap);
         this->steamManager.setAchievement(GET_YUFFIE_IN_TEAM);
-    }
 
     if (!this->steamManager.isAchieved(GET_VINCENT_IN_TEAM) && isVincentUnlocked(savemap->vincent_reg_mask))
-    {
         this->steamManager.setAchievement(GET_VINCENT_IN_TEAM);
-    }
 }
 
 // -------------------------- STEAM ACHIEVEMENTS OF FF8 ---------------------------

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1928,7 +1928,6 @@ struct ff7_externals
 	uint32_t menu_sub_71FF95, menu_shop_loop, get_materia_gil, menu_sub_6CBCB9;
 	uint32_t credits_main_loop;
 	uint32_t sub_404D80;
-	uint32_t sub_61C190, sub_61C113, sub_61C26A, sub_61BE95, sub_61C52A, sub_61C812;
 	uint32_t menu_sub_6CC0EA, menu_sub_6CBCF3, menu_sub_705D16, menu_sub_6CC17F;
 	uint32_t menu_decrease_item_quantity;
 	uint32_t menu_sub_6CDC09;

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -58,9 +58,6 @@ void ff7_limit_fps();
 void ff7_handle_ambient_playback();
 BOOL ff7_write_save_file(char slot);
 DWORD ff7_sub_404D80();
-void ff7_sub_61C26A(int param_1);
-void ff7_sub_61C52A();
-int ff7_return_0_61C812();
 
 
 // field

--- a/src/ff7/menu.cpp
+++ b/src/ff7/menu.cpp
@@ -135,4 +135,8 @@ void ff7_menu_sub_6CDC09(DWORD param_1){ // TO BE TESTED if chocobo is put in fa
     ((void (*)(DWORD))ff7_externals.menu_sub_6CDC09)(param_1);
 
     g_FF7SteamAchievements.unlockGoldChocoboAchievement(ff7_externals.savemap->chocobo_slots_first, ff7_externals.savemap->chocobo_slots_last);
+    g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
+
+    g_FF7SteamAchievements.initMateriaMastered(ff7_externals.savemap);
+    g_FF7SteamAchievements.unlockMasterMateriaAchievement(ff7_externals.savemap->chars);
 }

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -549,26 +549,10 @@ BOOL ff7_write_save_file(char slot)
 
 // Replaced this function only in credits main loop
 DWORD ff7_sub_404D80(){ // NOT TESTED
+	if (trace_all || trace_achievement)
+        ffnx_trace("%s - unlock end of game progress\n", __func__);
+
 	g_FF7SteamAchievements.unlockGameProgressAchievement(END_OF_GAME);
 
 	return ((DWORD(*)()) ff7_externals.sub_404D80)(); 
-}
-
-void ff7_sub_61C26A(int param_1){
-	((void(*)(int)) ff7_externals.sub_61C26A)(param_1);
-
-	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
-}
-
-void ff7_sub_61C52A(){
-	((void(*)()) ff7_externals.sub_61C52A)();
-	
-	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
-}
-
-// Does not replace a function, but a return 0; (first 5 bytes for the call and last 1 byte is RET)
-int ff7_return_0_61C812(){
-	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
-
-	return 0;
 }

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -555,14 +555,6 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.credits_main_loop = credits_main_loop;
 	ff7_externals.sub_404D80 = get_relative_call(ff7_externals.credits_main_loop, 0x211);
 
-	uint32_t* pointer_functions_9055A0 = (uint32_t*)get_absolute_value(common_externals.update_field_entities, 0x464);
-	ff7_externals.sub_61C190 = pointer_functions_9055A0[10];
-	ff7_externals.sub_61C113 = pointer_functions_9055A0[202];
-	ff7_externals.sub_61C26A = get_relative_call(ff7_externals.sub_61C113, 0x4B);
-	ff7_externals.sub_61BE95 = pointer_functions_9055A0[200];
-	ff7_externals.sub_61C52A = get_relative_call(ff7_externals.sub_61BE95, 0x12C);
-	ff7_externals.sub_61C812 = pointer_functions_9055A0[205];
-
 	ff7_externals.menu_sub_6CC0EA = get_relative_call(ff7_externals.menu_shop_loop, 0x30FE);
 	ff7_externals.menu_sub_6CBCF3 = get_relative_call(ff7_externals.menu_sub_6CC0EA, 0x43);
 	ff7_externals.menu_sub_705D16 = ff7_externals.menu_subs_call_table[4];

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -242,12 +242,6 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		// GAME PROGRESS
 		replace_call_function(ff7_externals.credits_main_loop + 0x211, ff7_sub_404D80);
 
-		// PHS VISIBILITY
-		replace_call_function(ff7_externals.sub_61C113 + 0x4B, ff7_sub_61C26A);
-		replace_call_function(ff7_externals.sub_61C190 + 0x41, ff7_sub_61C26A);
-		replace_call_function(ff7_externals.sub_61BE95 + 0x12C, ff7_sub_61C52A);
-		replace_call_function(ff7_externals.sub_61C812 + 0xEF, ff7_return_0_61C812);
-
 		// MATERIA GOT
 		replace_call_function(ff7_externals.menu_sub_6CC0EA + 0x43, ff7_menu_sub_6CBCF3);
 		replace_call_function(ff7_externals.menu_sub_705D16 + 0x1729, ff7_menu_sub_6CC17F);
@@ -256,7 +250,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		// LAST LIMIT BREAK
 		replace_function(ff7_externals.menu_decrease_item_quantity, ff7_menu_decrease_item_quantity);
 
-		// GOLD CHOCOBO
+		// GOLD CHOCOBO, YUFFIE, VINCENT
 		replace_call_function(ff7_externals.menu_sub_718DBE + 0x37F, ff7_menu_sub_6CDC09);
 
 		// INITIALIZATION AT LOAD SAVE FILE


### PR DESCRIPTION
Also:
 - Add more logs to PHS hooks
 - Reinitialize materia mastered each time PHS visibility changes