### PR TITLE
60FPS: Add 60 fps animation for enemy deaths, actor movement, and man…

### DIFF
--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -412,6 +412,10 @@ trace_achievement = false
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 trace_battle_camera = false
 
+# trace_battle_animation - Dump in the logs only APIs that has to do with battle animation
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+trace_battle_animation = false
+
 # vertex_log - Dump in the logs current engine vertex data being passed to the GPU for drawing
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 vertex_log = false

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -61,6 +61,7 @@ bool trace_ambient;
 bool trace_gamepad;
 bool trace_achievement;
 bool trace_battle_camera;
+bool trace_battle_animation;
 bool vertex_log;
 bool uniform_log;
 bool show_renderer_backend;
@@ -180,6 +181,7 @@ void read_cfg()
 	trace_gamepad = config["trace_gamepad"].value_or(false);
 	trace_achievement = config["trace_achievement"].value_or(false);
 	trace_battle_camera = config["trace_battle_camera"].value_or(false);
+	trace_battle_animation = config["trace_battle_animation"].value_or(false);
 	vertex_log = config["vertex_log"].value_or(false);
 	uniform_log = config["uniform_log"].value_or(false);
 	show_renderer_backend = config["show_renderer_backend"].value_or(true);

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -74,6 +74,7 @@ extern bool trace_ambient;
 extern bool trace_gamepad;
 extern bool trace_achievement;
 extern bool trace_battle_camera;
+extern bool trace_battle_animation;
 extern bool vertex_log;
 extern bool uniform_log;
 extern bool show_renderer_backend;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -127,6 +127,7 @@ uint32_t scene_stack_pointer = 0;
 // global frame counter
 uint32_t frame_counter = 0;
 double frame_rate = 0;
+int frame_multiplier = 1;
 
 // default 32-bit BGRA texture format presented to the game
 struct texture_format *texture_format;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <stdio.h>
+#include <array>
 
 #include "common.h"
 
@@ -560,30 +561,236 @@ struct battle_actor_data
 	uint32_t field_54_others[206];
 };
 
