### PR TITLE
Support of correct camera speed at 60 FPS

### DIFF
--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -408,6 +408,10 @@ trace_gamepad = false
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 trace_achievement = false
 
+# trace_battle_camera - Dump in the logs only APIs that has to do with battle camera
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+trace_battle_camera = false
+
 # vertex_log - Dump in the logs current engine vertex data being passed to the GPU for drawing
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 vertex_log = false

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -60,6 +60,7 @@ bool trace_voice;
 bool trace_ambient;
 bool trace_gamepad;
 bool trace_achievement;
+bool trace_battle_camera;
 bool vertex_log;
 bool uniform_log;
 bool show_renderer_backend;
@@ -178,6 +179,7 @@ void read_cfg()
 	trace_ambient = config["trace_ambient"].value_or(false);
 	trace_gamepad = config["trace_gamepad"].value_or(false);
 	trace_achievement = config["trace_achievement"].value_or(false);
+	trace_battle_camera = config["trace_battle_camera"].value_or(false);
 	vertex_log = config["vertex_log"].value_or(false);
 	uniform_log = config["uniform_log"].value_or(false);
 	show_renderer_backend = config["show_renderer_backend"].value_or(true);

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -73,6 +73,7 @@ extern bool trace_voice;
 extern bool trace_ambient;
 extern bool trace_gamepad;
 extern bool trace_achievement;
+extern bool trace_battle_camera;
 extern bool vertex_log;
 extern bool uniform_log;
 extern bool show_renderer_backend;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -560,6 +560,32 @@ struct battle_actor_data
 	uint32_t field_54_others[206];
 };
 
