### PR TITLE
FF7Achievement: Fix and improve Steam achievements

### DIFF
--- a/src/achievement.h
+++ b/src/achievement.h
@@ -92,16 +92,19 @@ private:
     static inline const byte BAHAMUT_ZERO_MATERIA_ID = 0x58;
     static inline const byte KOTR_MATERIA_ID = 0x59;
 
-    static inline const WORD DIAMOND_WEAPON_START = 980;
-    static inline const WORD DIAMOND_WEAPON_END = 981;
-    static inline const WORD RUBY_WEAPON_START = 982;
-    static inline const WORD RUBY_WEAPON_END = 983;
-    static inline const WORD EMERALD_WEAPON_START = 984;
-    static inline const WORD EMERALD_WEAPON_END = 987;
-    static inline const WORD ULTIMATE_WEAPON_START = 988;
-    static inline const WORD ULTIMATE_WEAPON_END = 991;
+    // took from here https://finalfantasy.fandom.com/wiki/Diamond_Weapon_(Final_Fantasy_VII_boss)#Formations
+    static inline const WORD DIAMOND_WEAPON_SCENE_ID = 980;
+    static inline const WORD RUBY_WEAPON_SCENE_ID = 982;
+    static inline const WORD EMERALD_WEAPON_SCENE_ID = 984;
+    static inline const WORD ULTIMATE_WEAPON_SCENE_ID = 287;
 
     static inline const byte GOLD_CHOCOBO_TYPE = 0x04;
+    static inline const int N_GOLD_CHOCOBO_FIRST_SLOTS = 4;
+    static inline const int N_GOLD_CHOCOBO_LAST_SLOTS = 2;
+
+    static inline const std::string DEATH_OF_AERITH_MOVIE_NAME = "earithdd";
+    static inline const std::string SHINRA_ANNIHILATED_MOVIE_NAME = "hwindjet";
+    static inline const std::string END_OF_GAME_MOVIE_NAME = "ending3";
 
     SteamManager steamManager;
 
@@ -115,7 +118,8 @@ private:
     bool masteredMateria[N_TYPE_MATERIA];
     bool yuffieUnlocked;
     bool vincentUnlocked;
-    bool caitsithLastLimitUnlocked;
+    int caitsithNumKills;
+    bool isGoldChocoboSlot[N_GOLD_CHOCOBO_FIRST_SLOTS + N_GOLD_CHOCOBO_LAST_SLOTS];
 
     bool isYuffieUnlocked(char yuffieRegular);
     bool isVincentUnlocked(char vincentRegular);
@@ -133,11 +137,11 @@ public:
     void unlockBattleSquareAchievement(WORD battle_location_id);
     void unlockGotMateriaAchievement(byte materia_id);
     void unlockMasterMateriaAchievement(savemap_char *characters);
-    void unlockFirstLimitBreakAchievement(savemap_char *characters);
+    void unlockFirstLimitBreakAchievement(unsigned char characterIndex);
     void unlockLastLimitBreakAchievement(WORD item_id);
     void unlockCaitSithLastLimitBreakAchievement(savemap_char *characters);
     void unlockGoldChocoboAchievement(chocobo_slot *firstFourSlots, chocobo_slot *lastTwoSlots);
-    void unlockGameProgressAchievement(int achID);
+    void unlockGameProgressAchievement(std::string movieName);
     void unlockYuffieAndVincentAchievement(savemap *savemap);
 };
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2318,17 +2318,6 @@ uint32_t ff7_get_inserted_cd(void) {
 		break;
 	}
 
