### PR TITLE
[ IDEA ] Refactor externals functions

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -250,6 +250,27 @@ struct common_externals
 	uint32_t update_entities_call;
 };
 
+template <typename T>
+struct external_fn;
+
+template<typename R, typename... Args>
+struct external_fn<R(Args...)>{
+	uint32_t address;
+
+	operator uint32_t() const {
+		return address;
+	}
+
+	external_fn<R(Args...)>& operator=(uint32_t address){
+		this->address = address;
+		return *this;
+	}
+
+	R call(Args... args) const {
+		return (reinterpret_cast<R(*)(Args...)>(address))(std::forward<Args>(args)...);
+	}
+};
+
 // heap allocation wrappers
 // driver_* functions are to be used for data internal to the driver, memory which is never allocated or free'd by the game
 // external_* functions must be used for memory which could be allocated or free'd by the game

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1905,7 +1905,7 @@ struct ff7_externals
 	uint32_t sub_74DB8C;
 	void (*sub_767039)(DWORD*,DWORD*,DWORD*);
 	uint32_t play_battle_music_call;
-	uint32_t (*play_battle_end_music)();
+	external_fn<uint32_t()> play_battle_end_music;
 	uint32_t play_battle_music_win_call;
 	uint32_t wm_change_music;
 	uint32_t wm_play_music_call;
@@ -1925,14 +1925,15 @@ struct ff7_externals
 	uint32_t battle_enemy_killed_sub_433BD2;
 	uint32_t battle_sub_5C7F94;
 	uint32_t menu_battle_end_sub_6C9543;
-	uint32_t menu_sub_71FF95, menu_shop_loop, get_materia_gil, menu_sub_6CBCB9;
+	uint32_t menu_sub_71FF95, menu_shop_loop, get_materia_gil;
+	external_fn<void(int)> menu_sub_6CBCB9;
 	uint32_t menu_sub_6CC0EA, menu_sub_6CBCF3, menu_sub_705D16, menu_sub_6CC17F;
 	uint32_t battle_sub_5C930F, battle_sub_435139;
 	uint32_t menu_decrease_item_quantity;
 	uint32_t sub_610973, sub_611098;
 	uint32_t sub_60FA7D;
 	uint32_t menu_sub_7212FB;
-	uint32_t load_save_file;
+	external_fn<int(int)> load_save_file;
 	uint32_t field_load_models_atoi;
 };
 

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -557,7 +557,7 @@ int ff7_field_load_models_atoi(const char* str)
 //#########################
 
 int ff7_load_save_file(int param_1){
-	int returnValue = ((int(*)(int))ff7_externals.load_save_file)(param_1);
+	int returnValue = ff7_externals.load_save_file.call(param_1);
 	g_FF7SteamAchievements.initStatsFromSaveFile(*ff7_externals.savemap);
 	return returnValue;
 }

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -196,7 +196,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	common_externals.destroy_tex_header = get_relative_call((uint32_t)common_externals.destroy_tex, 0x78);
 
 	ff7_externals.play_battle_music_call = main_loop + 0x300;
-	ff7_externals.play_battle_end_music = (uint32_t(*)())get_relative_call(ff7_externals.battle_fanfare_music, 0x21);
+	ff7_externals.play_battle_end_music = get_relative_call(ff7_externals.battle_fanfare_music, 0x21);
 	ff7_externals.play_battle_music_win_call = ff7_externals.battle_fanfare_music + 0x21;
 	ff7_externals.battle_sub_42A0E7 = get_relative_call(ff7_externals.battle_sub_429AC0, 0xA4);
 	ff7_externals.load_battle_stage = get_relative_call(ff7_externals.battle_sub_42A0E7, 0x78);

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -491,7 +491,7 @@ uint32_t ff7_battle_music_fanfare()
 
 	next_music_channel = 1;
 
-	uint32_t ret = ff7_externals.play_battle_end_music();
+	uint32_t ret = ff7_externals.play_battle_end_music.call();
 
 	next_music_channel = 0;
 


### PR DESCRIPTION
I thought of doing something for all the double declaration and type casting of externals. I just put an example with load_save_file function and another one. These are the advantages and disadvantages that I thought about.
- \+ Avoid all the type casting
- \+ No change in ff7_data.h about get_relative_call() or others.
- \+ The type checking of the compiler still works for the external functions arguments (even the IDE sees it)
-  \- Might increase significantly the compilation time due to the templateù

What do you think? Is it useful? Worth it?