### PR TITLE
FF7Achievement: Fix and refactor FF7 achievements

### DIFF
--- a/src/achievement.h
+++ b/src/achievement.h
@@ -102,7 +102,6 @@ private:
     static inline const WORD ULTIMATE_WEAPON_START = 988;
     static inline const WORD ULTIMATE_WEAPON_END = 991;
 
-    // gold chocobo from https://gamefaqs.gamespot.com/pc/130791-final-fantasy-vii/faqs/13970
     static inline const byte GOLD_CHOCOBO_TYPE = 0x04;
 
     SteamManager steamManager;
@@ -111,17 +110,24 @@ private:
     std::vector<int> unknownMateriaList;
     std::vector<int> unmasterableMateriaList;
     std::vector<int> limitBreakItemsID;
+    
     WORD previousUsedLimitNumber[N_CHARACTERS];
+    bool equipMasteredMateriaCharacter[N_CHARACTERS][N_EQUIP_MATERIA_PER_CHARACTER];
     bool masteredMateria[N_TYPE_MATERIA];
+    bool yuffieUnlocked;
+    bool vincentUnlocked;
+    bool caitsithLastLimitUnlocked;
+
+    bool isYuffieUnlocked(char yuffieRegular);
+    bool isVincentUnlocked(char vincentRegular);
 
 public:
     void init();
+    void initStatsFromSaveFile(savemap *savemap);
+    void initCharStatsBeforeBattle(savemap_char *characters);
     void initMateriaMastered(savemap *savemap);
     bool isMateriaMastered(uint32_t materia);
     bool isAllMateriaMastered(bool* masteredMateria);
-    bool isYuffieUnlocked(char yuffieRegular);
-    bool isVincentUnlocked(char vincentRegular);
-    void setPreviousLimitUsedNumber(savemap_char *characters);
     void unlockBattleWonAchievement(WORD battleSceneID);
     void unlockGilAchievement(uint32_t gilAmount);
     void unlockCharacterLevelAchievement(savemap_char *characters);

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1930,7 +1930,8 @@ struct ff7_externals
 	uint32_t sub_404D80;
 	uint32_t menu_sub_6CC0EA, menu_sub_6CBCF3, menu_sub_705D16, menu_sub_6CC17F;
 	uint32_t menu_decrease_item_quantity;
-	uint32_t menu_sub_6CDC09;
+	uint32_t sub_610973, sub_611098;
+	uint32_t sub_60FA7D;
 	uint32_t menu_sub_7212FB;
 	uint32_t load_save_file;
 	uint32_t field_load_models_atoi;

--- a/src/ff7/battle.cpp
+++ b/src/ff7/battle.cpp
@@ -46,7 +46,7 @@ void ff7_battle_fight_fanfare()
 void ff7_load_battle_stage(int param_1, int battle_location_id, int **param_3){
 	((void(*)(int, int, int **)) ff7_externals.load_battle_stage)(param_1, battle_location_id, param_3);
 
-	g_FF7SteamAchievements.setPreviousLimitUsedNumber(ff7_externals.savemap->chars);
+	g_FF7SteamAchievements.initCharStatsBeforeBattle(ff7_externals.savemap->chars);
 	g_FF7SteamAchievements.unlockBattleSquareAchievement(battle_location_id);
 }
 

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -59,6 +59,9 @@ void ff7_handle_ambient_playback();
 BOOL ff7_write_save_file(char slot);
 DWORD ff7_sub_404D80();
 int ff7_field_load_models_atoi(const char* str);
+void ff7_chocobo_field_entity_60FA7D(WORD param1, short param2, short param3);
+void ff7_character_regularly_field_entity_60FA7D(WORD param1, short param2, short param3);
+int ff7_load_save_file(int param_1);
 
 // field
 void field_load_textures(struct ff7_game_obj *game_object, struct struc_3 *struc_3);
@@ -85,7 +88,6 @@ uint32_t get_filesize(struct ff7_file *file);
 uint32_t tell_file(struct ff7_file *file);
 void seek_file(struct ff7_file *file, uint32_t offset);
 char *make_pc_name(struct file_context *file_context, struct ff7_file *file, char *filename);
-int ff7_load_save_file(int param_1);
 
 // graphics
 void destroy_d3d2_indexed_primitive(struct indexed_primitive *ip);

--- a/src/ff7/file.cpp
+++ b/src/ff7/file.cpp
@@ -576,9 +576,3 @@ char *make_pc_name(struct file_context *file_context, struct ff7_file *file, cha
 
 	return ret;
 }
-
-int ff7_load_save_file(int param_1){
-	int returnValue = ((int(*)(int))ff7_externals.load_save_file)(param_1);
-	g_FF7SteamAchievements.initMateriaMastered(ff7_externals.savemap);
-	return returnValue;
-}