-struct battle_camera_position{
+struct bcamera_position{
 	short location_x;
 	short location_y;
 	short location_z;
-	WORD unused;
+	WORD unused_6;
 	WORD current_position;
 	WORD frames_to_wait;
 	byte field_C;
 	byte field_D;
 };
 
-struct battle_camera_fn_data{
+struct bcamera_fn_data{
 	WORD field_0;
-	WORD field_1;
+	WORD field_2;
 	WORD n_frames;
-	short b_x; 
-	short b_y;
-	short b_z;
-	short c_x;
-	short c_y;
-	short c_z;
-	byte unused_1[6];
-	byte variationIndex;
-	byte unused_2[15];
+	short field_6; 
+	short field_8;
+	short field_A;
+	short field_C;
+	short field_E;
+	short field_10;
+	byte unused_12[6];
+	byte field_18;
+	byte unused_19[15];
+};
+
+struct battle_model_state
+{
+    uint16_t characterID;     // BE1178, 0
+    uint16_t animScriptIndex; // BE117A, 2
+    byte actionFlags;
+    byte field_5;
+    short field_6;
+    uint16_t AnimationData; // BE1180, 8
+    uint16_t animScriptPtr; // BE1182, 0xA
+    uint16_t field_C;
+    uint16_t runningAnimIdx; // 0xE
+    uint16_t totalBones;
+    uint16_t height;
+    short field_14;
+    uint16_t initialXRotation;
+    uint16_t initialYRotation;
+    uint16_t initialZRotation;
+    uint16_t field_1C;
+    uint16_t field_1E;
+    uint16_t field_20;
+    byte animationEffect; // BE119A, 0x22
+    byte commandID;       // BE119B, 0x23
+    byte field_24;
+    byte field_25;
+    byte actorIsNotActing;
+    byte field_27;
+    byte field_28;
+    byte unkActorFlags;
+    byte field_2A;
+    byte bData0x12[16];         // 0x2B
+    byte isScriptExecuting;     // BE11B3, 0x3B
+    byte currentScriptPosition; // 0x3C
+    byte waitFrames;            // 0x3D
+    byte modelEffectFlags;      // 0x3E
+    byte field_3F;
+    uint32_t field_40;
+    uint32_t field_44;
+    uint32_t field_48;
+    uint32_t field_4C;
+    uint32_t field_50;
+    uint32_t field_54;
+    uint32_t field_58;
+    uint32_t field_5C;
+    uint32_t field_60;
+    uint32_t field_64;
+    uint32_t field_68;
+    uint32_t field_6C;
+    uint32_t field_70;
+    uint32_t field_74;
+    byte padding3[0xE6];       // 0x78
+    uint16_t restingXRotation; // BE12D8, 0x15E
+    uint16_t restingYRotation; // 0x160
+    uint16_t restingZRotation;
+    uint16_t field_164;
+    int16_t restingXPosition; // BE12DE, 0x166
+    int16_t restingYPosition;
+    int16_t restingZPosition; // 0x16A
+    uint32_t field_16C;
+    uint32_t *field_170;
+    uint32_t field_174;
+    byte padding5[0xA24];
+    uint32_t playedAnimFrames;
+    uint32_t currentPlayingFrame;
+    uint32_t tableRelativeModelAnimIdx;
+    uint32_t *modelDataPtr;
+    byte padding4[0xF18];
+    uint32_t setForLimitBreaks; // 0x1AC4
+    uint32_t field_1AC8;
+    float field_1ACC;
+    float field_1AD0;
+    float field_1AD4;
+    uint32_t padding_1AD8;
+    float field_1ADC;
+    uint32_t padding_1AE0;
+    uint32_t field_1AE4;
+    uint32_t field_1AE8;
+};
+
+struct battle_model_state_small
+{
+    uint32_t field_0;
+    uint16_t bData68[4];
+    uint16_t field_C;
+    uint16_t bData76[6];
+    uint16_t bData88[6];
+    uint16_t actorIsNotActing;
+    uint16_t field_28;
+    uint16_t field_2A;
+    uint16_t someHPCopy;
+    uint16_t field_2E;
+    uint16_t someMPCopy;
+    byte modelDataIndex; // 0x032
+    byte field_33;
+    byte innateStatusMask;
+    byte field_35;
+    byte field_36;
+    byte field_37;
+    uint16_t field_38;
+    uint16_t field_3A;
+    uint16_t field_3C;
+    uint16_t actionIdx;
+    byte field_40;
+    byte field_41;
+    byte field_42;
+    byte field_43;
+    byte field_44;
+    byte field_45;
+    byte field_46;
+    byte field_47;
+    byte field_48;
+    byte field_49;
+    byte field_4A;
+    byte field_4B;
+    byte field_4C;
+    byte field_4D;
+    byte field_4E;
+    byte field_4F;
+    byte field_50;
+    byte field_51;
+    byte field_52;
+    byte field_53;
+    byte field_54;
+    byte field_55;
+    byte field_56;
+    byte field_57;
+    byte field_58;
+    byte field_59;
+    byte field_5A;
+    byte field_5B;
+    byte field_5C;
+    byte field_5D;
+    byte field_5E;
+    byte field_5F;
+    byte field_60;
+    byte field_61;
+    byte field_62;
+    byte field_63;
+    byte field_64;
+    byte field_65;
+    byte field_66;
+    byte field_67;
+    byte field_68;
+    byte field_69;
+    byte field_6A;
+    byte field_6B;
+    byte field_6C;
+    byte field_6D;
+    byte field_6E;
+    byte field_6F;
+    byte field_70;
+    byte field_71;
+    byte field_72;
+    byte field_73;
+};
+
+struct effect100_data
+{
+    uint16_t field_0;
+    uint16_t field_2;
+    short n_frames;
+    short field_6;
+    short field_8;
+    short field_A;
+    short field_C;
+    short field_E;
+    int field_10;
+    int field_14;
+    byte field_18;
+    byte field_19;
+    byte field_1A[6];
+};
+
+struct effect60_data
+{
+    uint16_t field_0;
+    uint16_t field_2;
+    short n_frames;
+    short field_6;
+    short field_8;
+    short field_A;
+    uint16_t padding;
+    short field_E;
+    int field_10;
+    int field_14;
+    byte field_18;
+    byte field_19[7];
+};
+
+struct effect10_data
+{
+    uint16_t field_0;
+    uint16_t field_2;
+    short n_frames;
+    short field_6;
+    short field_8;
+    short field_A;
+    short field_C;
+    short field_E;
+    int field_10;
+    int field_14;
+    byte field_18;
+    byte field_19;
+    byte field_1A;
+    byte field_1B[5];
 };
 
 struct battle_chdir_struc
@@ -1996,31 +2203,128 @@ struct ff7_externals
 	byte* issued_action_target_type;
 	byte* issued_action_target_index;
 	uint32_t field_load_models_atoi;
-	battle_camera_fn_data* battle_camera_fn_data;
-	battle_camera_position* battle_camera_position_BE10F0;
-	battle_camera_position* battle_camera_position_BE1130;
+	
+	// battle camera script externals
+	bcamera_fn_data* camera_fn_data;
+	bcamera_position* battle_camera_position;
+	bcamera_position* battle_camera_focal_position;
 	uint32_t* camera_fn_array;
 	uint32_t handle_camera_functions;
-	uint32_t battle_camera_sub_5C3FD5;
-	uint32_t battle_camera_sub_5C23D1;
+	uint32_t set_camera_focal_position_scripts;
+	uint32_t set_camera_position_scripts;
 	uint32_t add_fn_to_camera_fn_array;
 	uint32_t execute_camera_functions;
 	uint32_t battle_camera_sub_5C52F8;
 	uint32_t battle_camera_sub_5C3E6F;
-	byte* battle_camera_scripts_8FEE30;
-	byte* battle_camera_scripts_8FEE2C;
-	DWORD* battle_camera_scripts_9A13BC;
-	DWORD* battle_camera_scripts_9010D0;
-	DWORD* battle_camera_scripts_901270;
+	byte* battle_camera_focal_scripts_8FEE30;
+	byte* battle_camera_position_scripts_8FEE2C;
+	DWORD* battle_camera_global_scripts_9A13BC;
+	DWORD* battle_camera_position_scripts_9010D0;
+	DWORD* battle_camera_focal_scripts_901270;
 	byte* battle_camera_script_index;
 	DWORD* battle_camera_script_offset;
 	WORD* camera_fn_index;
-	DWORD* battle_data_C05FF4;
+	WORD* camera_fn_counter;
+	uint32_t battle_camera_position_sub_5C3D0D;
+	uint32_t battle_camera_position_sub_5C557D;
+	uint32_t battle_camera_position_sub_5C5B9C;
+	uint32_t battle_camera_focal_sub_5C5F5E;
+	uint32_t battle_camera_focal_sub_5C5714;
 	uint32_t battle_sub_430DD0;
 	uint32_t battle_sub_429D8A;
-	uint32_t battle_camera_sub_5C3D0D;
-	uint32_t sub_662538;
-	uint32_t sub_6624FD;
+	uint32_t battle_sub_6E3135;
+
+	// animation script externals
+	uint32_t battle_sub_42A5EB;
+	uint32_t battle_sub_42E275;
+	uint32_t battle_sub_42E34A;
+	uint32_t battle_sub_5BD5E9;
+	uint32_t battle_sub_5C1D9A;
+	uint32_t run_animation_script;
+	uint32_t add_fn_to_effect100_fn;
+	uint32_t execute_effect100_fn;
+	uint32_t add_fn_to_effect60_fn;
+	uint32_t execute_effect60_fn;
+	uint32_t add_fn_to_effect10_fn;
+	uint32_t execute_effect10_fn;
+	uint32_t battle_enemy_death_5BBD24;
+	uint32_t battle_enemy_death_sub_5BBE32;
+	uint32_t battle_iainuki_death_5BCAAA;
+	uint32_t battle_iainuki_death_sub_5BCBB8;
+	uint32_t battle_boss_death_5BC48C;
+	uint32_t battle_boss_death_sub_5BC6ED;
+	uint32_t battle_boss_death_sub_5BC5EC;
+	uint32_t battle_boss_death_call_5BD436;
+	uint32_t battle_melting_death_5BC21F;
+	uint32_t battle_melting_death_sub_5BC32D;
+	uint32_t battle_disintegrate_2_death_5BBA82;
+	uint32_t battle_disintegrate_2_death_sub_5BBBDE;
+	uint32_t battle_morph_death_5BC812;
+	uint32_t battle_morph_death_sub_5BC920;
+	uint32_t battle_disintegrate_1_death_5BBF31;
+	uint32_t battle_disintegrate_1_death_sub_5BC04D;
+	uint32_t battle_sub_42C0A7;
+	uint32_t battle_sub_5C0E4B;
+	uint32_t battle_sub_5D4240;
+	uint32_t battle_sub_5BD96D;
+	uint32_t battle_sub_425D29;
+	uint32_t battle_sub_5BDA0F;
+	uint32_t get_n_frames_display_action_string;
+	uint32_t battle_sub_426DE3;
+	uint32_t battle_sub_426941;
+	uint32_t battle_sub_426899;
+	uint32_t battle_sub_4267F1;
+	uint32_t battle_sub_5C1C8F;
+	uint32_t battle_sub_42C66D;
+	uint32_t battle_sub_42C823;
+	uint32_t battle_move_character_to_enemy_426A26;
+	uint32_t battle_sub_42739D;
+	uint32_t battle_sub_426F58;
+	uint32_t battle_move_character_to_enemy_4270DE;
+	uint32_t battle_sub_5C18BC;
+	uint32_t battle_sub_4276B6;
+	uint32_t battle_sub_4255B7;
+	uint32_t battle_sub_425E5F;
+	uint32_t battle_sub_425520;
+	uint32_t battle_sub_5BCF9D;
+	uint32_t battle_sub_425AAD;
+	uint32_t battle_sub_427A6C;
+	uint32_t battle_sub_427AF1;
+	uint32_t battle_sub_427737;
+	uint32_t battle_sub_4277B1;
+	uint32_t battle_sub_5BCD42;
+	uint32_t battle_sub_5BD050;
+	uint32_t battle_sub_5BE4E2;
+
+	battle_model_state *g_battle_model_state;
+	battle_model_state_small *g_small_battle_model_state;
+	uint32_t* effect100_array_fn;
+	uint16_t* effect100_counter;
+	uint16_t* effect100_array_idx;
+	effect100_data* effect100_array_data;
+	uint32_t* effect60_array_fn;
+	uint16_t* effect60_counter;
+	uint16_t* effect60_array_idx;
+	effect60_data* effect60_array_data;
+	uint32_t* effect10_array_fn;
+	uint16_t* effect10_counter;
+	uint16_t* effect10_array_idx;
+	effect10_data* effect10_array_data;
+	short* effect10_array_data_8FE1F6;
+	std::array<byte*, 14> animation_script_pointers;
+	byte* g_is_effect_loading;
+	byte* g_is_battle_paused;
+	byte* g_actor_idle_scripts;
+	byte* g_script_wait_frames;
+	int** g_script_args; // 8 global values
+	byte* special_actor_id;
+	int* field_battle_BFB2E0;
+	float* field_float_battle_7B7680;
+	DWORD* field_dword_9AD1AC;
+	byte* field_byte_DC0E11;
+	byte* field_battle_byte_BF2E1C;
+	byte* field_battle_byte_BE10B4;
+	short* resting_Y_array_data;
 };
 
 uint32_t ff7gl_load_group(uint32_t group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -1,0 +1,758 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 myst6re                                            //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//    Copyright (C) 2020 John Pritchard                                     //
+//    Copyright (C) 2021 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2021 Tang-Tang Zhou                                     //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#include <unordered_set>
+#include <unordered_map>
+
+#include "../ff7.h"
+#include "../log.h"
+#include "../globals.h"
+#include "defs.h"
+
+const std::unordered_map<byte, int> numArgsOpCode = {
+    {0x8E, 0},
+    {0x8F, 0},
+    {0x90, 3},
+    {0x91, 1}, // Function added
+    {0x92, 0},
+    {0x93, 0}, // Function added
+    {0x94, 5}, // Function added
+    {0x95, 0},
+    {0x96, 2}, // effect60 fn added (barret gun)
+    {0x97, 2},
+    {0x98, 1},
+    {0x99, 6},
+    {0x9A, 4},
+    {0x9B, 0},
+    {0x9C, 0},
+    {0x9D, 1}, // Dispatches Tifa limit breaks
+    {0x9E, 0xFF},
+    {0x9F, 0},
+    {0xA0, 1},
+    {0xA1, 2},
+    {0xA2, 1},
+    {0xA3, 1},
+    {0xA4, 0}, // Spell aura related
+    {0xA5, 0}, // Spell aura related
+    {0xA6, 0},
+    {0xA7, 1},
+    {0xA8, 2}, // Move actor to resting position
+    {0xA9, 2},
+    {0xAA, 0},
+    {0xAB, 4},
+    {0xAC, 1}, // Vincent related
+    {0xAD, 5}, // Barret related machine gun effect
+    {0xAE, 0}, // Resting position related
+    {0xAF, 1}, // Resting position reset
+    {0xB0, 0}, // Resting position related
+    {0xB1, 0}, // Resting position related
+    {0xB2, 0}, // nop
+    {0xB3, 0xFF},
+    {0xB4, 0}, // Y rotation
+    {0xB5, 11},
+    {0xB6, 1}, // running animation related
+    {0xB7, 0}, // death effects
+    {0xB8, 0},
+    {0xB9, 1}, // setup animation camera data
+    {0xBA, 2}, // resting Y rotation
+    {0xBC, 1}, // Idle camera index
+    {0xBD, 4}, // rotate to target animation
+    {0xBE, 1}, // not Tifa stuff
+    {0xBF, 2},
+    {0xC1, 0xFF},
+    {0xC2, 1}, // display damage
+    {0xC3, 0}, // some effects
+    {0xC4, 3}, // resting Y rotation (inverting direction)
+    {0xC5, 0}, // set frames to wait to 0xBFD0F0
+    {0xC6, 1}, // set 0xBFD0F0 frames to wait
+    {0xC7, 3}, // enemy animation thing
+    {0xC8, 5}, // effects thing
+    {0xC9, 0}, // nop
+    {0xCA, 0xFF},
+    {0xCB, 8},
+    {0xCC, 1}, // move effects thing
+    {0xCE, 1},
+    {0xCF, 8}, // 3d move effects
+    {0xD0, 3}, // move effects
+    {0xD1, 5}, // move effects
+    {0xD2, 0},
+    {0xD3, 0},
+    {0xD4, 3}, // move effects
+    {0xD5, 8}, // move effects
+    {0xD6, 1}, // effects thing
+    {0xD7, 2}, // effects thing
+    {0xD8, 3}, // effects thing
+    {0xDA, 1},
+    {0xDB, 4}, // effect machine gun
+    {0xDC, 3}, // rotation stuff
+    {0xDD, 2}, // machine gun effects
+    {0xDE, 2}, // machine gun stuff
+    {0xDF, 0}, // resting Y rotation
+    {0xE0, 0}, // spell aura related
+    {0xE1, 0}, // appear model
+    {0xE2, 0}, // vanish model
+    {0xE3, 0}, // position actor
+    {0xE4, 0}, // resting stuff
+    {0xE5, 0}, // rotation stuff
+    {0xE6, 0}, // spell aura stuff
+    {0xE7, 1},
+    {0xE8, 0},
+    {0xE9, 3}, // move effects
+    {0xEA, 0}, // display action string effect
+    {0xEB, 0xFF},
+    {0xEC, 0xFF},
+    {0xED, 0}, // resting stuff
+    {0xEE, 0xFF},
+    {0xF0, 0}, // foot dust effect
+    {0xF1, -1},
+    {0xF2, 0}, // nop
+    {0xF3, 0xFF},
+    {0xF4, 0xFF},
+    {0xF5, 1}, // game init enemies
+    {0xF6, 0}, // death effects
+    {0xF7, 1}, // delay damage display effect
+    {0xF8, 1}, // effect stuff
+    {0xF9, 0}, // resets actor orientation
+    {0xFA, 0},
+    {0xFB, 4},
+    {0xFC, 0}, // setting orientation for target-all action
+    {0xFD, 6}, // set resting position
+    {0xFE, 0xFF},
+    {0xFF, 0xFF},
+};
+
+const std::unordered_set<byte> endingOpCode{{0xA2, 0xA7, 0xA9, 0xB6, 0xF1}};
+std::array<bool, 100> isNewEffect100Function{};
+std::array<bool, 10> isNewEffect10Function{};
+std::array<bool, 60> isNewEffect60Function{};
+std::unordered_set<uint32_t> patchedAddress{};
+
+std::array<int, 100> extFramesCounterEffect100;
+std::array<bool, 100> useExtFramesCounterEffect100;
+std::array<int, 60> extFramesCounterEffect60;
+std::array<bool, 60> useExtFramesCounterEffect60;
+bool isAddFunctionDisabled = false;
+
+void patchAnimationScriptArg(byte *scriptPointer, byte position)
+{
+    if (!patchedAddress.contains((DWORD)(scriptPointer + position)))
+    {
+        byte beforeValue = scriptPointer[position];
+        scriptPointer[position] = scriptPointer[position] * frame_multiplier;
+
+        if (beforeValue >= 0x100 / frame_multiplier)
+            ffnx_error("Script arg multiplication out of bound at 0x%x: before is %d, after is %d\n", (DWORD)(scriptPointer + position),
+                       beforeValue, scriptPointer[position]);
+    }
+
+    patchedAddress.insert((DWORD)(scriptPointer + position));
+}
+
+byte getActorIdleAnimScript(byte actorID)
+{
+    return ff7_externals.g_actor_idle_scripts[actorID];
+}
+
+battle_model_state *getBattleModelState(byte actorID)
+{
+    return &(ff7_externals.g_battle_model_state[actorID]);
+}
+
+battle_model_state_small *getSmallBattleModelState(byte actorID)
+{
+    return &(ff7_externals.g_small_battle_model_state[actorID]);
+}
+
+byte *getAnimScriptPointer(byte **ptrToScriptTable, battle_model_state &ownerModelState)
+{
+    byte *scriptPtr = ptrToScriptTable[ownerModelState.animScriptIndex];
+    if (ownerModelState.animScriptIndex >= 0x2E && ownerModelState.animScriptIndex <= 0x3B && ownerModelState.animScriptIndex != 0x33)
+    {
+        if (ownerModelState.animScriptIndex == 0x39)
+            ownerModelState.field_25 |= 0x80u;
+        scriptPtr = ff7_externals.animation_script_pointers[ownerModelState.animScriptIndex - 0x2E];
+    }
+    return scriptPtr;
+}
+
+void ff7_run_animation_script(byte actorID, byte **ptrToScriptTable)
+{
+    // creates copy of model states
+    battle_model_state ownerModelState = *getBattleModelState(actorID);
+    battle_model_state_small smallModelState = *getSmallBattleModelState(actorID);
+
+    byte script_wait_frames = *ff7_externals.g_script_wait_frames;
+
+    if (trace_all || trace_battle_animation)
+        ffnx_trace("%s - running animation script with idx: %d for actor %d. current position: %i\n", __func__, ownerModelState.animScriptIndex, actorID, ownerModelState.currentScriptPosition);
+    if (!*ff7_externals.g_is_battle_paused)
+    {
+        bool isScriptActive = true;
+        byte *scriptPtr = getAnimScriptPointer(ptrToScriptTable, ownerModelState);
+
+        if (ownerModelState.modelEffectFlags & 1)
+        {
+            ownerModelState.isScriptExecuting = 1;
+            ownerModelState.currentScriptPosition = 0;
+            ownerModelState.waitFrames = 0;
+        }
+        if (ownerModelState.isScriptExecuting)
+        {
+            ownerModelState.playedAnimFrames = 0;
+            while (isScriptActive)
+            {
+                byte currentOpCode = scriptPtr[ownerModelState.currentScriptPosition++];
+
+                if (trace_all || trace_battle_animation)
+                    ffnx_trace("opcode: 0x%x\n", currentOpCode);
+
+                switch (currentOpCode)
+                {
+                case 0xC5:
+                    ownerModelState.waitFrames = script_wait_frames;
+                    break;
+                case 0xC6:
+                    patchAnimationScriptArg(scriptPtr, ownerModelState.currentScriptPosition);
+                    script_wait_frames = scriptPtr[ownerModelState.currentScriptPosition++];
+                    break;
+                case 0x9E:
+                    if (actorID == *ff7_externals.special_actor_id)
+                    {
+                        if (*ff7_externals.effect100_counter != 0)
+                            ownerModelState.currentScriptPosition--;
+                    }
+                    else if (!(getBattleModelState(*ff7_externals.special_actor_id)->actorIsNotActing == 1 && *ff7_externals.effect100_counter == 0))
+                    {
+                        ownerModelState.currentScriptPosition--;
+                    }
+                    isScriptActive = false;
+                    break;
+                case 0xB3:
+                    if ((smallModelState.field_0 & 0x1000) != 0)
+                    {
+                        byte position;
+                        do
+                            position = scriptPtr[ownerModelState.currentScriptPosition++];
+                        while (position != 0xB2);
+                    }
+                    break;
+                case 0xC1:
+                    ownerModelState.currentScriptPosition = 0;
+                    byte position;
+                    do
+                        position = scriptPtr[ownerModelState.currentScriptPosition++];
+                    while (position != 0xC9);
+                    break;
+                case 0xCA:
+                    if (*ff7_externals.g_is_effect_loading)
+                    {
+                        ownerModelState.currentScriptPosition = 0;
+                        byte position;
+                        do
+                            position = scriptPtr[ownerModelState.currentScriptPosition++];
+                        while (position != 0xC9);
+                    }
+                    break;
+                case 0xCE:
+                    if (actorID >= 4)
+                    {
+                        byte position;
+                        do
+                            position = scriptPtr[ownerModelState.currentScriptPosition++];
+                        while (position != 0xCD);
+                    }
+                    break;
+                case 0xEB:
+                case 0xEC:
+                    if (*ff7_externals.g_is_effect_loading)
+                    {
+                        ownerModelState.currentScriptPosition--;
+                        isScriptActive = false;
+                    }
+                    break;
+                case 0xF3:
+                    if (ownerModelState.waitFrames != 0)
+                    {
+                        ownerModelState.waitFrames--;
+                        ownerModelState.currentScriptPosition--;
+                        isScriptActive = false;
+                    }
+                    break;
+                case 0xF4:
+                    patchAnimationScriptArg(scriptPtr, ownerModelState.currentScriptPosition);
+                    ownerModelState.waitFrames = scriptPtr[ownerModelState.currentScriptPosition++];
+                    break;
+                case 0xFE:
+                    if (ownerModelState.waitFrames == 0)
+                    {
+                        currentOpCode = scriptPtr[ownerModelState.currentScriptPosition];
+                        if (currentOpCode == 0xC0)
+                        {
+                            ownerModelState.currentScriptPosition = 0;
+                            ownerModelState.waitFrames = 0;
+                            ownerModelState.isScriptExecuting = 0;
+                            ownerModelState.runningAnimIdx = *scriptPtr;
+                            ownerModelState.animScriptIndex = getActorIdleAnimScript(actorID);
+                            scriptPtr = ptrToScriptTable[ownerModelState.animScriptIndex];
+                        }
+                    }
+                    break;
+                case 0xEE:
+                case 0xFF:
+                    ownerModelState.actorIsNotActing = 1;
+                    ownerModelState.currentScriptPosition = 0;
+                    ownerModelState.isScriptExecuting = 0;
+                    ownerModelState.waitFrames = 0;
+                    ownerModelState.animScriptIndex = getActorIdleAnimScript(actorID);
+                    scriptPtr = ptrToScriptTable[ownerModelState.animScriptIndex];
+                    break;
+                default:
+                    if (numArgsOpCode.contains(currentOpCode))
+                    {
+                        ownerModelState.currentScriptPosition += numArgsOpCode.at(currentOpCode);
+                        if (endingOpCode.contains(currentOpCode))
+                            isScriptActive = false;
+                    }
+                    else
+                    {
+                        if (trace_all || trace_battle_animation)
+                            ffnx_trace("not existing opcode: 0x%02x\n", currentOpCode);
+                        isScriptActive = false;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    // execute original run animation script
+    ((void (*)(byte, byte **))ff7_externals.run_animation_script)(actorID, ptrToScriptTable);
+
+    if (ownerModelState.currentScriptPosition != getBattleModelState(actorID)->currentScriptPosition)
+        ffnx_error("%s - Animation script pointer simulation wrong! Final position does not match (simulation: %d != real: %d)\n", __func__,
+                   ownerModelState.currentScriptPosition, getBattleModelState(actorID)->currentScriptPosition);
+
+    if (ownerModelState.waitFrames != getBattleModelState(actorID)->waitFrames)
+        ffnx_error("%s - Camera script pointer simulation wrong! Final frames to wait does not match (simulation: %d != real: %d)\n", __func__,
+                   ownerModelState.waitFrames, getBattleModelState(actorID)->waitFrames);
+}
+
+int ff7_add_fn_to_effect100_fn(uint32_t function)
+{
+    int idx;
+    for (idx = 0; idx < 100; idx++)
+    {
+        if (ff7_externals.effect100_array_fn[idx] == 0 && *ff7_externals.effect100_array_idx <= idx)
+            break;
+    }
+    if (idx >= 100)
+        return 0xFFFF;
+    if (isAddFunctionDisabled)
+        return idx;
+
+    ff7_externals.effect100_array_fn[idx] = function;
+    ff7_externals.effect100_array_data[idx].field_0 = *ff7_externals.effect100_array_idx;
+    *ff7_externals.effect100_counter = *ff7_externals.effect100_counter + 1;
+
+    extFramesCounterEffect100[idx] = 0;
+    useExtFramesCounterEffect100[idx] = false;
+    isNewEffect100Function[idx] = true;
+    return idx;
+}
+
+void ff7_execute_effect100_fn()
+{
+    uint16_t &fn_index = *ff7_externals.effect100_array_idx;
+    for (fn_index = 0; fn_index < 100; fn_index++)
+    {
+        if ((ff7_externals.effect100_array_fn[fn_index] == 0) || (ff7_externals.field_dword_9AD1AC == 0))
+        {
+            if (isNewEffect100Function[fn_index])
+                isNewEffect100Function[fn_index] = false;
+
+            if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_42782A)
+                ((void (*)())ff7_externals.effect100_array_fn[fn_index])();
+        }
+        else
+        {
+            if (isNewEffect100Function[fn_index])
+            {
+                if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_425D29)
+                {
+                    ff7_externals.effect100_array_data[fn_index].n_frames *= frame_multiplier;
+                }
+                else if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_5BDA0F)
+                {
+                    ff7_externals.effect100_array_data[fn_index].field_2 /= frame_multiplier;
+                    ff7_externals.effect100_array_data[fn_index].n_frames *= frame_multiplier;
+                }
+                else if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_enemy_death_5BBD24 ||
+                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_iainuki_death_5BCAAA ||
+                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_boss_death_5BC48C ||
+                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_melting_death_5BC21F ||
+                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_disintegrate_2_death_5BBA82 ||
+                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_morph_death_5BC812 ||
+                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_5C0E4B ||
+                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_5D4240 ||
+                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_42782A)
+                {
+                    // these are already fixed functions 
+                }
+                else
+                {
+                    useExtFramesCounterEffect100[fn_index] = true;
+                }
+
+                if (trace_all || trace_battle_animation)
+                    ffnx_trace("%s - executing function: 0x%x\n", __func__, ff7_externals.effect100_array_fn[fn_index]);
+
+                isNewEffect100Function[fn_index] = false;
+            }
+
+            // TODO: fix other effect100 functions by calling the function each 4 frame and keep the animation going for the other 3 frames 
+            // (hack solution: exploting pause variable; while game is paused, animation are still going, or find where animations are cleaned up)
+            ((void (*)())ff7_externals.effect100_array_fn[fn_index])();
+
+            if (ff7_externals.effect100_array_data[fn_index].field_0 == (uint16_t)-1)
+            {
+                ff7_externals.effect100_array_data[fn_index].field_0 = 0;
+                ff7_externals.effect100_array_data[fn_index].field_2 = 0;
+                ff7_externals.effect100_array_fn[fn_index] = 0;
+                *ff7_externals.effect100_counter = *ff7_externals.effect100_counter - 1;
+            }
+        }
+    }
+    fn_index = 0;
+}
+
+int ff7_add_fn_to_effect10_fn(uint32_t function)
+{
+    int idx;
+    for (idx = 0; idx < 10; idx++)
+    {
+        if (ff7_externals.effect10_array_fn[idx] == 0 && *ff7_externals.effect10_array_idx <= idx)
+            break;
+    }
+    if (idx >= 10)
+        return 0xFFFF;
+    if (isAddFunctionDisabled)
+        return idx;
+
+    ff7_externals.effect10_array_fn[idx] = function;
+    ff7_externals.effect10_array_data[idx].field_0 = *ff7_externals.effect10_array_idx;
+    *ff7_externals.effect10_counter = *ff7_externals.effect10_counter + 1;
+
+    isNewEffect10Function[idx] = true;
+    return idx;
+}
+
+void ff7_execute_effect10_fn()
+{
+    uint16_t &fn_index = *ff7_externals.effect10_array_idx;
+    for (fn_index = 0; fn_index < 10; fn_index++)
+    {
+        auto &effect10_data = ff7_externals.effect10_array_data[fn_index];
+        if (ff7_externals.effect10_array_fn[fn_index] != 0)
+        {
+            if (isNewEffect10Function[fn_index])
+            {
+                if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_426DE3)
+                {
+                    // Related to resting positions
+                    effect10_data.n_frames *= frame_multiplier;
+                    effect10_data.field_18 *= frame_multiplier; // probably wait frames
+                    effect10_data.field_C /= frame_multiplier;
+                    effect10_data.field_E /= frame_multiplier;
+                    effect10_data.field_6 /= frame_multiplier;
+                }
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_426941)
+                {
+                    // Related to resting positions
+                    effect10_data.n_frames *= frame_multiplier;
+                    effect10_data.field_A /= frame_multiplier;
+                    effect10_data.field_C /= frame_multiplier;
+                }
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_426899)
+                {
+                    // Related to resting Y rotation
+                    effect10_data.n_frames *= frame_multiplier;
+                    effect10_data.field_E /= frame_multiplier;
+                }
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_4267F1)
+                {
+                    // Related to resting Y position
+                    effect10_data.n_frames *= frame_multiplier;
+                    effect10_data.field_A /= frame_multiplier;
+                }
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_42C66D ||
+                         ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_42C823)
+                {
+                    // 42C66D is the transparent level fade out of the character
+                    // 42C823 is the transparent level fade in of the characters
+                    // TODO: fix vanishing model bug when there is fade in and fade out in sequence
+                    effect10_data.n_frames *= frame_multiplier;
+                    effect10_data.field_E /= frame_multiplier;
+                    effect10_data.field_8 /= frame_multiplier;
+                    effect10_data.field_A /= frame_multiplier;
+                    effect10_data.field_C /= frame_multiplier;
+                }
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_move_character_to_enemy_426A26)
+                {
+                    // Animation of moving characters from attacker to attacked
+                    effect10_data.n_frames *= frame_multiplier;
+                    effect10_data.field_18 *= frame_multiplier; // probably wait frames
+                    effect10_data.field_C /= frame_multiplier;
+                    effect10_data.field_E /= frame_multiplier;
+                }
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_42739D)
+                {
+                    // Animation of moving characters from attacker to attacked
+                    effect10_data.n_frames *= frame_multiplier;
+                    effect10_data.field_19 *= frame_multiplier;
+                    effect10_data.field_1A *= frame_multiplier;
+                    effect10_data.field_C /= frame_multiplier;
+                    effect10_data.field_E /= frame_multiplier;
+                }
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_426F58)
+                {
+                    effect10_data.n_frames *= frame_multiplier;
+                    // Do not modify the others, already done elsewhere
+                }
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_move_character_to_enemy_4270DE)
+                {
+                    // Animation of moving characters for some limit breaks from attacker to attacked
+                    effect10_data.n_frames *= frame_multiplier;
+                    effect10_data.field_19 *= frame_multiplier;
+                    effect10_data.field_1A *= frame_multiplier;
+                    effect10_data.field_C /= frame_multiplier;
+                    effect10_data.field_E /= frame_multiplier;
+                    effect10_data.field_14 /= frame_multiplier;
+                }
+                if (trace_all || trace_battle_animation)
+                    ffnx_trace("%s - executing function: 0x%x\n", __func__, ff7_externals.effect10_array_fn[fn_index]);
+
+                isNewEffect10Function[fn_index] = false;
+            }
+
+            ((void (*)())ff7_externals.effect10_array_fn[fn_index])();
+
+            if (effect10_data.field_0 == (uint16_t)-1)
+            {
+                effect10_data.field_0 = 0;
+                effect10_data.field_2 = 0;
+                ff7_externals.effect10_array_fn[fn_index] = 0;
+                *ff7_externals.effect10_counter = *ff7_externals.effect10_counter - 1;
+            }
+        }
+    }
+    fn_index = 0;
+}
+
+int ff7_add_fn_to_effect60_fn(uint32_t function)
+{
+    int idx;
+    for (idx = 0; idx < 10; idx++)
+    {
+        if (ff7_externals.effect60_array_fn[idx] == 0 && *ff7_externals.effect60_array_idx <= idx)
+            break;
+    }
+    if (idx >= 10)
+        return 0xFFFF;
+    if (isAddFunctionDisabled)
+        return idx;
+
+    ff7_externals.effect60_array_fn[idx] = function;
+    ff7_externals.effect60_array_data[idx].field_0 = *ff7_externals.effect60_array_idx;
+    *ff7_externals.effect60_counter = *ff7_externals.effect60_counter + 1;
+
+    extFramesCounterEffect60[idx] = 0;
+    useExtFramesCounterEffect60[idx] = false;
+    isNewEffect60Function[idx] = true;
+    return idx;
+}
+
+void ff7_execute_effect60_fn()
+{
+    uint16_t &fn_index = *ff7_externals.effect60_array_idx;
+    for (fn_index = 0; fn_index < 60; fn_index++)
+    {
+        if (ff7_externals.effect60_array_fn[fn_index] != 0)
+        {
+            if (isNewEffect60Function[fn_index])
+            {
+                if (ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_4276B6 ||
+                    ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_4255B7 ||
+                    ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_427737 ||
+                    ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_425AAD ||
+                    ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_427AF1 ||
+                    ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_4277B1)
+                {
+                    ff7_externals.effect60_array_data[fn_index].n_frames *= frame_multiplier;
+                }
+                else if (ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5BD96D)
+                {
+                    ff7_externals.effect60_array_data[fn_index].n_frames *= frame_multiplier;
+                    ff7_externals.effect60_array_data[fn_index].field_2 /= frame_multiplier;
+                }
+                else if (ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_425E5F ||
+                         ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5C1C8F ||
+                         ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5BCF9D ||
+                         ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_425520 ||
+                         ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_boss_death_sub_5BC5EC ||
+                         ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5BCD42 ||
+                         ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5BE4E2 ||
+                         ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5C18BC)
+                {
+                    // these are already fixed functions 
+                }
+                else
+                {
+                    useExtFramesCounterEffect60[fn_index] = true;
+                }
+
+                if (trace_all || trace_battle_animation)
+                    ffnx_trace("%s - executing function: 0x%x\n", __func__, ff7_externals.effect60_array_fn[fn_index]);
+
+                isNewEffect60Function[fn_index] = false;
+            }
+
+            if (useExtFramesCounterEffect60[fn_index])
+            {
+                // Execute function but updates field_2 only every 4 frames. Also avoid adding new functions on the other 3 frames
+                // TODO: fixes other effect60 functions that does not use field_2 or needs other modifications
+                auto data_prev = ff7_externals.effect60_array_data[fn_index];
+                if (extFramesCounterEffect60[fn_index] % frame_multiplier != 0)
+                    isAddFunctionDisabled = true;
+
+                ((void (*)())ff7_externals.effect60_array_fn[fn_index])();
+
+                isAddFunctionDisabled = false;
+                if (extFramesCounterEffect60[fn_index] % frame_multiplier != 0)
+                    ff7_externals.effect60_array_data[fn_index].field_2 = data_prev.field_2;
+
+                extFramesCounterEffect60[fn_index]++;
+            }
+            else
+            {
+                ((void (*)())ff7_externals.effect60_array_fn[fn_index])();
+            }
+
+            if (ff7_externals.effect60_array_data[fn_index].field_0 == (uint16_t)-1)
+            {
+                ff7_externals.effect60_array_data[fn_index].field_0 = 0;
+                ff7_externals.effect60_array_data[fn_index].field_2 = 0;
+                ff7_externals.effect60_array_fn[fn_index] = 0;
+                *ff7_externals.effect60_counter = *ff7_externals.effect60_counter - 1;
+            }
+        }
+    }
+    fn_index = 0;
+}
+
+void ff7_boss_death_animation_5BC5EC()
+{
+    auto &fn_data = ff7_externals.effect60_array_data[*ff7_externals.effect60_array_idx];
+    if (fn_data.n_frames == 0)
+    {
+        fn_data.field_0 = 0xFFFF;
+    }
+    else
+    {
+        if (fn_data.n_frames == (58 * frame_multiplier) || fn_data.n_frames == (64 * frame_multiplier))
+            *ff7_externals.field_battle_BFB2E0 = ((uint32_t(*)(byte, byte, byte))ff7_externals.battle_boss_death_call_5BD436)(0xFA, 0xFA, 0xFA);
+
+        int sign = ((fn_data.n_frames & 1) == 0) ? -1 : 1;
+        getBattleModelState(fn_data.field_8)->restingZPosition = fn_data.field_A + sign * 0x40;
+        fn_data.n_frames--;
+    }
+}
+
+void ff7_battle_sub_5BD96D()
+{
+    auto &fn_data = ff7_externals.effect60_array_data[*ff7_externals.effect60_array_idx];
+    if (fn_data.n_frames == 0)
+    {
+        fn_data.field_0 = 0xFFFF;
+    }
+    else
+    {
+        getBattleModelState(fn_data.field_6)->field_6 += fn_data.field_2;
+        fn_data.n_frames--;
+    }
+}
+
+int ff7_get_n_frames_display_action_string()
+{
+    int shiftValue = 2 - frame_multiplier / 2;
+    return ((int)*ff7_externals.field_byte_DC0E11 >> shiftValue) + 4 * frame_multiplier;
+}
+
+void ff7_battle_disintegrate_1_death_sub_5BC04D(byte effect10_array_idx)
+{
+    auto &fn_data = ff7_externals.effect10_array_data[effect10_array_idx];
+    auto &battle_model_state = *getBattleModelState(fn_data.field_8);
+    if (fn_data.n_frames == 0)
+    {
+        fn_data.field_0 = 0xFFFF;
+        battle_model_state.field_25 &= 0x7F;
+        battle_model_state.field_C &= 0xFFDF;
+        battle_model_state.actorIsNotActing = 1;
+        ((void (*)(byte))ff7_externals.battle_sub_42C0A7)(fn_data.field_8);
+    }
+    else
+    {
+        battle_model_state.field_14 += 0x80 / frame_multiplier;
+        if (battle_model_state.field_28 > 0)
+            battle_model_state.field_28 -= 0x10 / frame_multiplier;
+
+        battle_model_state.field_1AC8 = 1;
+
+        // effect10_array_data_8FE1F6 is a short array of 15 size. To avoid overflowing, divide also the index
+        battle_model_state.field_1ADC += (float)(int)ff7_externals.effect10_array_data_8FE1F6[(int)(fn_data.n_frames / frame_multiplier)] / frame_multiplier;
+        battle_model_state.field_1ACC += 22.5f / frame_multiplier;
+        battle_model_state.field_1AD0 += 22.5f / frame_multiplier;
+        battle_model_state.field_1AD4 += 22.5f / frame_multiplier;
+        fn_data.n_frames--;
+    }
+}
+
+void ff7_battle_sub_426F58()
+{
+    auto &fn_data = ff7_externals.effect10_array_data[*ff7_externals.effect10_array_idx];
+    if (fn_data.n_frames == 0)
+    {
+        fn_data.field_0 = 0xFFFF;
+    }
+    else
+    {
+        *ff7_externals.g_script_args[2] = fn_data.field_A;
+        *ff7_externals.g_script_args[3] = fn_data.field_8;
+        *ff7_externals.g_script_args[4] = fn_data.field_10;
+        getBattleModelState(*ff7_externals.g_script_args[3])->restingXPosition += fn_data.field_C / frame_multiplier;
+        getBattleModelState(*ff7_externals.g_script_args[3])->restingZPosition += fn_data.field_E / frame_multiplier;
+
+        int index = (int)(fn_data.field_18 / frame_multiplier) + *ff7_externals.g_script_args[4] * 8; // to avoid overflow
+        getBattleModelState(*ff7_externals.g_script_args[3])->restingYPosition += ff7_externals.resting_Y_array_data[index] / frame_multiplier;
+        fn_data.field_18++;
+        fn_data.n_frames--;
+    }
+}

