### PR TITLE
FF7Achievement: Fix debug flag bug and avoid steam_appid.txt for steam edition

### DIFF
--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -221,7 +221,7 @@ void read_cfg()
 	ff7_footsteps = config["ff7_footsteps"].value_or(false);
 	enable_analogue_controls = config["enable_analogue_controls"].value_or(false);
 	enable_steam_achievements = config["enable_steam_achievements"].value_or(false);
-	steam_achievements_debug_mode = config["enable_steam_achievements"].value_or(false);
+	steam_achievements_debug_mode = config["steam_achievements_debug_mode"].value_or(false);
 
 	// Windows x or y size can't be less then 0
 	if (window_size_x < 0) window_size_x = 0;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -453,12 +453,14 @@ int common_create_window(HINSTANCE hInstance, struct game_obj* game_object)
 	RECT Rect;
 
 	// Init Steam API
-	if(enable_steam_achievements)
+	if(steam_edition || enable_steam_achievements)
 	{	
-		// generate automatically steam_appid.txt file
-		std::ofstream steam_appid_file("steam_appid.txt");
-		steam_appid_file << ((ff8) ? FF8_APPID : FF7_APPID);
-		steam_appid_file.close();
+		// generate automatically steam_appid.txt
+		if(!steam_edition){
+			std::ofstream steam_appid_file("steam_appid.txt");
+			steam_appid_file << ((ff8) ? FF8_APPID : FF7_APPID);
+			steam_appid_file.close();
+		}
 
 		if (SteamAPI_RestartAppIfNecessary((ff8) ? FF8_APPID : FF7_APPID))
 		{
@@ -700,7 +702,7 @@ void common_cleanup(struct game_obj *game_object)
 	if(trace_all) ffnx_trace("dll_gfx: cleanup\n");
 
 	// Shutdown Steam API
-	if(enable_steam_achievements)
+	if(steam_edition || enable_steam_achievements)
 		SteamAPI_Shutdown();
 
 	if (steam_edition)
@@ -959,7 +961,7 @@ void common_flip(struct game_obj *game_object)
 	}
 
 	// Steamworks SDK API run callbacks
-	if(enable_steam_achievements)
+	if(steam_edition || enable_steam_achievements)
 		SteamAPI_RunCallbacks();
 
 }
@@ -2318,7 +2320,7 @@ uint32_t ff7_get_inserted_cd(void) {
 		break;
 	}
 
-	if(enable_steam_achievements)
+	if(steam_edition || enable_steam_achievements)
 		if(insertedCD != requiredCD)
 			g_FF7SteamAchievements.unlockGameProgressAchievement();
 

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -231,7 +231,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	//###############################
 	// steam achievement unlock calls
 	//###############################
-	if(enable_steam_achievements)
+	if(steam_edition || enable_steam_achievements)
 	{
 		// BATTLE SQUARE
 		replace_call_function(ff7_externals.battle_sub_42A0E7 + 0x78, ff7_load_battle_stage);

--- a/src/movies.cpp
+++ b/src/movies.cpp
@@ -192,7 +192,7 @@ uint32_t ff7_prepare_movie(char *name, uint32_t loop, struct dddevice **dddevice
 	}
 	// ---------------------------
 
-	if(enable_steam_achievements)
+	if(steam_edition || enable_steam_achievements)
 		g_FF7SteamAchievements.initMovieStats(std::string(filename));
 	
 	return true;
@@ -221,7 +221,7 @@ retry:
 
 		ff7_externals.movie_object->movie_end = 1;
 
-		if(enable_steam_achievements)
+		if(steam_edition || enable_steam_achievements)
 			if(g_FF7SteamAchievements.isEndingMovie())
 				g_FF7SteamAchievements.unlockGameProgressAchievement();
 


### PR DESCRIPTION
I've seen that steam_appid.txt is useless if run as steam edition. I also thought to activate steam achievements on steam edition directly (w/o looking at the flag in toml file), but maybe it is too soon.