### PR TITLE
FF7Achievement: Release

### DIFF
--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -237,8 +237,9 @@ steam_game_userdata = ""
 ###########################
 
 #[STEAM ACHIEVEMENTS EXTENSION]
-# This flag will enable steam overlay and steam achievements (Steam MUST be running on background).
-# Files required: steam_api.dll (version 1.51+) that comes together with FFNx
+# This flag will enable steam overlay and steam achievements (Steam MUST be running and you must be online and 
+# connected to the Internet to unlock achievement).
+# Note: incompatible with mods that change dramatically the gameplay (for example, New Threat mod), use it at your own risk
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 enable_steam_achievements = false
 
@@ -338,6 +339,11 @@ show_error_popup = false
 # Usually useful for debug pruposes. Do not enable otherwise.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 renderer_debug = false
+
+# Enable this flag if you want to go into debug mode for steam achievements (open popup window for achievements).
+# Useful for debug purposes. Do not enable otherwise.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+steam_achievements_debug_mode = false
 
 # Creates a full crashdump file if the game crashes. Useful to be analyzed with WinDbg when reporting issues.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/achievement.h
+++ b/src/achievement.h
@@ -56,6 +56,7 @@ public:
     void init(achievement *achievements, int nAchievements);
 
     bool requestStats();
+    bool showAchievementProgress(int achID, int progressValue, int maxValue);
     bool setAchievement(int achID);
     bool isAchieved(int achID);
     const char* getStringAchievementID(int achID);