--- a/src/ff7/camera.cpp
+++ b/src/ff7/camera.cpp
@@ -23,46 +23,45 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <utility>
+#include <span>
 
 #include "../ff7.h"
 #include "../log.h"
+#include "../globals.h"
 
-enum class PatchType
+const std::unordered_map<byte, int> numArgsPositionOpCode{{0xD5, 2}, {0xD6, 0}, {0xD7, 2}, {0xD8, 9}, {0xD9, 0}, {0xDA, 0}, {0xDB, 0}, {0xDC, 0}, {0xDD, 1}, {0xDE, 1}, {0xDF, 0}, {0xE0, 2}, {0xE1, 0}, {0xE2, 1}, {0xE3, 9}, {0xE4, 8}, {0xE5, 8}, {0xE6, 7}, {0xE7, 8}, {0xE9, 8}, {0xEB, 9}, {0xEF, 8}, {0xF0, 7}, {0xF1, 0}, {0xF2, 5}, {0xF3, 5}, {0xF4, -1}, {0xF5, 1}, {0xF7, 7}, {0xF8, 12}, {0xF9, 6}, {0xFE, 0}, {0xFF, -1}};
+const std::unordered_map<byte, int> numArgsOpCode{{0xD8, 9}, {0xD9, 0}, {0xDB, 0}, {0xDC, 0}, {0xDD, 1}, {0xDE, 1}, {0xDF, 0}, {0xE0, 2}, {0xE1, 0}, {0xE2, 1}, {0xE3, 9}, {0xE4, 8}, {0xE5, 8}, {0xE6, 7}, {0xE8, 8}, {0xEA, 8}, {0xEC, 9}, {0xF0, 8}, {0xF4, -1}, {0xF5, 1}, {0xF8, 7}, {0xF9, 7}, {0xFA, 6}, {0xFE, 0}, {0xFF, -1}};
+const std::unordered_set<byte> endingFocalOpCodes{0xF0, 0xF8, 0xF9, 0xFF};
+const std::unordered_set<byte> endingPositionOpCodes{0xEF, 0xF0, 0xF7, 0xFF};
+constexpr int CAMERA_ARRAY_SIZE = 16;
+std::array<bool, CAMERA_ARRAY_SIZE> isNewCameraFunction{};
+
+void patchOpCodeF5(bcamera_position *camera_position, char variationIndex)
 {
-    NONE = 0,
-    FIELD_1,
-    FIELD_3,
-    FIELD_4
-};
-
-PatchType patchTypeCameraFunction[16];
-const int frameMultiplier = ((ff7_fps_limiter == FF7_LIMITER_30FPS) ? 2 : 4);
-
-void patchOpCodeF5(battle_camera_position* camera_position, char variationIndex)
-{
-    camera_position[variationIndex].frames_to_wait = (camera_position[variationIndex].frames_to_wait + 1) * frameMultiplier;
-    camera_position[variationIndex].frames_to_wait--; // After 0xF5, there should "always" be an opcode 0xF4 
+    camera_position[variationIndex].frames_to_wait = (camera_position[variationIndex].frames_to_wait + 1) * frame_multiplier;
+    camera_position[variationIndex].frames_to_wait--; // After 0xF5, there should "always" be an opcode 0xF4
 }
 
 byte *getCameraScriptPointer(char variationIndex, short cameraScriptIdx, bool isSub5C3FD5)
 {
     int internalOffset = isSub5C3FD5 ? 4 : 0;
     if (cameraScriptIdx == -1)
-        return isSub5C3FD5 ? ff7_externals.battle_camera_scripts_8FEE30 : ff7_externals.battle_camera_scripts_8FEE2C;
+        return isSub5C3FD5 ? ff7_externals.battle_camera_focal_scripts_8FEE30 : ff7_externals.battle_camera_position_scripts_8FEE2C;
     else if (cameraScriptIdx == -2)
-        return isSub5C3FD5 ? (byte *)ff7_externals.battle_camera_scripts_901270[*ff7_externals.battle_camera_script_index] : (byte *)ff7_externals.battle_camera_scripts_9010D0[*ff7_externals.battle_camera_script_index];
+        return isSub5C3FD5 ? (byte *)ff7_externals.battle_camera_focal_scripts_901270[*ff7_externals.battle_camera_script_index] : (byte *)ff7_externals.battle_camera_position_scripts_9010D0[*ff7_externals.battle_camera_script_index];
     else if (cameraScriptIdx == -3)
     {
-        int outerOffset = variationIndex * 4 + *(int *)(*ff7_externals.battle_camera_scripts_9A13BC + 0x8 + internalOffset) - *ff7_externals.battle_camera_script_offset;
-        int finalOffset = *(int *)(*ff7_externals.battle_camera_scripts_9A13BC + outerOffset) - *ff7_externals.battle_camera_script_offset;
-        return (byte *)(*ff7_externals.battle_camera_scripts_9A13BC + finalOffset);
+        int outerOffset = variationIndex * 4 + *(int *)(*ff7_externals.battle_camera_global_scripts_9A13BC + 0x8 + internalOffset) - *ff7_externals.battle_camera_script_offset;
+        int finalOffset = *(int *)(*ff7_externals.battle_camera_global_scripts_9A13BC + outerOffset) - *ff7_externals.battle_camera_script_offset;
+        return (byte *)(*ff7_externals.battle_camera_global_scripts_9A13BC + finalOffset);
     }
-    int outerOffset = (3 * cameraScriptIdx + variationIndex) * 4 + *(int *)(*ff7_externals.battle_camera_scripts_9A13BC + internalOffset) - *ff7_externals.battle_camera_script_offset;
-    int finalOffset = *(int *)(*ff7_externals.battle_camera_scripts_9A13BC + outerOffset) - *ff7_externals.battle_camera_script_offset;
-    return (byte *)(*ff7_externals.battle_camera_scripts_9A13BC + finalOffset);
+    int outerOffset = (3 * cameraScriptIdx + variationIndex) * 4 + *(int *)(*ff7_externals.battle_camera_global_scripts_9A13BC + internalOffset) - *ff7_externals.battle_camera_script_offset;
+    int finalOffset = *(int *)(*ff7_externals.battle_camera_global_scripts_9A13BC + outerOffset) - *ff7_externals.battle_camera_script_offset;
+    return (byte *)(*ff7_externals.battle_camera_global_scripts_9A13BC + finalOffset);
 }
 
