### PR TITLE
FF7Achievement: Fix game progress achievement

### DIFF
--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -175,7 +175,7 @@ void SteamManager::OnAchievementStored(UserAchievementStored_t *pCallback)
 void SteamAchievementsFF7::init()
 {
     this->steamManager.init(g_AchievementsFF7, FF7_N_ACHIEVEMENTS);
-    this->movieName = INVALID_MOVIE_NAME;
+    this->lastSeenMovieName = INVALID_MOVIE_NAME;
 }
 
 void SteamAchievementsFF7::initStatsFromSaveFile(const savemap& savemap){
@@ -187,6 +187,7 @@ void SteamAchievementsFF7::initStatsFromSaveFile(const savemap& savemap){
     for (int i = 0; i < N_GOLD_CHOCOBO_LAST_SLOTS; i++)
         this->isGoldChocoboSlot[i + N_GOLD_CHOCOBO_FIRST_SLOTS] = savemap.chocobo_slots_last[i].type == GOLD_CHOCOBO_TYPE;
 
+    this->lastSeenMovieName = INVALID_MOVIE_NAME;
     this->initMateriaMastered(savemap);
 
     if (trace_all || trace_achievement){
@@ -219,7 +220,7 @@ void SteamAchievementsFF7::initMovieStats(const string movieName){
     if (trace_all || trace_achievement)
         ffnx_trace("%s - the movie name initialized is: %s\n", __func__, movieName.c_str());
 
-    this->movieName = std::move(movieName);
+    this->lastSeenMovieName = std::move(movieName);
 }
 
 void SteamAchievementsFF7::initMateriaMastered(const savemap& savemap)
@@ -297,6 +298,10 @@ bool SteamAchievementsFF7::isYuffieUnlocked(char yuffieRegular){
 bool SteamAchievementsFF7::isVincentUnlocked(char vincentRegular){
     // took from https://github.com/sithlord48/ff7tk/blob/master/src/data/FF7Save.cpp#L4799
     return vincentRegular & (1 << 2);
+}
+
+string SteamAchievementsFF7::getLastSeenMovieName(){
+    return this->lastSeenMovieName;
 }
 
 void SteamAchievementsFF7::unlockBattleWonAchievement(WORD battleSceneID)
@@ -489,27 +494,20 @@ void SteamAchievementsFF7::unlockGoldChocoboAchievement(const chocobo_slot first
 
 void SteamAchievementsFF7::unlockGameProgressAchievement()
 {
-    if (this->movieName.compare(INVALID_MOVIE_NAME) == 0){
-        ffnx_error("%s - trying to unlock game progress achievement but there is no movie name initialized\n", __func__);
-        return;
-    }
-
     if (trace_all || trace_achievement)
-        ffnx_trace("%s - trying to unlock game progress achievement (movieName: %s)\n", __func__, this->movieName.c_str());
+        ffnx_trace("%s - trying to unlock game progress achievement (movieName: %s)\n", __func__, this->lastSeenMovieName.c_str());
 
-    if (!(this->steamManager.isAchieved(DEATH_OF_AERITH)) && this->movieName.compare(DEATH_OF_AERITH_MOVIE_NAME) == 0)
+    if (!(this->steamManager.isAchieved(DEATH_OF_AERITH)) && this->lastSeenMovieName == DEATH_OF_AERITH_MOVIE_NAME)
         this->steamManager.setAchievement(DEATH_OF_AERITH);
 
-    if (!(this->steamManager.isAchieved(SHINRA_ANNIHILATED)) && this->movieName.compare(SHINRA_ANNIHILATED_MOVIE_NAME) == 0)
+    if (!(this->steamManager.isAchieved(SHINRA_ANNIHILATED)) && this->lastSeenMovieName == SHINRA_ANNIHILATED_MOVIE_NAME)
         this->steamManager.setAchievement(SHINRA_ANNIHILATED);
 
-    if (!(this->steamManager.isAchieved(END_OF_GAME)) && this->movieName.compare(END_OF_GAME_MOVIE_NAME) == 0)
+    if (!(this->steamManager.isAchieved(END_OF_GAME)) && this->lastSeenMovieName == END_OF_GAME_MOVIE_NAME)
         this->steamManager.setAchievement(END_OF_GAME);
-
-    this->movieName = INVALID_MOVIE_NAME;
 }
 
-void SteamAchievementsFF7::unlockYuffieAndVincentAchievement(char yuffieRegMask, char vincentRegMask)
+void SteamAchievementsFF7::unlockYuffieAndVincentAchievement(unsigned char yuffieRegMask, unsigned char vincentRegMask)
 {
     if (trace_all || trace_achievement)
         ffnx_trace("%s - trying to unlock yuffie and vincent achievement (yuffie_reg: 0x%02x, vincent_reg: 0x%02x)\n",

--- a/src/achievement.h
+++ b/src/achievement.h
@@ -101,11 +101,6 @@ private:
     static inline constexpr int N_GOLD_CHOCOBO_FIRST_SLOTS = 4;
     static inline constexpr int N_GOLD_CHOCOBO_LAST_SLOTS = 2;
 
-    static inline const std::string DEATH_OF_AERITH_MOVIE_NAME = "earithdd";
-    static inline const std::string SHINRA_ANNIHILATED_MOVIE_NAME = "hwindjet";
-    static inline const std::string END_OF_GAME_MOVIE_NAME = "ending3";
-    static inline const std::string INVALID_MOVIE_NAME = "";
-
     static inline constexpr byte unknownMateriaList[] = {0x16, 0x26, 0x2D, 0x2E, 0x2F, 0x3F, 0x42, 0x43};
     static inline constexpr byte unmasterableMateriaList[] = {0x11, 0x30, 0x49, 0x5A};
     static inline constexpr WORD limitBreakItemsID[] = {0x57, 0x58, 0x59, 0x5A, 0x5B, 0x5C, 0xFFFF, 0x5D, 0x5E};
@@ -121,7 +116,7 @@ private:
     bool vincentUnlocked;
     int caitsithNumKills;
     bool isGoldChocoboSlot[N_GOLD_CHOCOBO_FIRST_SLOTS + N_GOLD_CHOCOBO_LAST_SLOTS];
-    std::string movieName;
+    std::string lastSeenMovieName;
 
     bool isYuffieUnlocked(char yuffieRegular);
     bool isVincentUnlocked(char vincentRegular);
@@ -130,10 +125,17 @@ private:
     bool isAllMateriaMastered(const bool masteredMateriaList[]);
 
 public:
+    static inline const std::string DEATH_OF_AERITH_MOVIE_NAME = "earithdd";
+    static inline const std::string SHINRA_ANNIHILATED_MOVIE_NAME = "hwindjet";
+    static inline const std::string END_OF_GAME_MOVIE_NAME = "ending2";
+    static inline const std::string INVALID_MOVIE_NAME = "";
+
     void init();
     void initStatsFromSaveFile(const savemap& savemap);
     void initCharStatsBeforeBattle(const savemap_char characters[]);
     void initMovieStats(const std::string movieName);
+
+    std::string getLastSeenMovieName();
     
     void unlockBattleWonAchievement(WORD battleSceneID);
     void unlockGilAchievement(uint32_t gilAmount);
@@ -146,7 +148,7 @@ public:
     void unlockCaitSithLastLimitBreakAchievement(const savemap_char characters[]);
     void unlockGoldChocoboAchievement(const chocobo_slot firstFourSlots[], const chocobo_slot lastTwoSlots[]);
     void unlockGameProgressAchievement();
-    void unlockYuffieAndVincentAchievement(char yuffieRegMask, char vincentRegMask);
+    void unlockYuffieAndVincentAchievement(unsigned char yuffieRegMask, unsigned char vincentRegMask);
 };
 
 class SteamAchievementsFF8

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2318,6 +2318,10 @@ uint32_t ff7_get_inserted_cd(void) {
 		break;
 	}
 
+	if(enable_steam_achievements)
+		if(insertedCD != requiredCD)
+			g_FF7SteamAchievements.unlockGameProgressAchievement();
+
 	if (requiredCD > 0 && requiredCD <= 3) ret = requiredCD;
 
 	insertedCD = ret;

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -416,9 +416,6 @@ bool ff7_skip_movies()
 				ff7_externals.play_midi(2);
 		}
 
-		if(enable_steam_achievements)
-			g_FF7SteamAchievements.unlockGameProgressAchievement();
-
 		return true;
 	}
 

--- a/src/movies.cpp
+++ b/src/movies.cpp
@@ -222,7 +222,8 @@ retry:
 		ff7_externals.movie_object->movie_end = 1;
 
 		if(enable_steam_achievements)
-			g_FF7SteamAchievements.unlockGameProgressAchievement();
+			if(g_FF7SteamAchievements.getLastSeenMovieName() == SteamAchievementsFF7::END_OF_GAME_MOVIE_NAME)
+				g_FF7SteamAchievements.unlockGameProgressAchievement();
 
 		return true;
 	}


### PR DESCRIPTION
This improves the end part 1 and end part 2 achievement since they will show after the menu screen of END PART (in which it allows you to save the game). For the end of game achievement, it has been moved to the end of "ending2" movie because the last movie ("ending3") is just before the game exiting which might avoid activating the achievement since it is not a sync call (unlocking the achievement at skip movies has been removed because the "ending2" movie cannot be skipped)
 - Unlock end part 1 and 2 achievement through cd check after seen the respective last movie of each part
 - Unlock end of game achievement on ending2 movie which is the one before the list of credits