@@ -68,50 +69,47 @@ public:
 class SteamAchievementsFF7 
 {
 private:
-    static inline const int N_CHARACTERS = 9;
-    static inline const int N_TYPE_MATERIA = 91;
-    static inline const int N_UNKNOWN_MATERIA = 8;
+    static inline constexpr int N_CHARACTERS = 9;
+    static inline constexpr int N_TYPE_MATERIA = 91;
+    static inline constexpr int N_UNKNOWN_MATERIA = 8;
 
-    static inline const int N_MATERIA_SLOT = 200;
-    static inline const int N_STOLEN_MATERIA_SLOT = 48;
-    static inline const int N_EQUIP_MATERIA_PER_CHARACTER = 16;
-    static inline const WORD BATTLE_SQUARE_LOCATION_ID = 0x0025;
-    static inline const WORD FIRST_LIMIT_BREAK_CODE = 0x0001;
-    static inline const WORD FOURTH_LIMIT_BREAK_CODE = 0x0200;
-    static inline const int GIL_ACHIEVEMENT_VALUE = 99999999;
-    static inline const int TOP_LEVEL_CHARACTER = 99;
+    static inline constexpr int N_MATERIA_SLOT = 200;
+    static inline constexpr int N_STOLEN_MATERIA_SLOT = 48;
+    static inline constexpr int N_EQUIP_MATERIA_PER_CHARACTER = 16;
+    static inline constexpr int GIL_ACHIEVEMENT_VALUE = 99999999;
+    static inline constexpr int TOP_LEVEL_CHARACTER = 99;
 
-    static inline const int YUFFIE_INDEX = 5;
-    static inline const int CAIT_SITH_INDEX = 6;
-    static inline const int VINCENT_INDEX = 7;
-    static inline const byte YOUNG_CLOUD_ID = 0x09;
-    static inline const byte SEPHIROTH_ID = 0x0A;
+    static inline constexpr int YUFFIE_INDEX = 5;
+    static inline constexpr int CAIT_SITH_INDEX = 6;
+    static inline constexpr int VINCENT_INDEX = 7;
+    static inline constexpr byte YOUNG_CLOUD_ID = 0x09;
+    static inline constexpr byte SEPHIROTH_ID = 0x0A;
 
-    static inline const byte MATERIA_EMPTY_SLOT = 0xFF;
-    static inline const int MATERIA_AP_MASTERED = 0xFFFFFF;
-    static inline const byte BAHAMUT_ZERO_MATERIA_ID = 0x58;
-    static inline const byte KOTR_MATERIA_ID = 0x59;
+    static inline constexpr byte MATERIA_EMPTY_SLOT = 0xFF;
+    static inline constexpr int MATERIA_AP_MASTERED = 0xFFFFFF;
+    static inline constexpr byte BAHAMUT_ZERO_MATERIA_ID = 0x58;
+    static inline constexpr byte KOTR_MATERIA_ID = 0x59;
 
     // took from here https://finalfantasy.fandom.com/wiki/Diamond_Weapon_(Final_Fantasy_VII_boss)#Formations
-    static inline const WORD DIAMOND_WEAPON_SCENE_ID = 980;
-    static inline const WORD RUBY_WEAPON_SCENE_ID = 982;
-    static inline const WORD EMERALD_WEAPON_SCENE_ID = 984;
-    static inline const WORD ULTIMATE_WEAPON_SCENE_ID = 287;
+    static inline constexpr WORD DIAMOND_WEAPON_SCENE_ID = 980;
+    static inline constexpr WORD RUBY_WEAPON_SCENE_ID = 982;
+    static inline constexpr WORD EMERALD_WEAPON_SCENE_ID = 984;
+    static inline constexpr WORD ULTIMATE_WEAPON_SCENE_ID = 287;
+    static inline constexpr WORD BATTLE_SQUARE_LOCATION_ID = 0x0025;
 
-    static inline const byte GOLD_CHOCOBO_TYPE = 0x04;
-    static inline const int N_GOLD_CHOCOBO_FIRST_SLOTS = 4;
-    static inline const int N_GOLD_CHOCOBO_LAST_SLOTS = 2;
+    static inline constexpr byte GOLD_CHOCOBO_TYPE = 0x04;
+    static inline constexpr int N_GOLD_CHOCOBO_FIRST_SLOTS = 4;
+    static inline constexpr int N_GOLD_CHOCOBO_LAST_SLOTS = 2;
 
     static inline const std::string DEATH_OF_AERITH_MOVIE_NAME = "earithdd";
     static inline const std::string SHINRA_ANNIHILATED_MOVIE_NAME = "hwindjet";
     static inline const std::string END_OF_GAME_MOVIE_NAME = "ending3";
 
-    SteamManager steamManager;
+    static inline constexpr byte unknownMateriaList[] = {0x16, 0x26, 0x2D, 0x2E, 0x2F, 0x3F, 0x42, 0x43};
+    static inline constexpr byte unmasterableMateriaList[] = {0x11, 0x30, 0x49, 0x5A};
+    static inline constexpr WORD limitBreakItemsID[] = {0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0xFFFF, 0x5D, 0x5E};
 
-    std::vector<int> indexToFirstLimitIndex;
-    std::vector<int> unknownMateriaList;
-    std::vector<int> unmasterableMateriaList;
-    std::vector<int> limitBreakItemsID;
+    SteamManager steamManager;
     
     WORD previousUsedLimitNumber[N_CHARACTERS];
     bool equipMasteredMateriaCharacter[N_CHARACTERS][N_EQUIP_MATERIA_PER_CHARACTER];
@@ -123,26 +121,27 @@ private:
 
     bool isYuffieUnlocked(char yuffieRegular);
     bool isVincentUnlocked(char vincentRegular);
+    void initMateriaMastered(const savemap& savemap);
+    bool isMateriaMastered(uint32_t materia);
+    bool isAllMateriaMastered(const bool masteredMateriaList[]);
 
 public:
     void init();
-    void initStatsFromSaveFile(savemap *savemap);
-    void initCharStatsBeforeBattle(savemap_char *characters);
-    void initMateriaMastered(savemap *savemap);
-    bool isMateriaMastered(uint32_t materia);
-    bool isAllMateriaMastered(bool* masteredMateria);
+    void initStatsFromSaveFile(const savemap& savemap);
+    void initCharStatsBeforeBattle(const savemap_char characters[]);
+    
     void unlockBattleWonAchievement(WORD battleSceneID);
     void unlockGilAchievement(uint32_t gilAmount);
-    void unlockCharacterLevelAchievement(savemap_char *characters);
-    void unlockBattleSquareAchievement(WORD battle_location_id);
-    void unlockGotMateriaAchievement(byte materia_id);
-    void unlockMasterMateriaAchievement(savemap_char *characters);
+    void unlockCharacterLevelAchievement(const savemap_char characters[]);
+    void unlockBattleSquareAchievement(WORD battleLocationID);
+    void unlockGotMateriaAchievement(byte materiaID);
+    void unlockMasterMateriaAchievement(const savemap_char characters[]);
     void unlockFirstLimitBreakAchievement(unsigned char characterIndex);
-    void unlockLastLimitBreakAchievement(WORD item_id);
-    void unlockCaitSithLastLimitBreakAchievement(savemap_char *characters);
-    void unlockGoldChocoboAchievement(chocobo_slot *firstFourSlots, chocobo_slot *lastTwoSlots);
+    void unlockLastLimitBreakAchievement(WORD itemID);
+    void unlockCaitSithLastLimitBreakAchievement(const savemap_char characters[]);
+    void unlockGoldChocoboAchievement(const chocobo_slot firstFourSlots[], const chocobo_slot lastTwoSlots[]);
     void unlockGameProgressAchievement(std::string movieName);
-    void unlockYuffieAndVincentAchievement(savemap *savemap);
+    void unlockYuffieAndVincentAchievement(char yuffieRegMask, char vincentRegMask);
 };
 
 class SteamAchievementsFF8
