### PR TITLE
GameHacks: Add auto attack hack for FF7 battles (L2 + R3 or CTRL + A)

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1961,6 +1961,15 @@ struct ff7_externals
 	uint32_t sub_60FA7D;
 	uint32_t menu_sub_7212FB;
 	uint32_t load_save_file;
+	uint32_t handle_actor_ready;
+	WORD* battle_menu_state;
+	uint32_t set_battle_menu_state_data;
+	uint32_t dispatch_chosen_battle_action;
+	uint32_t set_battle_targeting_data;
+	uint16_t* issued_action_id;
+	byte* issued_command_id;
+	byte* issued_action_target_type;
+	byte* issued_action_target_index;
 	uint32_t field_load_models_atoi;
 };
 

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -25,7 +25,7 @@
 void magic_thread_start(void (*func)());
 void ff7_load_battle_stage(int param_1, int battle_location_id, int **param_3);
 void ff7_battle_sub_5C7F94(int param_1, int param_2);
-void ff7_battle_sub_6DB0EE();
+
 void ff7_battle_set_command_and_action_id(short command_id, short action_id);
 
 // menu
@@ -37,6 +37,8 @@ byte ff7_menu_sub_6CBCF3(uint32_t materia_id);
 void ff7_menu_sub_6CC17F(uint32_t materia);
 uint32_t ff7_menu_decrease_item_quantity(uint32_t item_data);
 void ff7_menu_sub_6CDC09(DWORD param_1);
+void ff7_battle_menu_sub_6DB0EE();
+void ff7_set_battle_menu_state_data_at_full_atb(short param_1, short param_2, short menu_state);
 
 // misc
 uint32_t get_equipment_stats(uint32_t party_index, uint32_t type);

--- a/src/ff7/menu.cpp
+++ b/src/ff7/menu.cpp
@@ -23,6 +23,7 @@
 #include "../ff7.h"
 #include "../log.h"
 #include "../achievement.h"
+#include "../gamehacks.h"
 
 void ff7_menu_battle_end_sub_6C9543()
 {
@@ -132,4 +133,28 @@ uint32_t ff7_menu_decrease_item_quantity(uint32_t item_used)
     }
     g_FF7SteamAchievements->unlockLastLimitBreakAchievement(item_used & 0x1FF);
     return item_id & 0xFFFF0000 | (uint32_t)local_c;
+}
+
+void dispatchAttackCommand(){
+    *ff7_externals.issued_command_id = 0x01;
+    *ff7_externals.issued_action_target_type = 0;
+    *ff7_externals.issued_action_target_index = 4;
+    ((void(*)())ff7_externals.dispatch_chosen_battle_action)();
+}
+
+void ff7_battle_menu_sub_6DB0EE(){
+    ((void(*)())ff7_externals.battle_sub_6DB0EE)();
+    if(gamehacks.isAutoAttack() && (*ff7_externals.battle_menu_state >= 0 && *ff7_externals.battle_menu_state < 19)){
+        dispatchAttackCommand();
+    }
+}
+
+void ff7_set_battle_menu_state_data_at_full_atb(short param_1, short param_2, short menu_state){
+    if(gamehacks.isAutoAttack())
+    {
+        dispatchAttackCommand();
+    }
+    else{
+        ((void(*)(short, short, short))ff7_externals.set_battle_menu_state_data)(param_1, param_2, menu_state);
+    }
 }

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -540,6 +540,18 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 
 	ff7_externals.field_current_actor = (struct ff7_field_ad_object*)get_absolute_value(common_externals.execute_opcode_table[0xA8], 0x1C6);
 