+#pragma pack(1)
+struct battle_camera_position{
+	WORD location_x;
+	WORD location_y;
+	WORD location_z;
+	WORD unused;
+	WORD current_position;
+	WORD frames_to_wait;
+	byte field_C;
+	byte field_D;
+};
+
+#pragma pack(1)
+struct battle_camera_fn_data{
+	WORD field_1;
+	WORD field_2; 
+	WORD field_3; 
+	WORD field_4; 
+	WORD field_5;
+	WORD field_6;
+	DWORD field_7;
+	DWORD unused_1;
+	byte index;
+	byte unused_2[19];
+};
+
 struct battle_chdir_struc
 {
 	uint32_t sucess;
@@ -1971,6 +1997,22 @@ struct ff7_externals
 	byte* issued_action_target_type;
 	byte* issued_action_target_index;
 	uint32_t field_load_models_atoi;
+	battle_camera_fn_data* battle_camera_data;
+	battle_camera_position* battle_camera_position_BE10F0;
+	battle_camera_position* battle_camera_position_BE1130;
+	uint32_t* camera_fn_array;
+	uint32_t handle_camera_functions;
+	uint32_t battle_camera_sub_5C3FD5;
+	uint32_t battle_camera_sub_5C23D1;
+	uint32_t add_fn_to_camera_fn_array;
+	uint32_t execute_camera_functions;
+	byte* battle_camera_scripts_8FEE30;
+	byte* battle_camera_scripts_8FEE2C;
+	DWORD* battle_camera_scripts_9A13BC;
+	DWORD* battle_camera_scripts_9010D0;
+	DWORD* battle_camera_scripts_901270;
+	byte* battle_camera_script_index;
+	DWORD* battle_camera_script_offset;
 };
 
 uint32_t ff7gl_load_group(uint32_t group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7/camera.cpp
+++ b/src/ff7/camera.cpp
@@ -1,0 +1,217 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 myst6re                                            //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//    Copyright (C) 2020 John Pritchard                                     //
+//    Copyright (C) 2021 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2021 Tang-Tang Zhou                                     //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#include <unordered_set>
+#include <unordered_map>
+#include <utility>
+
+#include "../ff7.h"
+#include "../log.h"
+
+bool isSpecialCameraFunction[16];
+std::unordered_set<DWORD> scriptArgAddressPatched;
+
+void patchCameraScriptArg(byte *scriptPointer, byte position)
+{
+    if (scriptArgAddressPatched.find((DWORD)(scriptPointer + position)) == scriptArgAddressPatched.end())
+    {
+        byte beforeValue = scriptPointer[position];
+        scriptPointer[position] = scriptPointer[position] * 2;
+
+        if (((short)beforeValue) * 2 != scriptPointer[position])
+            ffnx_error("Script arg multiplication out of bound at 0x%x: before is %d, after is %d\n", (DWORD)(scriptPointer + position),
+                       beforeValue, scriptPointer[position]);
+    }
+
+    scriptArgAddressPatched.insert((DWORD)(scriptPointer + position));
+}
+
+byte *getCameraScriptPointer(char variationIndex, short cameraScriptIdx, bool isSub5C3FD5)
+{
+    int internalOffset = isSub5C3FD5 ? 4 : 0;
+    if (cameraScriptIdx == -1)
+        return isSub5C3FD5 ? ff7_externals.battle_camera_scripts_8FEE30 : ff7_externals.battle_camera_scripts_8FEE2C;
+    else if (cameraScriptIdx == -2)
+        return isSub5C3FD5 ? (byte *)ff7_externals.battle_camera_scripts_901270[*ff7_externals.battle_camera_script_index] : (byte *)ff7_externals.battle_camera_scripts_9010D0[*ff7_externals.battle_camera_script_index];
+    else if (cameraScriptIdx == -3)
+    {
+        int outerOffset = variationIndex * 4 + *(int *)(*ff7_externals.battle_camera_scripts_9A13BC + 0x8 + internalOffset) - *ff7_externals.battle_camera_script_offset;
+        int finalOffset = *(int *)(*ff7_externals.battle_camera_scripts_9A13BC + outerOffset) - *ff7_externals.battle_camera_script_offset;
+        return (byte *)(*ff7_externals.battle_camera_scripts_9A13BC + finalOffset);
+    }
+    int outerOffset = (3 * cameraScriptIdx + variationIndex) * 4 + *(int *)(*ff7_externals.battle_camera_scripts_9A13BC + internalOffset) - *ff7_externals.battle_camera_script_offset;
+    int finalOffset = *(int *)(*ff7_externals.battle_camera_scripts_9A13BC + outerOffset) - *ff7_externals.battle_camera_script_offset;
+    return (byte *)(*ff7_externals.battle_camera_scripts_9A13BC + finalOffset);
+}
+
+std::pair<uint16_t, uint16_t> simulateCameraScript(byte *scriptPtr, uint16_t currentPosition, uint16_t framesToWait, std::unordered_map<byte, int> &numArgsOpCode,
+                                                   std::unordered_map<byte, int> &argIdxDoubleOpCode, std::unordered_set<byte> &deactiveOpCodes)
+{
+    if (trace_all || trace_battle_camera)
+        ffnx_trace("%s - START LIST OF CAMERA SCRIPT OPCODE AND ARGS\n", __func__);
+
+    bool isScriptActive = true;
+    while (isScriptActive)
+    {
+        byte currentOpCode = scriptPtr[currentPosition++];
+
+        if (trace_all || trace_battle_camera)
+            ffnx_trace("opcode: 0x%0x\n", currentOpCode);
+
+        switch (currentOpCode)
+        {
+        case 0xF4:
+            if (framesToWait != 0)
+            {
+                framesToWait--;
+                currentPosition--;
+                isScriptActive = false;
+            }
+            break;
+        case 0xF5:
+            patchCameraScriptArg(scriptPtr, currentPosition);
+            framesToWait = scriptPtr[currentPosition++];
+            break;
+        case 0xFE:
+            if (framesToWait == 0)
+            {
+                currentOpCode = scriptPtr[currentPosition];
+
+                if (trace_all || trace_battle_camera)
+                    ffnx_trace("0xFE case: opcode 0x%0x\n", currentOpCode);
+
+                if (currentOpCode == 192)
+                {
+                    framesToWait = 0;
+                    currentPosition = 0;
+                }
+            }
+            break;
+        default:
+            if (numArgsOpCode.find(currentOpCode) != numArgsOpCode.end())
+            {
+                if (argIdxDoubleOpCode.find(currentOpCode) != argIdxDoubleOpCode.end())
+                    patchCameraScriptArg(scriptPtr, currentPosition + argIdxDoubleOpCode[currentOpCode]);
+
+                currentPosition += numArgsOpCode[currentOpCode];
+
+                if (deactiveOpCodes.find(currentOpCode) != deactiveOpCodes.end())
+                    isScriptActive = false;
+            }
+            else
+            {
+                if (trace_all || trace_battle_camera)
+                    ffnx_error("%s - Strange OpCode 0x%0x in camera script\n", __func__, currentOpCode);
+                isScriptActive = false;
+            }
+            break;
+        }
+    }
+    if (trace_all || trace_battle_camera)
+        ffnx_trace("%s - END LIST OF CAMERA SCRIPT OPCODE AND ARGS\n", __func__);
+
+    return std::make_pair(currentPosition, framesToWait);
+}
+
+// For 0xE7 and 0xE9 opcode of battle_camera_sub_5C23D1
+int ff7_add_fn_to_camera_fn_special(uint32_t function)
+{
+    int fnIdx = ((int (*)(uint32_t))ff7_externals.add_fn_to_camera_fn_array)(function);
+    isSpecialCameraFunction[fnIdx] = true;
+    return fnIdx;
+}
+
+void ff7_execute_camera_functions()
+{
+    for (int index = 0; index < 16; index++)
+    {
+        if (ff7_externals.camera_fn_array[index] != 0 && isSpecialCameraFunction[index])
+        {
+            if (trace_all || trace_battle_camera)
+                ffnx_trace("%s - function started 0x%x", __func__, ff7_externals.camera_fn_array[index]);
+
+            ff7_externals.battle_camera_data[index].field_4 *= 2;
+            isSpecialCameraFunction[index] = false;
+        }
+    }
+    ((void (*)())ff7_externals.execute_camera_functions)();
+}
+
+void ff7_battle_camera_sub_5C3FD5(char variationIndex, DWORD param_2, short cameraScriptIdx)
+{
+    if (trace_all || trace_battle_camera)
+        ffnx_trace("%s - Parameters: %d, %d, %d\n", __func__, variationIndex, param_2, cameraScriptIdx);
+
+    battle_camera_position *battle_camera_position = ff7_externals.battle_camera_position_BE1130;
+
+    byte *scriptPtr = getCameraScriptPointer(variationIndex, cameraScriptIdx, true);
+    uint16_t currentPosition = (battle_camera_position[variationIndex].current_position == 255) ? 0 : battle_camera_position[variationIndex].current_position;
+    uint16_t framesToWait = (battle_camera_position[variationIndex].current_position == 255) ? 0 : battle_camera_position[variationIndex].frames_to_wait;
+
+    std::unordered_map<byte, int> numArgsOpCode{{0xD8, 9}, {0xD9, 0}, {0xDB, 0}, {0xDC, 0}, {0xDD, 1}, {0xDE, 1}, {0xDF, 0}, {0xE0, 2}, {0xE1, 0}, {0xE2, 1}, {0xE3, 9}, {0xE4, 8}, {0xE5, 8}, {0xE6, 7}, {0xE8, 8}, {0xEA, 8}, {0xEC, 9}, {0xF0, 8}, {0xF4, -1}, {0xF5, 1}, {0xF8, 7}, {0xF9, 7}, {0xFA, 6}, {0xFE, 0}, {0xFF, -1}};
+    std::unordered_map<byte, int> argIdxDoubleOpCode{{0xD8, 8}, {0xE2, 0}, {0xE3, 8}, {0xE4, 7}, {0xE5, 7}, {0xE6, 6}, {0xE8, 7}, {0xEA, 7}, {0xEC, 8}};
+    std::unordered_set<byte> deactiveOpCodes{0xF0, 0xF8, 0xF9, 0xFF};
+
+    std::pair<uint16_t, uint16_t> results = simulateCameraScript(scriptPtr, currentPosition, framesToWait, numArgsOpCode, argIdxDoubleOpCode, deactiveOpCodes);
+    currentPosition = results.first;
+    framesToWait = results.second;
+
+    ((void (*)(char, DWORD, short))ff7_externals.battle_camera_sub_5C3FD5)(variationIndex, param_2, cameraScriptIdx);
+
+    if (currentPosition != battle_camera_position[variationIndex].current_position)
+        ffnx_error("%s - Camera script pointer simulation wrong! Battle camera final position does not match (simulation: %d != real: %d)\n", __func__,
+                   currentPosition, battle_camera_position[variationIndex].current_position);
+
+    if (framesToWait != battle_camera_position[variationIndex].frames_to_wait)
+        ffnx_error("%s - Camera script pointer simulation wrong! Battle camera final frames to wait does not match (simulation: %d != real: %d)\n", __func__,
+                   framesToWait, battle_camera_position[variationIndex].frames_to_wait);
+}
+
+void ff7_battle_camera_sub_5C23D1(char variationIndex, DWORD param_2, short cameraScriptIdx)
+{
+    if (trace_all || trace_battle_camera)
+        ffnx_trace("%s - Parameters: %d, %d, %d\n", __func__, variationIndex, param_2, cameraScriptIdx);
+
+    battle_camera_position *battle_camera_position = ff7_externals.battle_camera_position_BE10F0;
+
+    byte *scriptPtr = getCameraScriptPointer(variationIndex, cameraScriptIdx, false);
+    uint16_t currentPosition = (battle_camera_position[variationIndex].current_position == 255) ? 0 : battle_camera_position[variationIndex].current_position;
+    uint16_t framesToWait = (battle_camera_position[variationIndex].current_position == 255) ? 0 : battle_camera_position[variationIndex].frames_to_wait;
+
+    std::unordered_map<byte, int> numArgsOpCode{{0xD5, 2}, {0xD6, 0}, {0xD7, 2}, {0xD8, 9}, {0xD9, 0}, {0xDA, 0}, {0xDB, 0}, {0xDC, 0}, {0xDD, 1}, {0xDE, 1}, {0xDF, 0}, {0xE0, 2}, {0xE1, 0}, {0xE2, 1}, {0xE3, 9}, {0xE4, 8}, {0xE5, 8}, {0xE6, 7}, {0xE7, 8}, {0xE9, 8}, {0xEB, 9}, {0xEF, 8}, {0xF0, 7}, {0xF1, 0}, {0xF2, 5}, {0xF3, 5}, {0xF4, -1}, {0xF5, 1}, {0xF7, 7}, {0xF8, 12}, {0xF9, 6}, {0xFE, 0}, {0xFF, -1}};
+    std::unordered_map<byte, int> argIdxDoubleOpCode{{0xD8, 8}, {0xE2, 0}, {0xE3, 8}, {0xE4, 7}, {0xE5, 7}, {0xE6, 6}, {0xEB, 0}};
+    std::unordered_set<byte> deactiveOpCodes{0xEF, 0xF0, 0xF7, 0xFF};
+
+    std::pair<uint16_t, uint16_t> results = simulateCameraScript(scriptPtr, currentPosition, framesToWait, numArgsOpCode, argIdxDoubleOpCode, deactiveOpCodes);
+    currentPosition = results.first;
+    framesToWait = results.second;
+
+    ((void (*)(char, DWORD, short))ff7_externals.battle_camera_sub_5C23D1)(variationIndex, param_2, cameraScriptIdx);
+
+    if (currentPosition != battle_camera_position[variationIndex].current_position)
+        ffnx_error("%s - Camera script pointer simulation wrong! Battle camera final position does not match (simulation: %d != real: %d)\n", __func__,
+                   currentPosition, battle_camera_position[variationIndex].current_position);
+
+    if (framesToWait != battle_camera_position[variationIndex].frames_to_wait)
+        ffnx_error("%s - Camera script pointer simulation wrong! Battle camera final frames to wait does not match (simulation: %d != real: %d)\n", __func__,
+                   framesToWait, battle_camera_position[variationIndex].frames_to_wait);
+}

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -63,6 +63,10 @@ int ff7_field_load_models_atoi(const char* str);
 void ff7_chocobo_field_entity_60FA7D(WORD param1, short param2, short param3);
 void ff7_character_regularly_field_entity_60FA7D(WORD param1, short param2, short param3);
 int ff7_load_save_file(int param_1);
+int ff7_add_fn_to_camera_fn_special(uint32_t function);
+void ff7_execute_camera_functions();
+void ff7_battle_camera_sub_5C3FD5(char index, DWORD param_2, short param_3);
+void ff7_battle_camera_sub_5C23D1(char index, DWORD param_2, short param_3);
 
 // field
 void field_load_textures(struct ff7_game_obj *game_object, struct struc_3 *struc_3);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -552,6 +552,25 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.issued_action_target_index = (byte*)get_absolute_value(ff7_externals.set_battle_targeting_data, 0x164);
 	// --------------------------------
 
+	// camera 60 fps
+	ff7_externals.handle_camera_functions = get_relative_call(ff7_externals.battle_sub_42D992, 0xE3);
+	ff7_externals.battle_camera_sub_5C3FD5 = get_relative_call(ff7_externals.handle_camera_functions, 0x35);
+	ff7_externals.battle_camera_sub_5C23D1 = get_relative_call(ff7_externals.handle_camera_functions, 0x4B);
+	ff7_externals.execute_camera_functions = get_relative_call(ff7_externals.handle_camera_functions, 0x55);
+	ff7_externals.add_fn_to_camera_fn_array = get_relative_call(ff7_externals.battle_camera_sub_5C3FD5, 0xF40);
+	ff7_externals.camera_fn_array = (uint32_t*)get_absolute_value(ff7_externals.add_fn_to_camera_fn_array, 0x39);
+	ff7_externals.battle_camera_data = (battle_camera_fn_data*)get_absolute_value(ff7_externals.battle_camera_sub_5C3FD5, 0x7EC);
+	ff7_externals.battle_camera_position_BE10F0 = (battle_camera_position*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0x331);
+	ff7_externals.battle_camera_position_BE1130 = (battle_camera_position*)get_absolute_value(ff7_externals.battle_camera_sub_5C3FD5, 0x233);
+	ff7_externals.battle_camera_scripts_8FEE30 = (byte*)get_absolute_value(ff7_externals.battle_camera_sub_5C3FD5, 0xC1);
+	ff7_externals.battle_camera_scripts_8FEE2C = (byte*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0xC1);
+	ff7_externals.battle_camera_scripts_9A13BC = (DWORD*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0x17);
+	ff7_externals.battle_camera_scripts_9010D0 = (DWORD*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0xDC);
+	ff7_externals.battle_camera_scripts_901270 = (DWORD*)get_absolute_value(ff7_externals.battle_camera_sub_5C3FD5, 0xDC);
+	ff7_externals.battle_camera_script_index = (byte*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0xD2);
+	ff7_externals.battle_camera_script_offset = (DWORD*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0x25);
+	// --------------------------------
+	
 	//ff7 achievement related externals
 	uint32_t sub_434347 = get_relative_call(ff7_externals.battle_loop, 0x484);
 	uint32_t* pointer_functions_7C2980 = (uint32_t*)get_absolute_value(sub_434347, 0x19C);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -188,6 +188,16 @@ void ff7_init_hooks(struct game_obj *_game_object)
 			*ff7_externals.battle_fps_menu_multiplier /= 4;
 			break;
 		}
+
+		if (ff7_fps_limiter >= FF7_LIMITER_30FPS)
+		{
+			// Battle camera support for 30 fps and 60 fps battle
+			replace_call_function(ff7_externals.battle_camera_sub_5C23D1 + 0x1161, ff7_add_fn_to_camera_fn_special);
+			replace_call_function(ff7_externals.battle_camera_sub_5C23D1 + 0xFED, ff7_add_fn_to_camera_fn_special);
+			replace_call_function(ff7_externals.handle_camera_functions + 0x55, ff7_execute_camera_functions);
+			replace_call_function(ff7_externals.handle_camera_functions + 0x35, ff7_battle_camera_sub_5C3FD5);
+			replace_call_function(ff7_externals.handle_camera_functions + 0x4B, ff7_battle_camera_sub_5C23D1);
+		}
 	}
 
 	// #####################


### PR DESCRIPTION
This is what I have done on the camera 60 fps support. It is kinda a mess, but I have seen that it has the correct speed in the battle intro camera movement and also other things which I don't remember or cannot distinguish since the animations are quicker.

I have commented two lines in the ff7_opengl.cpp since they cause crashes, but they are in the original hext patch. While other two multiplication are missing because they cannot be done with this technique.