-bool simulateCameraScript(byte *scriptPtr, uint16_t &currentPosition, uint16_t &framesToWait, std::unordered_map<byte, int> &numArgsOpCode, std::unordered_set<byte> &deactiveOpCodes)
+bool simulateCameraScript(byte *scriptPtr, uint16_t &currentPosition, uint16_t &framesToWait, const std::unordered_map<byte, int> &numArgsOpCode,
+                          const std::unordered_set<byte> &endingOpCodes)
 {
     if (trace_all || trace_battle_camera)
         ffnx_trace("%s - START LIST OF CAMERA SCRIPT OPCODE AND ARGS\n", __func__);
@@ -88,7 +87,7 @@ bool simulateCameraScript(byte *scriptPtr, uint16_t &currentPosition, uint16_t &
             break;
         case 0xF5:
             executedOpCodeF5 = true;
-            framesToWait = scriptPtr[currentPosition++] * frameMultiplier;
+            framesToWait = scriptPtr[currentPosition++] * frame_multiplier;
             break;
         case 0xFE:
             if (framesToWait == 0)
@@ -106,11 +105,11 @@ bool simulateCameraScript(byte *scriptPtr, uint16_t &currentPosition, uint16_t &
             }
             break;
         default:
-            if (numArgsOpCode.find(currentOpCode) != numArgsOpCode.end())
+            if (numArgsOpCode.contains(currentOpCode))
             {
-                currentPosition += numArgsOpCode[currentOpCode];
+                currentPosition += numArgsOpCode.at(currentOpCode);
 
-                if (deactiveOpCodes.find(currentOpCode) != deactiveOpCodes.end())
+                if (endingOpCodes.contains(currentOpCode))
                     isScriptActive = false;
             }
             else
@@ -128,115 +127,82 @@ bool simulateCameraScript(byte *scriptPtr, uint16_t &currentPosition, uint16_t &
     return executedOpCodeF5;
 }
 
-void ff7_battle_camera_sub_5C3D0D()
+int ff7_add_fn_to_camera_fn(uint32_t function)
 {
-    long long result;
-
-    int index = *ff7_externals.camera_fn_index;
-    int variationIndex = ff7_externals.battle_camera_fn_data[index].variationIndex;
-
-    if (ff7_externals.battle_camera_fn_data[index].n_frames == 1)
-        ff7_externals.battle_camera_fn_data[index].field_0 = 0xFFFF;
-
-    ff7_externals.battle_camera_fn_data[index].c_x += ff7_externals.battle_camera_fn_data[index].b_y / frameMultiplier;
-    result = ((long long(*)(int))ff7_externals.sub_662538)(ff7_externals.battle_camera_fn_data[index].c_x);
-    ff7_externals.battle_camera_position_BE10F0[variationIndex].location_x = (((int)result * (int)ff7_externals.battle_camera_fn_data[index].b_z) >> 9) + ff7_externals.battle_camera_position_BE1130[variationIndex].location_x;
-    result = ((long long(*)(int))ff7_externals.sub_6624FD)(ff7_externals.battle_camera_fn_data[index].c_x);
-    ff7_externals.battle_camera_position_BE10F0[variationIndex].location_z = (((int)result * (int)ff7_externals.battle_camera_fn_data[index].b_z) >> 9) + ff7_externals.battle_camera_position_BE1130[variationIndex].location_z;
-    ff7_externals.battle_camera_position_BE10F0[variationIndex].location_y += ff7_externals.battle_camera_fn_data[index].b_x / frameMultiplier; 
-    // TODO: In some cases, this b_x / multiplier goes to 0, fix it somehow. Maybe do something also for the others that are divided b_y and c_y
-
-    if(trace_all || trace_battle_camera)
+    auto cameraArray = std::span<uint32_t>(ff7_externals.camera_fn_array, CAMERA_ARRAY_SIZE);
+    auto element = std::find(cameraArray.begin(), cameraArray.end(), 0);
+    if (element != cameraArray.end())
     {
-        ffnx_trace("new camera_position_BE1130_x: %d\n", ff7_externals.battle_camera_position_BE1130[variationIndex].location_x);
-        ffnx_trace("new camera_position_BE1130_y: %d\n", ff7_externals.battle_camera_position_BE1130[variationIndex].location_y);
-        ffnx_trace("new camera_position_BE1130_z: %d\n", ff7_externals.battle_camera_position_BE1130[variationIndex].location_z);
-        ffnx_trace("new camera_position_BE10F0_x: %d\n", ff7_externals.battle_camera_position_BE10F0[variationIndex].location_x);
-        ffnx_trace("new camera_position_BE10F0_y: %d\n", ff7_externals.battle_camera_position_BE10F0[variationIndex].location_y);
-        ffnx_trace("new camera_position_BE10F0_z: %d\n", ff7_externals.battle_camera_position_BE10F0[variationIndex].location_z);
+        int index = std::distance(cameraArray.begin(), element);
+        ff7_externals.camera_fn_array[index] = function;
+        ff7_externals.camera_fn_data[index].field_0 = *ff7_externals.camera_fn_index;
+        *ff7_externals.camera_fn_counter = *ff7_externals.camera_fn_counter + 1;
+
+        isNewCameraFunction[index] = true;
+        return index;
     }
-
-    ff7_externals.battle_camera_fn_data[index].b_z += ff7_externals.battle_camera_fn_data[index].c_y / frameMultiplier;
-    ff7_externals.battle_camera_fn_data[index].n_frames--;
-}
-
-// For the other opcodes
-int ff7_add_fn_to_camera_fn_for_field_1(uint32_t function)
-{
-    int fnIdx = ((int (*)(uint32_t))ff7_externals.add_fn_to_camera_fn_array)(function);
-    patchTypeCameraFunction[fnIdx] = PatchType::FIELD_1;
-    return fnIdx;
-}
-
-// For 0xEB opcode of battle_camera_sub_5C23D1
-int ff7_add_fn_to_camera_fn_for_field_3(uint32_t function)
-{
-    int fnIdx = ((int (*)(uint32_t))ff7_externals.add_fn_to_camera_fn_array)(function);
-    patchTypeCameraFunction[fnIdx] = PatchType::FIELD_3;
-    return fnIdx;
-}
-
-// For 0xE7 and 0xE9 opcode of battle_camera_sub_5C23D1
-int ff7_add_fn_to_camera_fn_for_field_4(uint32_t function)
-{
-    int fnIdx = ((int (*)(uint32_t))ff7_externals.add_fn_to_camera_fn_array)(function);
-    patchTypeCameraFunction[fnIdx] = PatchType::FIELD_4;
-    return fnIdx;
-}
-
-// For battle_camera_sub_5C52F8 and battle_camera_sub_5C3E6F
-int ff7_add_fn_to_camera_fn_special_multiply(uint32_t function)
-{   
-    ffnx_trace("%s - function added 0x%x\n", __func__, function);
-    DWORD *battle_data_C05FF4_pointer = (DWORD *)*ff7_externals.battle_data_C05FF4;
-    *battle_data_C05FF4_pointer *= frameMultiplier;
-    return ((int (*)(uint32_t))ff7_externals.add_fn_to_camera_fn_array)(function);
+    return 0xFFFF;
 }
 
 void ff7_execute_camera_functions()
-{   
-    for (int index = 0; index < 16; index++)
+{
+    uint16_t &fn_index = *ff7_externals.camera_fn_index;
+    for (fn_index = 0; fn_index < CAMERA_ARRAY_SIZE; fn_index++)
     {
-        if (ff7_externals.camera_fn_array[index] != 0)
+        if (ff7_externals.camera_fn_array[fn_index] != 0)
         {
-            if(patchTypeCameraFunction[index] != PatchType::NONE)
+            if (isNewCameraFunction[fn_index])
+            {
+                if (ff7_externals.camera_fn_array[fn_index] == ff7_externals.battle_camera_position_sub_5C5B9C ||
+                    ff7_externals.camera_fn_array[fn_index] == ff7_externals.battle_camera_focal_sub_5C5F5E ||
+                    ff7_externals.camera_fn_array[fn_index] == ff7_externals.battle_camera_position_sub_5C557D ||
+                    ff7_externals.camera_fn_array[fn_index] == ff7_externals.battle_camera_focal_sub_5C5714)
+                {
+                    ff7_externals.camera_fn_data[fn_index].n_frames *= frame_multiplier;
+                }
+                else if (ff7_externals.camera_fn_array[fn_index] == ff7_externals.battle_camera_position_sub_5C3D0D)
+                {
+                    ff7_externals.camera_fn_data[fn_index].n_frames *= frame_multiplier;
+                    ff7_externals.camera_fn_data[fn_index].field_8 /= frame_multiplier;
+                    ff7_externals.camera_fn_data[fn_index].field_6 /= frame_multiplier;
+                    ff7_externals.camera_fn_data[fn_index].field_E /= frame_multiplier;
+                }
+
                 if (trace_all || trace_battle_camera)
-                    ffnx_trace("%s - function started 0x%x\n", __func__, ff7_externals.camera_fn_array[index]);
-            
-            if(patchTypeCameraFunction[index] == PatchType::FIELD_1)
-                ff7_externals.battle_camera_fn_data[index].n_frames *= frameMultiplier;
-            else if (patchTypeCameraFunction[index] == PatchType::FIELD_3)
-                ff7_externals.battle_camera_fn_data[index].b_y *= frameMultiplier;
-            else if (patchTypeCameraFunction[index] == PatchType::FIELD_4)
-                ff7_externals.battle_camera_fn_data[index].b_z *= frameMultiplier;
-            
-            patchTypeCameraFunction[index] = PatchType::NONE;
+                    ffnx_trace("%s - executing function: 0x%x\n", __func__, ff7_externals.camera_fn_array[fn_index]);
+
+                isNewCameraFunction[fn_index] = false;
+            }
+
+            ((void (*)())ff7_externals.camera_fn_array[fn_index])();
+            if (ff7_externals.camera_fn_data[fn_index].field_0 == (uint16_t)-1)
+            {
+                ff7_externals.camera_fn_data[fn_index].field_0 = 0;
+                ff7_externals.camera_fn_data[fn_index].field_2 = 0;
+                ff7_externals.camera_fn_array[fn_index] = 0;
+                *ff7_externals.camera_fn_counter = *ff7_externals.camera_fn_counter - 1;
+            }
         }
     }
-    ((void (*)())ff7_externals.execute_camera_functions)();
+    fn_index = 0;
 }
 
-void ff7_battle_camera_sub_5C3FD5(char variationIndex, DWORD param_2, short cameraScriptIdx)
+void ff7_run_camera_focal_position_script(char variationIndex, DWORD param_2, short cameraScriptIdx)
 {
     if (trace_all || trace_battle_camera)
         ffnx_trace("%s - Parameters: %d, %d, %d\n", __func__, variationIndex, param_2, cameraScriptIdx);
 
-    battle_camera_position *cameraPosition = ff7_externals.battle_camera_position_BE1130;
+    bcamera_position *cameraPosition = ff7_externals.battle_camera_focal_position;
 
     byte *scriptPtr = getCameraScriptPointer(variationIndex, cameraScriptIdx, true);
     uint16_t currentPosition = (cameraPosition[variationIndex].current_position == 255) ? 0 : cameraPosition[variationIndex].current_position;
     uint16_t framesToWait = (cameraPosition[variationIndex].current_position == 255) ? 0 : cameraPosition[variationIndex].frames_to_wait;
 
-    std::unordered_map<byte, int> numArgsOpCode{{0xD8, 9}, {0xD9, 0}, {0xDB, 0}, {0xDC, 0}, {0xDD, 1}, {0xDE, 1}, {0xDF, 0}, {0xE0, 2}, {0xE1, 0}, 
-                                                {0xE2, 1}, {0xE3, 9}, {0xE4, 8}, {0xE5, 8}, {0xE6, 7}, {0xE8, 8}, {0xEA, 8}, {0xEC, 9}, {0xF0, 8}, 
-                                                {0xF4, -1}, {0xF5, 1}, {0xF8, 7}, {0xF9, 7}, {0xFA, 6}, {0xFE, 0}, {0xFF, -1}};
-    std::unordered_set<byte> deactiveOpCodes{0xF0, 0xF8, 0xF9, 0xFF};
+    bool executedOpCodeF5 = simulateCameraScript(scriptPtr, currentPosition, framesToWait, numArgsOpCode, endingFocalOpCodes);
 
-    bool executedOpCodeF5 = simulateCameraScript(scriptPtr, currentPosition, framesToWait, numArgsOpCode, deactiveOpCodes);
+    ((void (*)(char, DWORD, short))ff7_externals.set_camera_focal_position_scripts)(variationIndex, param_2, cameraScriptIdx);
 
-    ((void (*)(char, DWORD, short))ff7_externals.battle_camera_sub_5C3FD5)(variationIndex, param_2, cameraScriptIdx);
-
-    if(executedOpCodeF5)
+    if (executedOpCodeF5)
         patchOpCodeF5(cameraPosition, variationIndex);
 
     if (currentPosition != cameraPosition[variationIndex].current_position)
@@ -248,28 +214,22 @@ void ff7_battle_camera_sub_5C3FD5(char variationIndex, DWORD param_2, short came
                    framesToWait, cameraPosition[variationIndex].frames_to_wait);
 }
 
-void ff7_battle_camera_sub_5C23D1(char variationIndex, DWORD param_2, short cameraScriptIdx)
+void ff7_run_camera_position_script(char variationIndex, DWORD param_2, short cameraScriptIdx)
 {
     if (trace_all || trace_battle_camera)
         ffnx_trace("%s - Parameters: %d, %d, %d\n", __func__, variationIndex, param_2, cameraScriptIdx);
 
-    battle_camera_position *cameraPosition = ff7_externals.battle_camera_position_BE10F0;
+    bcamera_position *cameraPosition = ff7_externals.battle_camera_position;
 
     byte *scriptPtr = getCameraScriptPointer(variationIndex, cameraScriptIdx, false);
     uint16_t currentPosition = (cameraPosition[variationIndex].current_position == 255) ? 0 : cameraPosition[variationIndex].current_position;
     uint16_t framesToWait = (cameraPosition[variationIndex].current_position == 255) ? 0 : cameraPosition[variationIndex].frames_to_wait;
 
-    std::unordered_map<byte, int> numArgsOpCode{{0xD5, 2}, {0xD6, 0}, {0xD7, 2}, {0xD8, 9}, {0xD9, 0}, {0xDA, 0}, {0xDB, 0}, {0xDC, 0}, {0xDD, 1},
-                                                {0xDE, 1}, {0xDF, 0}, {0xE0, 2}, {0xE1, 0}, {0xE2, 1}, {0xE3, 9}, {0xE4, 8}, {0xE5, 8}, {0xE6, 7}, 
-                                                {0xE7, 8}, {0xE9, 8}, {0xEB, 9}, {0xEF, 8}, {0xF0, 7}, {0xF1, 0}, {0xF2, 5}, {0xF3, 5}, {0xF4, -1},
-                                                {0xF5, 1}, {0xF7, 7}, {0xF8, 12}, {0xF9, 6}, {0xFE, 0}, {0xFF, -1}};
-    std::unordered_set<byte> deactiveOpCodes{0xEF, 0xF0, 0xF7, 0xFF};
+    bool executedOpCodeF5 = simulateCameraScript(scriptPtr, currentPosition, framesToWait, numArgsPositionOpCode, endingPositionOpCodes);
 
-    bool executedOpCodeF5 = simulateCameraScript(scriptPtr, currentPosition, framesToWait, numArgsOpCode, deactiveOpCodes);
+    ((void (*)(char, DWORD, short))ff7_externals.set_camera_position_scripts)(variationIndex, param_2, cameraScriptIdx);
 
-    ((void (*)(char, DWORD, short))ff7_externals.battle_camera_sub_5C23D1)(variationIndex, param_2, cameraScriptIdx);
-
-    if(executedOpCodeF5)
+    if (executedOpCodeF5)
         patchOpCodeF5(cameraPosition, variationIndex);
 
     if (currentPosition != cameraPosition[variationIndex].current_position)

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -65,14 +65,24 @@ void ff7_character_regularly_field_entity_60FA7D(WORD param1, short param2, shor
 int ff7_load_save_file(int param_1);
 
 // camera
-int ff7_add_fn_to_camera_fn_special_multiply(uint32_t function);
-int ff7_add_fn_to_camera_fn_for_field_1(uint32_t function);
-int ff7_add_fn_to_camera_fn_for_field_3(uint32_t function);
-int ff7_add_fn_to_camera_fn_for_field_4(uint32_t function);
+int ff7_add_fn_to_camera_fn(uint32_t function);
 void ff7_execute_camera_functions();
-void ff7_battle_camera_sub_5C3FD5(char index, DWORD param_2, short param_3);
-void ff7_battle_camera_sub_5C23D1(char index, DWORD param_2, short param_3);
-void ff7_battle_camera_sub_5C3D0D();
+void ff7_run_camera_focal_position_script(char index, DWORD param_2, short param_3);
+void ff7_run_camera_position_script(char index, DWORD param_2, short param_3);
+
+// animation
+void ff7_run_animation_script(byte actorID, byte **ptrToScriptTable);
+int ff7_add_fn_to_effect100_fn(uint32_t function);
+int ff7_add_fn_to_effect60_fn(uint32_t function);
+int ff7_add_fn_to_effect10_fn(uint32_t function);
+void ff7_execute_effect100_fn();
+void ff7_execute_effect60_fn();
+void ff7_execute_effect10_fn();
+void ff7_boss_death_animation_5BC5EC();
+void ff7_battle_sub_5BD96D();
+void ff7_battle_sub_426F58();
+int ff7_get_n_frames_display_action_string();
+void ff7_battle_disintegrate_1_death_sub_5BC04D(byte effect10_array_idx);
 
 // field
 void field_load_textures(struct ff7_game_obj *game_object, struct struc_3 *struc_3);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -557,32 +557,188 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 
 	// camera 60 fps
 	ff7_externals.handle_camera_functions = get_relative_call(ff7_externals.battle_sub_42D992, 0xE3);
-	ff7_externals.battle_camera_sub_5C3FD5 = get_relative_call(ff7_externals.handle_camera_functions, 0x35);
-	ff7_externals.battle_camera_sub_5C23D1 = get_relative_call(ff7_externals.handle_camera_functions, 0x4B);
+	ff7_externals.set_camera_focal_position_scripts = get_relative_call(ff7_externals.handle_camera_functions, 0x35);
+	ff7_externals.set_camera_position_scripts = get_relative_call(ff7_externals.handle_camera_functions, 0x4B);
 	ff7_externals.execute_camera_functions = get_relative_call(ff7_externals.handle_camera_functions, 0x55);
-	ff7_externals.add_fn_to_camera_fn_array = get_relative_call(ff7_externals.battle_camera_sub_5C3FD5, 0xF40);
-	ff7_externals.battle_camera_sub_5C52F8 = get_relative_call(ff7_externals.battle_camera_sub_5C3FD5, 0x10A8);
-	ff7_externals.battle_camera_sub_5C3E6F = get_relative_call(ff7_externals.battle_camera_sub_5C23D1, 0x169E);
+	ff7_externals.add_fn_to_camera_fn_array = get_relative_call(ff7_externals.set_camera_focal_position_scripts, 0xF40);
+	ff7_externals.battle_camera_sub_5C52F8 = get_relative_call(ff7_externals.set_camera_focal_position_scripts, 0x10A8);
+	ff7_externals.battle_camera_sub_5C3E6F = get_relative_call(ff7_externals.set_camera_position_scripts, 0x169E);
 	ff7_externals.camera_fn_array = (uint32_t*)get_absolute_value(ff7_externals.add_fn_to_camera_fn_array, 0x39);
-	ff7_externals.battle_camera_fn_data = (battle_camera_fn_data*)get_absolute_value(ff7_externals.add_fn_to_camera_fn_array, 0x4D);
-	ff7_externals.battle_camera_position_BE10F0 = (battle_camera_position*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0x331);
-	ff7_externals.battle_camera_position_BE1130 = (battle_camera_position*)get_absolute_value(ff7_externals.battle_camera_sub_5C3FD5, 0x233);
-	ff7_externals.battle_camera_scripts_8FEE30 = (byte*)get_absolute_value(ff7_externals.battle_camera_sub_5C3FD5, 0xC1);
-	ff7_externals.battle_camera_scripts_8FEE2C = (byte*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0xC1);
-	ff7_externals.battle_camera_scripts_9A13BC = (DWORD*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0x17);
-	ff7_externals.battle_camera_scripts_9010D0 = (DWORD*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0xDC);
-	ff7_externals.battle_camera_scripts_901270 = (DWORD*)get_absolute_value(ff7_externals.battle_camera_sub_5C3FD5, 0xDC);
-	ff7_externals.battle_camera_script_index = (byte*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0xD2);
-	ff7_externals.battle_camera_script_offset = (DWORD*)get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0x25);
-	ff7_externals.battle_data_C05FF4 = (DWORD*)get_absolute_value(ff7_externals.battle_camera_sub_5C3E6F, 0x70);
+	ff7_externals.camera_fn_data = (bcamera_fn_data*)get_absolute_value(ff7_externals.add_fn_to_camera_fn_array, 0x4D);
+	ff7_externals.battle_camera_position = (bcamera_position*)get_absolute_value(ff7_externals.set_camera_position_scripts, 0x331);
+	ff7_externals.battle_camera_focal_position = (bcamera_position*)get_absolute_value(ff7_externals.set_camera_focal_position_scripts, 0x233);
+	ff7_externals.battle_camera_focal_scripts_8FEE30 = (byte*)get_absolute_value(ff7_externals.set_camera_focal_position_scripts, 0xC1);
+	ff7_externals.battle_camera_position_scripts_8FEE2C = (byte*)get_absolute_value(ff7_externals.set_camera_position_scripts, 0xC1);
+	ff7_externals.battle_camera_global_scripts_9A13BC = (DWORD*)get_absolute_value(ff7_externals.set_camera_position_scripts, 0x17);
+	ff7_externals.battle_camera_position_scripts_9010D0 = (DWORD*)get_absolute_value(ff7_externals.set_camera_position_scripts, 0xDC);
+	ff7_externals.battle_camera_focal_scripts_901270 = (DWORD*)get_absolute_value(ff7_externals.set_camera_focal_position_scripts, 0xDC);
+	ff7_externals.battle_camera_script_index = (byte*)get_absolute_value(ff7_externals.set_camera_position_scripts, 0xD2);
+	ff7_externals.battle_camera_script_offset = (DWORD*)get_absolute_value(ff7_externals.set_camera_position_scripts, 0x25);
 	ff7_externals.camera_fn_index = (WORD*)get_absolute_value(ff7_externals.add_fn_to_camera_fn_array, 0x46);
+	ff7_externals.camera_fn_counter = (WORD*)get_absolute_value(ff7_externals.add_fn_to_camera_fn_array, 0x54);
 
-	ff7_externals.battle_camera_sub_5C3D0D = get_absolute_value(ff7_externals.battle_camera_sub_5C23D1, 0x5DE);
-	ff7_externals.sub_662538 = get_relative_call(ff7_externals.battle_camera_sub_5C3D0D, 0x76);
-	ff7_externals.sub_6624FD = get_relative_call(ff7_externals.battle_camera_sub_5C3D0D, 0xBB);
+	ff7_externals.battle_camera_position_sub_5C3D0D = get_absolute_value(ff7_externals.set_camera_position_scripts, 0x5DE);
+	ff7_externals.battle_camera_position_sub_5C5B9C = get_absolute_value(ff7_externals.set_camera_position_scripts, 0x40A); 
+	ff7_externals.battle_camera_position_sub_5C557D = get_absolute_value(ff7_externals.set_camera_position_scripts, 0xE28); 
+	ff7_externals.battle_camera_focal_sub_5C5F5E = get_absolute_value(ff7_externals.set_camera_focal_position_scripts, 0xBDB); 
+	ff7_externals.battle_camera_focal_sub_5C5714 = get_absolute_value(ff7_externals.set_camera_focal_position_scripts, 0x67D); 
 
 	ff7_externals.battle_sub_430DD0 = get_relative_call(ff7_externals.battle_loop, 0x99E);
 	ff7_externals.battle_sub_429D8A = get_absolute_value(ff7_externals.battle_loop, 0x59);
+	uint32_t battle_sub_6D83C8 = get_relative_call(ff7_externals.battle_sub_6CE8B3, 0x77);
+	uint32_t battle_sub_6D82EA = get_relative_call(battle_sub_6D83C8, 0xE0);
+	uint32_t battle_sub_6D797C = get_relative_call(battle_sub_6D82EA, 0x59);
+	ff7_externals.battle_sub_6E3135 = get_relative_call(battle_sub_6D797C, 0x1C2);
+	// --------------------------------
+
+	// animation 60 fps
+	uint32_t battle_sub_42A5D0 = get_relative_call(ff7_externals.battle_sub_429AC0, 0x1A6);
+	ff7_externals.battle_sub_42A5EB = get_relative_call(battle_sub_42A5D0, 0x14);
+	ff7_externals.battle_sub_42E275 = get_relative_call(ff7_externals.battle_sub_42D992, 0x6C);
+	uint32_t battle_sub_42E3CA = get_relative_call(ff7_externals.battle_sub_42D992, 0x48);
+	ff7_externals.battle_sub_42E34A = get_relative_call(battle_sub_42E3CA, 0x70);
+	uint32_t battle_sub_42DBD2 = get_relative_call(ff7_externals.battle_sub_42D992, 0x90);
+	uint32_t battle_sub_42F21F = get_relative_call(battle_sub_42DBD2, 0x37);
+	uint32_t battle_sub_5B9EC2 = get_relative_call(battle_sub_42F21F, 0x38);
+	ff7_externals.battle_sub_5BD5E9 = get_relative_call(battle_sub_5B9EC2, 0x41);
+	uint32_t battle_sub_42DE61 = get_relative_call(ff7_externals.battle_sub_42D992, 0x9F);
+	uint32_t battle_sub_5C1B81 = get_absolute_value(battle_sub_42DE61, 0x17E);
+	ff7_externals.battle_sub_5C1D9A = get_relative_call(battle_sub_5C1B81, 0xA4);
+	ff7_externals.run_animation_script = get_relative_call(ff7_externals.battle_sub_42A5EB, 0xB8);
+	ff7_externals.add_fn_to_effect100_fn = get_relative_call(ff7_externals.run_animation_script, 0x48C2);
+	ff7_externals.execute_effect100_fn = get_relative_call(ff7_externals.battle_sub_42D992, 0x12E);
+	ff7_externals.add_fn_to_effect60_fn = get_relative_call(ff7_externals.run_animation_script, 0x394);
+	ff7_externals.execute_effect60_fn = get_relative_call(ff7_externals.battle_sub_42D992, 0x129);
+	ff7_externals.add_fn_to_effect10_fn = get_relative_call(ff7_externals.run_animation_script, 0x825);
+	ff7_externals.execute_effect10_fn = get_relative_call(ff7_externals.battle_sub_42D992, 0x4D);
+	uint32_t battle_sub_42B66A = get_relative_call(ff7_externals.run_animation_script, 0x460A);
+	
+	ff7_externals.effect100_array_data = (effect100_data*)get_absolute_value(ff7_externals.add_fn_to_effect100_fn, 0x5D);
+	ff7_externals.effect100_array_fn = (uint32_t*)get_absolute_value(ff7_externals.add_fn_to_effect100_fn, 0x48);
+	ff7_externals.effect100_counter = (uint16_t*)get_absolute_value(ff7_externals.add_fn_to_effect100_fn, 0x63);
+	ff7_externals.effect100_array_idx = (uint16_t*)get_absolute_value(ff7_externals.add_fn_to_effect100_fn, 0x32);
+	ff7_externals.effect60_array_data = (effect60_data*)get_absolute_value(ff7_externals.add_fn_to_effect60_fn, 0x5D);
+	ff7_externals.effect60_array_fn = (uint32_t*)get_absolute_value(ff7_externals.add_fn_to_effect60_fn, 0x48);
+	ff7_externals.effect60_array_idx = (uint16_t*)get_absolute_value(ff7_externals.add_fn_to_effect60_fn, 0x32);
+	ff7_externals.effect60_counter = (uint16_t*)get_absolute_value(ff7_externals.add_fn_to_effect60_fn, 0x63);
+	ff7_externals.effect10_array_data = (effect10_data*)get_absolute_value(ff7_externals.add_fn_to_effect10_fn, 0x5D);
+	ff7_externals.effect10_array_fn = (uint32_t*)get_absolute_value(ff7_externals.add_fn_to_effect10_fn, 0x48);
+	ff7_externals.effect10_array_idx = (uint16_t*)get_absolute_value(ff7_externals.add_fn_to_effect10_fn, 0x32);
+	ff7_externals.effect10_counter = (uint16_t*)get_absolute_value(ff7_externals.add_fn_to_effect10_fn, 0x63);
+	ff7_externals.g_actor_idle_scripts = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0x304);
+	ff7_externals.g_battle_model_state = (battle_model_state*)get_absolute_value(battle_sub_42B66A, 0xD9);
+	ff7_externals.g_small_battle_model_state = (battle_model_state_small*)get_absolute_value(ff7_externals.run_animation_script, 0x2BB9);
+	std::function<int(int)> shift_index = [](int index){return index - 0x2E;};
+	ff7_externals.animation_script_pointers[shift_index(0x2E)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0x81);
+	ff7_externals.animation_script_pointers[shift_index(0x2F)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0x90);
+	ff7_externals.animation_script_pointers[shift_index(0x30)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0x9F);
+	ff7_externals.animation_script_pointers[shift_index(0x31)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0xAE);
+	ff7_externals.animation_script_pointers[shift_index(0x32)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0xBD);
+	ff7_externals.animation_script_pointers[shift_index(0x34)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0xCC);
+	ff7_externals.animation_script_pointers[shift_index(0x35)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0xD8);
+	ff7_externals.animation_script_pointers[shift_index(0x36)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0xE4);
+	ff7_externals.animation_script_pointers[shift_index(0x37)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0xF0);
+	ff7_externals.animation_script_pointers[shift_index(0x38)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0xFC);
+	ff7_externals.animation_script_pointers[shift_index(0x39)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0x12D);
+	ff7_externals.animation_script_pointers[shift_index(0x3A)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0x139);
+	ff7_externals.animation_script_pointers[shift_index(0x3B)] = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0x145);
+	ff7_externals.g_is_effect_loading = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0x2D25);
+	ff7_externals.g_is_battle_paused = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0xA);
+	ff7_externals.special_actor_id = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0x286B);
+	ff7_externals.g_script_wait_frames = (byte*)get_absolute_value(ff7_externals.run_animation_script, 0x27E8);
+	ff7_externals.field_dword_9AD1AC = (DWORD*)get_absolute_value(ff7_externals.execute_effect100_fn, 0x41);
+	ff7_externals.g_script_args = (int**)get_absolute_value(ff7_externals.run_animation_script, 0x3EA);
+
+	// normal enemy death
+	uint32_t battle_run_enemy_deaths_42567E = get_relative_call(ff7_externals.run_animation_script, 0x4869);
+	ff7_externals.battle_enemy_death_5BBD24 = get_absolute_value(battle_run_enemy_deaths_42567E, 0x37);
+	ff7_externals.battle_enemy_death_sub_5BBE32 = get_relative_call(ff7_externals.battle_enemy_death_5BBD24, 0xF1);
+
+	// enemy death - iainuki
+	ff7_externals.battle_iainuki_death_5BCAAA = get_absolute_value(battle_run_enemy_deaths_42567E, 0x72);
+	ff7_externals.battle_iainuki_death_sub_5BCBB8 = get_relative_call(ff7_externals.battle_iainuki_death_5BCAAA, 0xF1);
+
+	// boss death
+	ff7_externals.battle_boss_death_5BC48C = get_absolute_value(battle_run_enemy_deaths_42567E, 0x16A);
+	ff7_externals.battle_boss_death_sub_5BC6ED = get_relative_call(ff7_externals.battle_boss_death_5BC48C, 0x144);
+	ff7_externals.battle_boss_death_sub_5BC5EC = get_absolute_value(ff7_externals.battle_boss_death_5BC48C, 0x9F);
+	ff7_externals.battle_boss_death_call_5BD436 = get_relative_call(ff7_externals.battle_boss_death_sub_5BC5EC, 0x7C);
+	ff7_externals.field_battle_BFB2E0 = (int*)get_absolute_value(ff7_externals.battle_boss_death_sub_5BC5EC, 0x85);
+
+	// enemy death - melting
+	ff7_externals.battle_melting_death_5BC21F = get_absolute_value(battle_run_enemy_deaths_42567E, 0xF7);
+	ff7_externals.battle_melting_death_sub_5BC32D = get_relative_call(ff7_externals.battle_melting_death_5BC21F, 0xF1);
+
+	// enemy death - disintegrate 2
+	ff7_externals.battle_disintegrate_2_death_5BBA82 = get_absolute_value(battle_run_enemy_deaths_42567E, 0x132);
+	ff7_externals.battle_disintegrate_2_death_sub_5BBBDE = get_relative_call(ff7_externals.battle_disintegrate_2_death_5BBA82, 0xFE);
+	ff7_externals.field_float_battle_7B7680 = (float*)get_absolute_value(ff7_externals.battle_disintegrate_2_death_sub_5BBBDE, 0x10F);
+
+	// enemy death - morph
+	ff7_externals.battle_morph_death_5BC812 = get_absolute_value(battle_run_enemy_deaths_42567E, 0x1A2);
+	ff7_externals.battle_morph_death_sub_5BC920 = get_relative_call(ff7_externals.battle_morph_death_5BC812, 0xF1);
+
+	// enemy death - disintegrate 1
+	ff7_externals.battle_disintegrate_1_death_5BBF31 = get_absolute_value(battle_run_enemy_deaths_42567E, 0xAD);
+	ff7_externals.battle_disintegrate_1_death_sub_5BC04D = get_relative_call(ff7_externals.battle_disintegrate_1_death_5BBF31, 0xFF);
+	ff7_externals.battle_sub_42C0A7 = get_relative_call(ff7_externals.battle_disintegrate_1_death_sub_5BC04D, 0x8D);
+	ff7_externals.effect10_array_data_8FE1F6 = (short*)get_absolute_value(ff7_externals.battle_disintegrate_1_death_sub_5BC04D, 0x123);
+	
+	// unknowns
+	uint32_t battle_sub_5C0E39 = get_relative_call(ff7_externals.battle_sub_427C22, 0x4DE);
+	ff7_externals.battle_sub_5C0E4B = get_absolute_value(battle_sub_5C0E39, 0x4);
+
+	uint32_t* battle_anim_functions_8FE860 = (uint32_t*)get_absolute_value(ff7_externals.battle_sub_427C22, 0x40E);
+	ff7_externals.battle_sub_5D4240 = battle_anim_functions_8FE860[56];
+	ff7_externals.battle_sub_5BD96D = get_absolute_value(ff7_externals.battle_sub_5D4240, 0x27);
+
+	ff7_externals.battle_sub_425D29 = get_absolute_value(ff7_externals.run_animation_script, 0x2850);
+
+	ff7_externals.battle_sub_5BDA0F = get_absolute_value(ff7_externals.run_animation_script, 0x240);
+
+	ff7_externals.battle_sub_5C1C8F = get_absolute_value(battle_sub_5C1B81, 0x3F);
+	uint32_t battle_sub_42C31C = get_relative_call(ff7_externals.battle_sub_5C1C8F, 0xEC);
+	ff7_externals.battle_sub_42C66D = get_absolute_value(battle_sub_42C31C, 0x45);
+	ff7_externals.battle_sub_42C823 = get_absolute_value(battle_sub_42C31C, 0x198);
+
+	// display string for actor actions
+	ff7_externals.battle_sub_42782A = get_absolute_value(ff7_externals.run_animation_script, 0x4906);
+	ff7_externals.get_n_frames_display_action_string = get_relative_call(ff7_externals.run_animation_script, 0x4918);
+	ff7_externals.field_byte_DC0E11 = (byte*)get_absolute_value(ff7_externals.get_n_frames_display_action_string, 0x6);
+
+	// resting positions and rotations
+	uint32_t battle_sub_426C9B = get_relative_call(ff7_externals.run_animation_script, 0x14C7);
+	ff7_externals.battle_sub_426DE3 = get_absolute_value(battle_sub_426C9B, 0x5);
+	ff7_externals.battle_sub_426941 = get_absolute_value(ff7_externals.run_animation_script, 0x1A5D);
+	ff7_externals.battle_sub_426899 = get_absolute_value(ff7_externals.run_animation_script, 0x821);
+	ff7_externals.battle_sub_4267F1 = get_absolute_value(ff7_externals.run_animation_script, 0xFF6);
+	ff7_externals.battle_move_character_to_enemy_426A26 = get_absolute_value(ff7_externals.run_animation_script, 0x1568);
+	ff7_externals.field_battle_byte_BF2E1C = (byte*)get_absolute_value(ff7_externals.battle_move_character_to_enemy_426A26, 0x86);
+	ff7_externals.field_battle_byte_BE10B4 = (byte*)get_absolute_value(ff7_externals.battle_move_character_to_enemy_426A26, 0x148);
+	ff7_externals.battle_sub_42739D = get_absolute_value(ff7_externals.run_animation_script, 0x248E);
+	ff7_externals.battle_sub_426F58 = get_absolute_value(ff7_externals.run_animation_script, 0x26AF);
+	ff7_externals.resting_Y_array_data = (short*)get_absolute_value(ff7_externals.battle_sub_426F58, 0x122);
+	ff7_externals.battle_move_character_to_enemy_4270DE = get_absolute_value(ff7_externals.run_animation_script, 0x2357);
+
+	// effect 60 related
+	ff7_externals.battle_sub_5C18BC = get_absolute_value(battle_sub_5C1B81, 0x30);
+	uint32_t battle_sub_5BD847 = get_relative_call(battle_sub_5B9EC2, 0x4D);
+	ff7_externals.battle_sub_5BD96D = get_absolute_value(battle_sub_5BD847, 0xE0);
+	ff7_externals.battle_sub_4276B6 = get_absolute_value(ff7_externals.run_animation_script, 0x3091);
+	ff7_externals.battle_sub_4255B7 = get_absolute_value(ff7_externals.run_animation_script, 0x390);
+	ff7_externals.battle_sub_425E5F = get_absolute_value(ff7_externals.battle_sub_425D29, 0xA8);
+	ff7_externals.battle_sub_425520 = get_absolute_value(ff7_externals.run_animation_script, 0x3F7A);
+	ff7_externals.battle_sub_5BCF9D = get_absolute_value(ff7_externals.battle_sub_429AC0, 0xDB);
+	ff7_externals.battle_sub_5BD050 = get_relative_call(ff7_externals.battle_sub_5BCF9D, 0x95);
+	ff7_externals.battle_sub_425AAD = get_absolute_value(ff7_externals.run_animation_script, 0x413);
+	uint32_t* battle_functions_8FE5E8 = (uint32_t*)get_absolute_value(ff7_externals.battle_sub_427C22, 0x4B9);
+	ff7_externals.battle_sub_427A6C = battle_functions_8FE5E8[147];
+	ff7_externals.battle_sub_427AF1 = get_absolute_value(ff7_externals.battle_sub_427A6C, 0x56);
+	ff7_externals.battle_sub_427737 = get_absolute_value(ff7_externals.run_animation_script, 0x3158);
+	ff7_externals.battle_sub_4277B1 = get_absolute_value(ff7_externals.run_animation_script, 0x472B);
+	ff7_externals.battle_sub_5BCD42 = get_absolute_value(ff7_externals.run_animation_script, 0x66F);
+	uint32_t battle_sub_5BE490 = get_relative_call(ff7_externals.run_animation_script, 0x3E6E);
+	ff7_externals.battle_sub_5BE4E2 = get_absolute_value(battle_sub_5BE490, 0x5);
 	// --------------------------------
 
 	//ff7 achievement related externals