+	// auto attack gamehacks
+	ff7_externals.handle_actor_ready = ff7_externals.battle_limit_breaks[0];
+	ff7_externals.battle_menu_state = (WORD*)get_absolute_value(ff7_externals.handle_actor_ready, 0x17B);
+	ff7_externals.set_battle_menu_state_data = get_relative_call(ff7_externals.handle_actor_ready, 0x187);
+	ff7_externals.dispatch_chosen_battle_action = get_relative_call(ff7_externals.battle_sub_6DB0EE, 0x50E);
+	ff7_externals.set_battle_targeting_data = get_relative_call(ff7_externals.battle_limit_breaks[19], 0x11A);
+	ff7_externals.issued_command_id = (byte*)get_absolute_value(ff7_externals.dispatch_chosen_battle_action, 0x12B);
+	ff7_externals.issued_action_id = (uint16_t*)get_absolute_value(ff7_externals.dispatch_chosen_battle_action, 0x122);
+	ff7_externals.issued_action_target_type = (byte*)get_absolute_value(ff7_externals.set_battle_targeting_data, 0x14E);
+	ff7_externals.issued_action_target_index = (byte*)get_absolute_value(ff7_externals.set_battle_targeting_data, 0x164);
+	// --------------------------------
+
 	//ff7 achievement related externals
 	uint32_t sub_434347 = get_relative_call(ff7_externals.battle_loop, 0x484);
 	uint32_t* pointer_functions_7C2980 = (uint32_t*)get_absolute_value(sub_434347, 0x19C);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -197,6 +197,12 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	replace_call_function(ff7_externals.worldmap_battle_toggle, ff7_toggle_battle_worldmap);
 
 	// #####################
+	// auto attack toggle
+	// #####################
+	replace_call_function(ff7_externals.battle_sub_6CE8B3 + 0xD9, ff7_battle_menu_sub_6DB0EE);
+	replace_call_function(ff7_externals.handle_actor_ready + 0x187, ff7_set_battle_menu_state_data_at_full_atb);
+
+	// #####################
 	// gamepad
 	// #####################
 	replace_function(ff7_externals.get_gamepad, ff7_get_gamepad);

--- a/src/gamehacks.cpp
+++ b/src/gamehacks.cpp
@@ -71,6 +71,15 @@ void GameHacks::toggleBattleMode()
 	holdInput();
 }
 
+void GameHacks::toggleAutoAttackMode()
+{
+	auto_attack_mode = !auto_attack_mode;
+
+	show_popup_msg(TEXTCOLOR_LIGHT_BLUE, "Auto attack mode: %s", auto_attack_mode ? "ENABLED" : "DISABLED");
+
+	holdInput();
+}
+
 void GameHacks::skipMovies()
 {
 	if (!ff8)
@@ -122,6 +131,9 @@ void GameHacks::processKeyboardInput(UINT msg, WPARAM wParam, LPARAM lParam)
 		{
 			switch (wParam)
 			{
+			case 'A':
+				toggleAutoAttackMode();
+				break;
 			case 'B':
 				toggleBattleMode();
 				break;
@@ -191,6 +203,12 @@ void GameHacks::processGamepadInput()
 			ff7_externals.gamepad_status->button12
 			)
 			toggleBattleMode();
+		// Toggle auto attack mode on L2+R3
+		else if (
+			ff7_externals.gamepad_status->button7 &&
+			ff7_externals.gamepad_status->button12
+			)
+			toggleAutoAttackMode();
 		// Skip Movies on SELECT+START
 		else if (
 			ff7_externals.gamepad_status->button9 &&
@@ -251,6 +269,11 @@ double GameHacks::getCurrentSpeedhack()
 bool GameHacks::wantsBattle()
 {
 	return battle_wanted;
+}
+
+bool GameHacks::isAutoAttack()
+{
+	return auto_attack_mode;
 }
 
 void GameHacks::holdInput()

--- a/src/gamehacks.h
+++ b/src/gamehacks.h
@@ -30,6 +30,7 @@ private:
 	bool speedhack_enabled;
 	double speedhack_current_speed;
 	bool battle_wanted = true;
+	bool auto_attack_mode = false;
 
 	// SPEEDHACK
 	void toggleSpeedhack();
@@ -39,6 +40,7 @@ private:
 
 	// BATTLE
 	void toggleBattleMode();
+	void toggleAutoAttackMode();
 
 	// MOVIES
 	void skipMovies();
@@ -62,6 +64,7 @@ public:
 
 	// BATTLE
 	bool wantsBattle();
+	bool isAutoAttack();
 
 	// INPUT VALIDATION
 	bool canInputBeProcessed();


### PR DESCRIPTION
Add a new game hack for FF7 that enables auto attack mode. Each character will attack the 1st enemy. It can be activated outside battle and in-battle; even during the battle menu selection. 