-	if(enable_steam_achievements){
-		if (trace_all || trace_achievement)
-			ffnx_trace("CD inserted: %d, CD required: %d\n", insertedCD, requiredCD);
-
-		if(insertedCD == 1 && requiredCD == 2)
-			g_FF7SteamAchievements.unlockGameProgressAchievement(DEATH_OF_AERITH);
-
-		if(insertedCD == 2 && requiredCD == 2)
-			g_FF7SteamAchievements.unlockGameProgressAchievement(SHINRA_ANNIHILATED);
-	}
-
 	if (requiredCD > 0 && requiredCD <= 3) ret = requiredCD;
 
 	insertedCD = ret;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -717,7 +717,7 @@ struct savemap_char
 	char field_20;
 	unsigned char level_progress_bar;
 	WORD learned_limit_break;
-	WORD field_24;
+	WORD num_kills;
 	WORD used_n_limit_1_1;
 	WORD field_28;
 	WORD field_2A;
@@ -1926,9 +1926,8 @@ struct ff7_externals
 	uint32_t battle_sub_5C7F94;
 	uint32_t menu_battle_end_sub_6C9543;
 	uint32_t menu_sub_71FF95, menu_shop_loop, get_materia_gil, menu_sub_6CBCB9;
-	uint32_t credits_main_loop;
-	uint32_t sub_404D80;
 	uint32_t menu_sub_6CC0EA, menu_sub_6CBCF3, menu_sub_705D16, menu_sub_6CC17F;
+	uint32_t battle_sub_5C930F, battle_sub_435139;
 	uint32_t menu_decrease_item_quantity;
 	uint32_t sub_610973, sub_611098;
 	uint32_t sub_60FA7D;

--- a/src/ff7/battle.cpp
+++ b/src/ff7/battle.cpp
@@ -35,14 +35,6 @@ void magic_thread_start(void (*func)())
 	func();
 }
 