--- a/src/globals.h
+++ b/src/globals.h
@@ -90,6 +90,7 @@ extern uint32_t ff8_currentdisk;
 
 extern uint32_t frame_counter;
 extern double frame_rate;
+extern int frame_multiplier;
 
 extern double speedhack_current;
 

--- a/src/patch.h
+++ b/src/patch.h
@@ -39,5 +39,30 @@ void patch_code_int(uint32_t offset, int r);
 void patch_code_uint(uint32_t offset, uint32_t r);
 void patch_code_float(uint32_t offset, float r);
 void patch_code_double(uint32_t offset, double r);
+
+template<typename T>
+void patch_multiply_code(uint32_t offset, int multiplier)
+{
+	DWORD dummy;
+
+	VirtualProtect((void *)offset, sizeof(T), PAGE_EXECUTE_READWRITE, &dummy);
+
+	*(T *)offset = (*(T *)offset) * (T)multiplier;
+
+    // TODO Add assertion
+}
+
+template<typename T>
+void patch_divide_code(uint32_t offset, int multiplier)
+{
+	DWORD dummy;
+
+	VirtualProtect((void *)offset, sizeof(T), PAGE_EXECUTE_READWRITE, &dummy);
+
+	*(T *)offset = (*(T *)offset) / (T)multiplier;
+
+    // TODO Add assertion
+}
+
 void memcpy_code(uint32_t offset, void *data, uint32_t size);
 void memset_code(uint32_t offset, uint32_t val, uint32_t size);


### PR DESCRIPTION
…y others

- Add support for 30/60 fps animation for all enemy deaths (normal, morph, boss, ...)
- Add support for 30/60 fps for character or enemy movement (attacker moving towards enemy)
- Add support for 30/60 fps for display top strings (for character moves)
- Add support for 30/60 fps for many other animations or wait frames (fix some sync with limit breaks)
- Add flag variable for tracing battle animation to cfg and toml file
- Add patch template function for multiplication and division
- Fix 30 fps bug due to frame_multiplier (add global variable frame_multiplier)
- Refactor battle camera external variables into more meaningful names