--- a/src/ff7/menu.cpp
+++ b/src/ff7/menu.cpp
@@ -129,14 +129,3 @@ uint32_t ff7_menu_decrease_item_quantity(uint32_t item_used)
     }
     return item_id & 0xFFFF0000 | (uint32_t)local_c;
 }
-
-// Called when finished writing a name of a chocobo/characters
-void ff7_menu_sub_6CDC09(DWORD param_1){ // TO BE TESTED if chocobo is put in farm before naming or after naming
-    ((void (*)(DWORD))ff7_externals.menu_sub_6CDC09)(param_1);
-
-    g_FF7SteamAchievements.unlockGoldChocoboAchievement(ff7_externals.savemap->chocobo_slots_first, ff7_externals.savemap->chocobo_slots_last);
-    g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
-
-    g_FF7SteamAchievements.initMateriaMastered(ff7_externals.savemap);
-    g_FF7SteamAchievements.unlockMasterMateriaAchievement(ff7_externals.savemap->chars);
-}

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -566,3 +566,22 @@ DWORD ff7_sub_404D80() // NOT TESTED
 
 	return ((DWORD(*)()) ff7_externals.sub_404D80)();
 }
+
+int ff7_load_save_file(int param_1){
+	int returnValue = ((int(*)(int))ff7_externals.load_save_file)(param_1);
+	g_FF7SteamAchievements.initStatsFromSaveFile(ff7_externals.savemap);
+	return returnValue;
+}
+
+void ff7_chocobo_field_entity_60FA7D(WORD param1, short param2, short param3){
+	((void(*)(WORD, short, short)) ff7_externals.sub_60FA7D)(param1, param2, param3);
+	
+	if(param3 == 0x04)
+		g_FF7SteamAchievements.unlockGoldChocoboAchievement(ff7_externals.savemap->chocobo_slots_first, ff7_externals.savemap->chocobo_slots_last);	
+}
+
+void ff7_character_regularly_field_entity_60FA7D(WORD param1, short param2, short param3){
+	((void(*)(WORD, short, short)) ff7_externals.sub_60FA7D)(param1, param2, param3);
+
+	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
+}

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -561,7 +561,12 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.menu_sub_6CC17F = get_relative_call(ff7_externals.menu_sub_705D16, 0x1729);
 
 	ff7_externals.menu_decrease_item_quantity = get_relative_call(ff7_externals.menu_shop_loop, 0x351D);
-	ff7_externals.menu_sub_6CDC09 = get_relative_call(ff7_externals.menu_sub_718DBE, 0x37F);
+
+	uint32_t* pointer_functions_9055A0 = (uint32_t*)get_absolute_value(common_externals.update_field_entities, 0x464);
+	ff7_externals.sub_610973 = pointer_functions_9055A0[128];
+	ff7_externals.sub_60FA7D = get_relative_call(ff7_externals.sub_610973, 0x14);
+	ff7_externals.sub_611098 = pointer_functions_9055A0[130];
+	ff7_externals.sub_60FA7D = get_relative_call(ff7_externals.sub_611098, 0x3A);
 
 	uint32_t menu_sub_6CBD65 = get_relative_call(ff7_externals.menu_sub_6CDA83, 0x54);
 	uint32_t menu_sub_722393 = get_relative_call(menu_sub_6CBD65, 0x4);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -233,6 +233,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	//###############################
 	if(enable_steam_achievements)
 	{
+		// FOR MASTER MATERIA, BATTLE WON, 1ST LIMIT BREAK
 		replace_call_function(ff7_externals.battle_fight_end + 0x25, ff7_battle_fight_fanfare);
 		replace_call_function(ff7_externals.battle_sub_42A0E7 + 0x78, ff7_load_battle_stage);
 
@@ -253,8 +254,9 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		// LAST LIMIT BREAK
 		replace_function(ff7_externals.menu_decrease_item_quantity, ff7_menu_decrease_item_quantity);
 
-		// GOLD CHOCOBO, YUFFIE, VINCENT
-		replace_call_function(ff7_externals.menu_sub_718DBE + 0x37F, ff7_menu_sub_6CDC09);
+		// GOLD CHOCOBO, YUFFIE, VINCENT: called through update_field_entities
+		replace_call_function(ff7_externals.sub_610973 + 0x14, ff7_chocobo_field_entity_60FA7D);
+		replace_call_function(ff7_externals.sub_611098 + 0x3A, ff7_character_regularly_field_entity_60FA7D);
 
 		// INITIALIZATION AT LOAD SAVE FILE
 		replace_call_function(ff7_externals.menu_sub_7212FB + 0xE9D, ff7_load_save_file);


### PR DESCRIPTION
 - Fix Gold Chocobo achievement by checking it when the slots are filled through some function under update_field_entities
 - Fix Yuffie and Vincent achievement by checking it when the regular mask of the two character is modified
 - Add FF7 variables to avoid unlocking some achievement randomly (unlock only when the condition actually switch from false to true)
 - Move ff7_load_save_file function to misc.cpp