-void ff7_battle_fight_fanfare()
-{
-	g_FF7SteamAchievements.unlockBattleWonAchievement(*ff7_externals.battle_scene_id);
-	
-	auto original_func = (void (*)()) ff7_externals.battle_fanfare_music;
-	original_func();
-}
-
 void ff7_load_battle_stage(int param_1, int battle_location_id, int **param_3){
 	((void(*)(int, int, int **)) ff7_externals.load_battle_stage)(param_1, battle_location_id, param_3);
 
@@ -50,10 +42,18 @@ void ff7_load_battle_stage(int param_1, int battle_location_id, int **param_3){
 	g_FF7SteamAchievements.unlockBattleSquareAchievement(battle_location_id);
 }
 
-void ff7_battle_sub_5C7F94(int param_1, int param_2){ // TESTED, but not when it truly increase the gil
+void ff7_battle_sub_5C7F94(int param_1, int param_2){
 	((void(*)(int, int)) ff7_externals.battle_sub_5C7F94)(param_1, param_2);
 
 	if (trace_all || trace_achievement)
 		ffnx_trace("%s - trying to unlock achievement for gil\n", __func__);
 	g_FF7SteamAchievements.unlockGilAchievement(ff7_externals.savemap->gil);
+}
+
+void ff7_battle_sub_435139(int param_1, char party_member_index, char param_3, WORD param_4){
+	((void(*)(int, char, char, WORD)) ff7_externals.battle_sub_435139)(param_1, party_member_index, param_3, param_4);
+
+	char characterID = ff7_externals.savemap->party_members[party_member_index];
+	if(ff7_externals.savemap->chars[characterID].current_limit_level == 1)
+		g_FF7SteamAchievements.unlockFirstLimitBreakAchievement(characterID);
 }

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -23,10 +23,10 @@
 
 // battle
 void magic_thread_start(void (*func)());
-void ff7_battle_fight_fanfare();
 void ff7_load_battle_stage(int param_1, int battle_location_id, int **param_3);
 void ff7_battle_sub_5C7F94(int param_1, int param_2);
 void ff7_battle_sub_6DB0EE();
+void ff7_battle_sub_435139(int param_1, char param_2, char param_3, WORD param_4);
 
 // menu
 void ff7_menu_battle_end_sub_6C9543();
@@ -57,7 +57,6 @@ void *ff7_menu_sub_6FAC38(uint32_t param1, uint32_t param2, uint8_t param3, uint
 void ff7_limit_fps();
 void ff7_handle_ambient_playback();
 BOOL ff7_write_save_file(char slot);
-DWORD ff7_sub_404D80();
 int ff7_field_load_models_atoi(const char* str);
 void ff7_chocobo_field_entity_60FA7D(WORD param1, short param2, short param3);
 void ff7_character_regularly_field_entity_60FA7D(WORD param1, short param2, short param3);

--- a/src/ff7/menu.cpp
+++ b/src/ff7/menu.cpp
@@ -28,11 +28,15 @@ void ff7_menu_battle_end_sub_6C9543()
 {
     ((void (*)())ff7_externals.menu_battle_end_sub_6C9543)();
 
+    if(*ff7_externals.menu_battle_end_mode == 0){
+        if (trace_all || trace_achievement)
+            ffnx_trace("%s - trying to unlock achievement for battle won and weapons\n", __func__);
+        g_FF7SteamAchievements.unlockBattleWonAchievement(*ff7_externals.battle_scene_id);
+    }
+
     if(*ff7_externals.menu_battle_end_mode == 1){
         if (trace_all || trace_achievement)
             ffnx_trace("%s - trying to unlock achievement for first limit, cait sith, character level, and master materia\n", __func__);
-        // this could be achieved when the limit break is used, instead in this way it is achieved only after battle ending
-        g_FF7SteamAchievements.unlockFirstLimitBreakAchievement(ff7_externals.savemap->chars);
 
         g_FF7SteamAchievements.unlockCaitSithLastLimitBreakAchievement(ff7_externals.savemap->chars);
         g_FF7SteamAchievements.unlockCharacterLevelAchievement(ff7_externals.savemap->chars);
@@ -56,8 +60,9 @@ int ff7_get_materia_gil(uint32_t materia)
     return materiaGil;
 }
 
+// called when selling an item
 void ff7_menu_sub_6CBCB9(int gilObtained)
-{ // NOT TESTED
+{
     if (ff7_externals.savemap->gil + gilObtained < ff7_externals.savemap->gil)
         ff7_externals.savemap->gil = -1;
     else

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -556,17 +556,6 @@ int ff7_field_load_models_atoi(const char* str)
 // steam achievement hooks
 //#########################
 
-// Replaced this function only in credits main loop
-DWORD ff7_sub_404D80() // NOT TESTED
-{
-	if (trace_all || trace_achievement)
-        ffnx_trace("%s - unlock end of game progress\n", __func__);
-
-	g_FF7SteamAchievements.unlockGameProgressAchievement(END_OF_GAME);
-
-	return ((DWORD(*)()) ff7_externals.sub_404D80)();
-}
-
 int ff7_load_save_file(int param_1){
 	int returnValue = ((int(*)(int))ff7_externals.load_save_file)(param_1);
 	g_FF7SteamAchievements.initStatsFromSaveFile(ff7_externals.savemap);
@@ -583,5 +572,6 @@ void ff7_chocobo_field_entity_60FA7D(WORD param1, short param2, short param3){
 void ff7_character_regularly_field_entity_60FA7D(WORD param1, short param2, short param3){
 	((void(*)(WORD, short, short)) ff7_externals.sub_60FA7D)(param1, param2, param3);
 
-	g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
+	if(param3 & (1 << 0) || param3 & (1 << 2))
+		g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
 }

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -552,8 +552,11 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.get_materia_gil = get_relative_call(ff7_externals.menu_shop_loop, 0x327B);
 	ff7_externals.menu_sub_6CBCB9 = get_relative_call(ff7_externals.menu_shop_loop, 0x353B);
 
-	ff7_externals.credits_main_loop = credits_main_loop;
-	ff7_externals.sub_404D80 = get_relative_call(ff7_externals.credits_main_loop, 0x211);
+	uint32_t battle_sub_435789 = get_relative_call(ff7_externals.battle_loop, 0x3B8);
+	uint32_t battle_sub_435D81 = get_relative_call(battle_sub_435789, 0x505);
+	uint32_t* pointer_functions_8FEE48 = (uint32_t*)get_absolute_value(battle_sub_435D81, 0x80F);
+	ff7_externals.battle_sub_5C930F = pointer_functions_8FEE48[6];
+	ff7_externals.battle_sub_435139 = get_relative_call(ff7_externals.battle_sub_5C930F, 0x86);
 
 	ff7_externals.menu_sub_6CC0EA = get_relative_call(ff7_externals.menu_shop_loop, 0x30FE);
 	ff7_externals.menu_sub_6CBCF3 = get_relative_call(ff7_externals.menu_sub_6CC0EA, 0x43);
@@ -572,6 +575,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	uint32_t menu_sub_722393 = get_relative_call(menu_sub_6CBD65, 0x4);
 	ff7_externals.menu_sub_7212FB = get_relative_call(menu_sub_722393, 0x8B);
 	ff7_externals.load_save_file = get_relative_call(ff7_externals.menu_sub_7212FB, 0xE9D);
+	// --------------------------------
 
 	ff7_externals.field_load_models_atoi = ff7_externals.field_load_models + 0x262;
 }

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -233,18 +233,16 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	//###############################
 	if(enable_steam_achievements)
 	{
-		// FOR MASTER MATERIA, BATTLE WON, 1ST LIMIT BREAK
-		replace_call_function(ff7_externals.battle_fight_end + 0x25, ff7_battle_fight_fanfare);
+		// BATTLE SQUARE
 		replace_call_function(ff7_externals.battle_sub_42A0E7 + 0x78, ff7_load_battle_stage);
 
-		// GIL
+		// GIL, MASTER MATERIA, BATTLE WON, 1ST LIMIT BREAK
 		replace_call_function(ff7_externals.battle_enemy_killed_sub_433BD2 + 0x2AF, ff7_battle_sub_5C7F94); 
 		replace_call_function(ff7_externals.menu_sub_6CDA83 + 0x20, ff7_menu_battle_end_sub_6C9543);
 		replace_call_function(ff7_externals.menu_shop_loop + 0x327B, ff7_get_materia_gil);
 		replace_function(ff7_externals.menu_sub_6CBCB9, ff7_menu_sub_6CBCB9);
 
-		// GAME PROGRESS
-		replace_call_function(ff7_externals.credits_main_loop + 0x211, ff7_sub_404D80);
+		replace_call_function(ff7_externals.battle_sub_5C930F + 0x86, ff7_battle_sub_435139);
 
 		// MATERIA GOT
 		replace_call_function(ff7_externals.menu_sub_6CC0EA + 0x43, ff7_menu_sub_6CBCF3);

--- a/src/movies.cpp
+++ b/src/movies.cpp
@@ -29,6 +29,7 @@
 #include "ff7/defs.h"
 #include "video/movies.h"
 #include "redirect.h"
+#include "achievement.h"
 
 // Required by > 15 FPS movies
 bool is_movie_bgfield = false;
@@ -191,6 +192,12 @@ uint32_t ff7_prepare_movie(char *name, uint32_t loop, struct dddevice **dddevice
 	}
 	// ---------------------------
 
+	// FF7 game progress achievement
+	if(enable_steam_achievements){
+		std::string movieName(filename);
+		g_FF7SteamAchievements.unlockGameProgressAchievement(movieName);
+	}
+	
 	return true;
 }
 


### PR DESCRIPTION
 - Fix cait sith last limit achievement by checking the number of kills
 - Fix bug in defeating weapons achievement by moving the check to the battle-end menu since fanfare sound is not played always
 - Fix bug in mastered all materia in case the player takes one of the unmasterable materia
 - Fix game progress achievement by unlocking them when the respective FMV movie plays
 - Improve 1st limit break achievement by checking it during battle (these also unlock when 1-2 limit breaks are used)