### PR TITLE
Voice: Add voice support for display action/info

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -109,6 +109,36 @@ enum model_modes
 	MDL_USE_CAMERA_MATRIX     = 0x8000,
 };
 
+enum class cmd_id
+{
+	CMD_ATTACK = 0x01,
+	CMD_MAGIC = 0x02,
+	CMD_SUMMON = 0x03,
+	CMD_ITEM = 0x04,
+	CMD_STEAL = 0x05,
+	CMD_SENSE = 0x06,
+	CMD_COIN = 0x07,
+	CMD_THROW = 0x08,
+	CMD_MORPH = 0x09,
+	CMD_DEATHBLOW = 0x0A,
+	CMD_MANIPULATE = 0x0B,
+	CMD_MIME = 0x0C,
+	CMD_ENEMY_SKILL = 0x0D,
+	CMD_MUG = 0x11,
+	CMD_CHANGE = 0x12,
+	CMD_DEFEND = 0x13,
+	CMD_LIMIT = 0x14,
+	CMD_W_MAGIC = 0x15,
+	CMD_W_SUMMON = 0x16,
+	CMD_W_ITEM = 0x17,
+	CMD_SLASH_ALL = 0x18,
+	CMD_DOUBLE_CUT = 0x19,
+	CMD_FLASH = 0x1A,
+	CMD_QUAD_CUT = 0x1B,
+	CMD_ENEMY_ACTION = 0x20,
+	CMD_POISONTICK = 0x23
+};
+
 // internal structure for menu sprites (global values, may not be a structure at all)
 struct menu_objects
 {
@@ -559,7 +589,7 @@ struct battle_actor_data
 	uint32_t action_power;
 	uint32_t attack_power;
 	uint32_t action_target_mask;
-	uint32_t field_54_others[206];
+	uint32_t field_54[206];
 };
 
 struct battle_actor_vars
@@ -2309,8 +2339,8 @@ struct ff7_externals
 	uint32_t menu_battle_end_sub_6C9543;
 	uint32_t menu_sub_71FF95, menu_shop_loop, get_materia_gil, opcode_increase_gil_call;
 	uint32_t opcode_add_materia_inventory_call, menu_sub_6CBCF3, menu_sub_705D16, menu_sub_6CC17F;
-	uint32_t battle_sub_42782A;
-	uint32_t battle_set_command_and_action_id;
+	uint32_t display_battle_action_text_42782A;
+	uint32_t display_battle_action_text_sub_6D71FA;
 	uint32_t menu_decrease_item_quantity;
 	uint32_t sub_610973, sub_611098;
 	uint32_t sub_60FA7D;
@@ -2470,6 +2500,7 @@ struct ff7_externals
 	int* g_is_battle_running;
 	WORD* field_battle_word_BF2E08;
 	WORD* field_battle_word_BF2032;
+	byte* g_active_actor_id;
 };
 
 uint32_t ff7gl_load_group(uint32_t group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -389,7 +389,7 @@ void ff7_execute_effect100_fn()
             if (isNewEffect100Function[fn_index])
                 isNewEffect100Function[fn_index] = false;
 
-            if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_42782A)
+            if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.display_battle_action_text_42782A)
                 ((void (*)())ff7_externals.effect100_array_fn[fn_index])();
         }
         else
@@ -413,7 +413,7 @@ void ff7_execute_effect100_fn()
                          ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_morph_death_5BC812 ||
                          ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_5C0E4B ||
                          ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_5D4240 ||
-                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_42782A)
+                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.display_battle_action_text_42782A)
                 {
                     // these are already fixed functions 
                 }

--- a/src/ff7/battle.cpp
+++ b/src/ff7/battle.cpp
@@ -50,7 +50,7 @@ void ff7_battle_sub_5C7F94(int param_1, int param_2){
 	g_FF7SteamAchievements->unlockGilAchievement(ff7_externals.savemap->gil);
 }
 