@@ -181,13 +180,13 @@ enum Achievements
     WON_1ST_BATTLE = 25,
     USE_1ST_LIMIT_CLOUD = 26,
     USE_1ST_LIMIT_BARRET = 27,
-    USE_1ST_LIMIT_VINCENT = 28,
+    USE_1ST_LIMIT_TIFA = 28,
     USE_1ST_LIMIT_AERITH = 29,
-    USE_1ST_LIMIT_CID = 30,
-    USE_1ST_LIMIT_TIFA = 31,
-    USE_1ST_LIMIT_YUFFIE = 32,
-    USE_1ST_LIMIT_REDXIII = 33,
-    USE_1ST_LIMIT_CAITSITH = 34,
+    USE_1ST_LIMIT_REDXIII = 30,
+    USE_1ST_LIMIT_YUFFIE = 31,
+    USE_1ST_LIMIT_CAITSITH = 32,
+    USE_1ST_LIMIT_VINCENT = 33,
+    USE_1ST_LIMIT_CID = 34,
     FIGHT_IN_BATTLE_SQUARE = 35
 };
 
@@ -269,14 +268,15 @@ achievement g_AchievementsFF7[] = {
     _ACH_ID(WON_1ST_BATTLE),
     _ACH_ID(USE_1ST_LIMIT_CLOUD),
     _ACH_ID(USE_1ST_LIMIT_BARRET),
-    _ACH_ID(USE_1ST_LIMIT_VINCENT),
-    _ACH_ID(USE_1ST_LIMIT_AERITH),
-    _ACH_ID(USE_1ST_LIMIT_CID),
     _ACH_ID(USE_1ST_LIMIT_TIFA),
-    _ACH_ID(USE_1ST_LIMIT_YUFFIE),
+    _ACH_ID(USE_1ST_LIMIT_AERITH),
     _ACH_ID(USE_1ST_LIMIT_REDXIII),
+    _ACH_ID(USE_1ST_LIMIT_YUFFIE),
     _ACH_ID(USE_1ST_LIMIT_CAITSITH),
-    _ACH_ID(FIGHT_IN_BATTLE_SQUARE)};
+    _ACH_ID(USE_1ST_LIMIT_VINCENT),
+    _ACH_ID(USE_1ST_LIMIT_CID),
+    _ACH_ID(FIGHT_IN_BATTLE_SQUARE)
+};
 
 achievement g_AchievementsFF8[] = {
     _ACH_ID(UNLOCK_GF_QUEZACOTL),
@@ -323,7 +323,8 @@ achievement g_AchievementsFF8[] = {
     _ACH_ID(DOG_TRICKS),
     _ACH_ID(TOTAL_KILLS_100),
     _ACH_ID(TOTAL_KILLS_1000),
-    _ACH_ID(TOTAL_KILLS_10000)};
+    _ACH_ID(TOTAL_KILLS_10000)
+};
 
 // Global, access to Achievements object
 extern SteamAchievementsFF7 g_FF7SteamAchievements;

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -103,6 +103,7 @@ long ff7_fps_limiter;
 bool ff7_footsteps;
 bool enable_analogue_controls;
 bool enable_steam_achievements;
