### PR TITLE
60FPS: Fix horizontal camera rotation bug and refactor

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -562,9 +562,9 @@ struct battle_actor_data
 
 #pragma pack(1)
 struct battle_camera_position{
-	WORD location_x;
-	WORD location_y;
-	WORD location_z;
+	short location_x;
+	short location_y;
+	short location_z;
 	WORD unused;
 	WORD current_position;
 	WORD frames_to_wait;
@@ -574,16 +574,18 @@ struct battle_camera_position{
 
 #pragma pack(1)
 struct battle_camera_fn_data{
+	WORD field_0;
 	WORD field_1;
-	WORD field_2; 
-	WORD field_3; 
-	WORD field_4; 
-	WORD field_5;
-	WORD field_6;
-	DWORD field_7;
-	DWORD unused_1;
-	byte index;
-	byte unused_2[19];
+	WORD n_frames;
+	short b_x; 
+	short b_y;
+	short b_z;
+	short c_x;
+	short c_y;
+	short c_z;
+	byte unused_1[6];
+	byte variationIndex;
+	byte unused_2[15];
 };
 
 struct battle_chdir_struc
@@ -1997,7 +1999,7 @@ struct ff7_externals
 	byte* issued_action_target_type;
 	byte* issued_action_target_index;
 	uint32_t field_load_models_atoi;
-	battle_camera_fn_data* battle_camera_data;
+	battle_camera_fn_data* battle_camera_fn_data;
 	battle_camera_position* battle_camera_position_BE10F0;
 	battle_camera_position* battle_camera_position_BE1130;
 	uint32_t* camera_fn_array;
@@ -2015,9 +2017,13 @@ struct ff7_externals
 	DWORD* battle_camera_scripts_901270;
 	byte* battle_camera_script_index;
 	DWORD* battle_camera_script_offset;
+	WORD* camera_fn_index;
 	DWORD* battle_data_C05FF4;
 	uint32_t battle_sub_430DD0;
 	uint32_t battle_sub_429D8A;
+	uint32_t battle_camera_sub_5C3D0D;
+	uint32_t sub_662538;
+	uint32_t sub_6624FD;
 };
 
 uint32_t ff7gl_load_group(uint32_t group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -63,6 +63,8 @@ int ff7_field_load_models_atoi(const char* str);
 void ff7_chocobo_field_entity_60FA7D(WORD param1, short param2, short param3);
 void ff7_character_regularly_field_entity_60FA7D(WORD param1, short param2, short param3);
 int ff7_load_save_file(int param_1);
+
+// camera
 int ff7_add_fn_to_camera_fn_special_multiply(uint32_t function);
 int ff7_add_fn_to_camera_fn_for_field_1(uint32_t function);
 int ff7_add_fn_to_camera_fn_for_field_3(uint32_t function);
@@ -70,6 +72,7 @@ int ff7_add_fn_to_camera_fn_for_field_4(uint32_t function);
 void ff7_execute_camera_functions();
 void ff7_battle_camera_sub_5C3FD5(char index, DWORD param_2, short param_3);
 void ff7_battle_camera_sub_5C23D1(char index, DWORD param_2, short param_3);
+void ff7_battle_camera_sub_5C3D0D();
 
 // field
 void field_load_textures(struct ff7_game_obj *game_object, struct struc_3 *struc_3);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -561,7 +561,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_camera_sub_5C52F8 = get_relative_call(ff7_externals.battle_camera_sub_5C3FD5, 0x10A8);
 	ff7_externals.battle_camera_sub_5C3E6F = get_relative_call(ff7_externals.battle_camera_sub_5C23D1, 0x169E);
 	ff7_externals.camera_fn_array = (uint32_t*)get_absolute_value(ff7_externals.add_fn_to_camera_fn_array, 0x39);
-	ff7_externals.battle_camera_data = (battle_camera_fn_data*)get_absolute_value(ff7_externals.battle_camera_sub_5C3FD5, 0x7EC);
+	ff7_externals.battle_camera_fn_data = (battle_camera_fn_data*)get_absolute_value(ff7_externals.add_fn_to_camera_fn_array, 0x4D);
 	ff7_externals.battle_camera_position_BE10F0 = (battle_camera_position*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0x331);
 	ff7_externals.battle_camera_position_BE1130 = (battle_camera_position*)get_absolute_value(ff7_externals.battle_camera_sub_5C3FD5, 0x233);
 	ff7_externals.battle_camera_scripts_8FEE30 = (byte*)get_absolute_value(ff7_externals.battle_camera_sub_5C3FD5, 0xC1);
@@ -572,6 +572,11 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_camera_script_index = (byte*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0xD2);
 	ff7_externals.battle_camera_script_offset = (DWORD*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0x25);
 	ff7_externals.battle_data_C05FF4 = (DWORD*)get_absolute_value(ff7_externals.battle_camera_sub_5C3E6F, 0x70);
+	ff7_externals.camera_fn_index = (WORD*)get_absolute_value(ff7_externals.add_fn_to_camera_fn_array, 0x46);
+
+	ff7_externals.battle_camera_sub_5C3D0D = get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0x5DE);
+	ff7_externals.sub_662538 = get_relative_call(ff7_externals.battle_camera_sub_5C3D0D, 0x76);
+	ff7_externals.sub_6624FD = get_relative_call(ff7_externals.battle_camera_sub_5C3D0D, 0xBB);
 
 	ff7_externals.battle_sub_430DD0 = get_relative_call(ff7_externals.battle_loop, 0x99E);
 	ff7_externals.battle_sub_429D8A = get_absolute_value(ff7_externals.battle_loop, 0x59);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -188,11 +188,14 @@ void ff7_init_hooks(struct game_obj *_game_object)
 			// Battle camera support for 30 fps and 60 fps battle 
 			replace_call_function(ff7_externals.battle_camera_sub_5C3FD5 + 0x681, ff7_add_fn_to_camera_fn_for_field_1);
 			replace_call_function(ff7_externals.battle_camera_sub_5C3FD5 + 0x830, ff7_add_fn_to_camera_fn_for_field_1);
-			replace_call_function(ff7_externals.battle_camera_sub_5C3FD5 + 0x993, ff7_add_fn_to_camera_fn_for_field_1);
+			replace_call_function(ff7_externals.battle_camera_sub_5C3FD5 + 0x993, ff7_add_fn_to_camera_fn_for_field_1); //OpCode 0xE8
 			replace_call_function(ff7_externals.battle_camera_sub_5C3FD5 + 0xBDF, ff7_add_fn_to_camera_fn_for_field_1);
-			replace_call_function(ff7_externals.battle_camera_sub_5C3FD5 + 0xCDA, ff7_add_fn_to_camera_fn_for_field_1);
+			replace_call_function(ff7_externals.battle_camera_sub_5C3FD5 + 0xF40, ff7_add_fn_to_camera_fn_for_field_1); //OpCode 0xE0 (don't know if needed)
+			replace_call_function(ff7_externals.battle_camera_sub_5C3FD5 + 0xCDA, ff7_add_fn_to_camera_fn_for_field_1); //OpCode 0xE6
 			replace_call_function(ff7_externals.battle_camera_sub_5C23D1 + 0x40E, ff7_add_fn_to_camera_fn_for_field_1);
-			replace_call_function(ff7_externals.battle_camera_sub_5C23D1 + 0x12D5, ff7_add_fn_to_camera_fn_for_field_1);
+			replace_call_function(ff7_externals.battle_camera_sub_5C23D1 + 0x153B, ff7_add_fn_to_camera_fn_for_field_1); //OpCode 0xE0 (don't know if needed)
+			replace_call_function(ff7_externals.battle_camera_sub_5C23D1 + 0x12D5, ff7_add_fn_to_camera_fn_for_field_1); //OpCode 0xE6
+			replace_call_function(ff7_externals.battle_camera_sub_5C23D1 + 0x5E2, ff7_add_fn_to_camera_fn_for_field_1); //OpCode 0xF8
 			replace_call_function(ff7_externals.battle_camera_sub_5C23D1 + 0xE2C, ff7_add_fn_to_camera_fn_for_field_3);
 			replace_call_function(ff7_externals.battle_camera_sub_5C23D1 + 0x1161, ff7_add_fn_to_camera_fn_for_field_4);
 			replace_call_function(ff7_externals.battle_camera_sub_5C23D1 + 0xFED, ff7_add_fn_to_camera_fn_for_field_4);
@@ -201,6 +204,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 			replace_call_function(ff7_externals.handle_camera_functions + 0x55, ff7_execute_camera_functions);
 			replace_call_function(ff7_externals.handle_camera_functions + 0x35, ff7_battle_camera_sub_5C3FD5);
 			replace_call_function(ff7_externals.handle_camera_functions + 0x4B, ff7_battle_camera_sub_5C23D1);
+			replace_function(ff7_externals.battle_camera_sub_5C3D0D, ff7_battle_camera_sub_5C3D0D);
 
 			// Battle outro camera frame fix: patch DAT_009AE138 (presumably frames to wait before closing battle mode)
 			patch_code_byte(ff7_externals.battle_sub_430DD0 + 0x3DE, 0x31 * frame_multiplier);


### PR DESCRIPTION
 - Fix horizontal camera rotation bug in one battle outro and other magic camera animation (opcode 0xF8)
 - Patch opcode 0xE0 like the others (untested: still don't know where this is used)
 - Refactor better camera script data structure