-void ff7_battle_set_command_and_action_id(short command_id, short action_id){
+void ff7_display_battle_action_text_sub_6D71FA(short command_id, short action_id){
 	ff7_externals.battle_actor_data->formation_entry = 1;
 	ff7_externals.battle_actor_data->command_index = command_id;
 	ff7_externals.battle_actor_data->action_index = action_id;

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -26,7 +26,7 @@ void magic_thread_start(void (*func)());
 void ff7_load_battle_stage(int param_1, int battle_location_id, int **param_3);
 void ff7_battle_sub_5C7F94(int param_1, int param_2);
 
-void ff7_battle_set_command_and_action_id(short command_id, short action_id);
+void ff7_display_battle_action_text_sub_6D71FA(short command_id, short action_id);
 
 // menu
 void ff7_menu_battle_end_sub_6C9543();

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -707,7 +707,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_sub_42C823 = get_absolute_value(battle_sub_42C31C, 0x198);
 
 	// display string for actor actions
-	ff7_externals.battle_sub_42782A = get_absolute_value(ff7_externals.run_animation_script, 0x4906);
+	ff7_externals.display_battle_action_text_42782A = get_absolute_value(ff7_externals.run_animation_script, 0x4906);
 	ff7_externals.get_n_frames_display_action_string = get_relative_call(ff7_externals.run_animation_script, 0x4918);
 	ff7_externals.field_byte_DC0E11 = (byte*)get_absolute_value(ff7_externals.get_n_frames_display_action_string, 0x6);
 
@@ -767,6 +767,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.g_is_battle_running = (int*)get_absolute_value(battle_main_loop, 0x247);
 	ff7_externals.field_battle_word_BF2E08 = (WORD*)get_absolute_value(ff7_externals.update_display_text_queue, 0xA);
 	ff7_externals.field_battle_word_BF2032 = (WORD*)get_absolute_value(ff7_externals.update_display_text_queue, 0x12C);
+	ff7_externals.g_active_actor_id = (byte*)get_absolute_value(ff7_externals.display_battle_action_text_42782A, 0x52);
 	// --------------------------------
 
 	//ff7 achievement related externals
@@ -787,8 +788,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.opcode_increase_gil_call = get_relative_call(ff7_externals.opcode_goldu, 0x38);
 
 	uint32_t battle_sub_5BF01F = get_relative_call(ff7_externals.battle_sub_42D992, 0x12E);
-	ff7_externals.battle_sub_42782A = get_absolute_value(battle_sub_5BF01F, 0xC4);
-	ff7_externals.battle_set_command_and_action_id = get_relative_call(ff7_externals.battle_sub_42782A, 0x77);
+	ff7_externals.display_battle_action_text_42782A = get_absolute_value(battle_sub_5BF01F, 0xC4);
+	ff7_externals.display_battle_action_text_sub_6D71FA = get_relative_call(ff7_externals.display_battle_action_text_42782A, 0x77);
 
 	ff7_externals.opcode_add_materia_inventory_call = get_relative_call(ff7_externals.opcode_smtra, 0x72);
 	ff7_externals.menu_sub_6CBCF3 = get_relative_call(ff7_externals.opcode_add_materia_inventory_call, 0x43);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -371,7 +371,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		replace_function(ff7_externals.opcode_increase_gil_call, ff7_opcode_increase_gil_call);
 
 		// 1ST LIMIT BREAK
-		replace_function(ff7_externals.battle_set_command_and_action_id, ff7_battle_set_command_and_action_id);
+		replace_function(ff7_externals.display_battle_action_text_sub_6D71FA, ff7_display_battle_action_text_sub_6D71FA);
 
 		// MATERIA GOT
 		replace_call_function(ff7_externals.opcode_add_materia_inventory_call + 0x43, ff7_menu_sub_6CBCF3);


### PR DESCRIPTION
- Add voice support for display info about steal, mug, sense, ...
- Disable keeping display text until voice end for display info about steal, mug, and etc
- Add voice support for display action such as magic, limit breaks, ...
- Implement random choice of character playing voice during display actions