+bool steam_achievements_debug_mode;
 
 std::vector<std::string> get_string_or_array_of_strings(const toml::node_view<toml::node> &node)
 {
@@ -220,6 +221,7 @@ void read_cfg()
 	ff7_footsteps = config["ff7_footsteps"].value_or(false);
 	enable_analogue_controls = config["enable_analogue_controls"].value_or(false);
 	enable_steam_achievements = config["enable_steam_achievements"].value_or(false);
+	steam_achievements_debug_mode = config["enable_steam_achievements"].value_or(false);
 
 	// Windows x or y size can't be less then 0
 	if (window_size_x < 0) window_size_x = 0;

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -116,5 +116,6 @@ extern long ff7_fps_limiter;
 extern bool ff7_footsteps;
 extern bool enable_analogue_controls;
 extern bool enable_steam_achievements;
+extern bool steam_achievements_debug_mode;
 
 void read_cfg();

--- a/src/ff7/menu.cpp
+++ b/src/ff7/menu.cpp
@@ -129,8 +129,7 @@ uint32_t ff7_menu_decrease_item_quantity(uint32_t item_used)
         local_c = party_item_slots[index];
         item_id = 0;
         party_item_slots[index] = 0xFFFF;
-
-        g_FF7SteamAchievements.unlockLastLimitBreakAchievement(item_used & 0x1FF);
     }
+    g_FF7SteamAchievements.unlockLastLimitBreakAchievement(item_used & 0x1FF);
     return item_id & 0xFFFF0000 | (uint32_t)local_c;
 }

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -558,7 +558,7 @@ int ff7_field_load_models_atoi(const char* str)
 
 int ff7_load_save_file(int param_1){
 	int returnValue = ((int(*)(int))ff7_externals.load_save_file)(param_1);
-	g_FF7SteamAchievements.initStatsFromSaveFile(ff7_externals.savemap);
+	g_FF7SteamAchievements.initStatsFromSaveFile(*ff7_externals.savemap);
 	return returnValue;
 }
 
@@ -573,5 +573,5 @@ void ff7_character_regularly_field_entity_60FA7D(WORD param1, short param2, shor
 	((void(*)(WORD, short, short)) ff7_externals.sub_60FA7D)(param1, param2, param3);
 
 	if(param3 & (1 << 0) || param3 & (1 << 2))
-		g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap);
+		g_FF7SteamAchievements.unlockYuffieAndVincentAchievement(ff7_externals.savemap->yuffie_reg_mask, ff7_externals.savemap->vincent_reg_mask);
 }


### PR DESCRIPTION
 - Allow unlocking last limit break achievement even when the item quantity is greater than 1
 - Refactor FF7 steam achievement using constexpr and const reference parameters when possible
 - Reorder FF7 achievement list to avoid using a list for swapping indices
 - Add show achievement progress for materia overlord achievement
 - Add debug flag in cfg for the future release of steam achievements