### PR TITLE
60FPS Battle: Many fix and interpolation of battle animations, and implemented pause trick

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2421,6 +2421,7 @@ struct ff7_externals
 	uint32_t battle_sub_5D4240;
 	uint32_t battle_sub_5BD96D;
 	uint32_t battle_sub_425D29;
+	uint32_t display_battle_damage_5BB410;
 	uint32_t battle_sub_5BDA0F;
 	uint32_t get_n_frames_display_action_string;
 	uint32_t battle_sub_426DE3;
@@ -2430,10 +2431,10 @@ struct ff7_externals
 	uint32_t battle_sub_5C1C8F;
 	uint32_t battle_sub_42C66D;
 	uint32_t battle_sub_42C823;
-	uint32_t battle_move_character_to_enemy_426A26;
-	uint32_t battle_sub_42739D;
-	uint32_t battle_sub_426F58;
-	uint32_t battle_move_character_to_enemy_4270DE;
+	uint32_t battle_move_character_sub_426A26;
+	uint32_t battle_move_character_sub_42739D;
+	uint32_t battle_move_character_sub_426F58;
+	uint32_t battle_move_character_sub_4270DE;
 	uint32_t battle_sub_5C18BC;
 	uint32_t battle_sub_4276B6;
 	uint32_t battle_sub_4255B7;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2453,7 +2453,8 @@ struct ff7_externals
 	uint32_t battle_sub_4277B1;
 	uint32_t battle_sub_5BCD42;
 	uint32_t battle_sub_5BD050;
-	uint32_t battle_sub_5BE4E2;
+	uint32_t battle_smoke_move_handler_5BE4E2;
+	uint32_t battle_smoke_move_effects_5BE5A9;
 	uint32_t battle_sub_42A72D;
 
 	battle_model_state *g_battle_model_state;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2418,8 +2418,8 @@ struct ff7_externals
 	uint32_t battle_disintegrate_1_death_5BBF31;
 	uint32_t battle_disintegrate_1_death_sub_5BC04D;
 	uint32_t battle_sub_42C0A7;
-	uint32_t battle_sub_5C0E4B;
-	uint32_t battle_sub_5D4240;
+	uint32_t run_summon_animations_5C0E4B;
+	uint32_t vincent_limit_fade_effect_sub_5D4240;
 	uint32_t battle_sub_5BD96D;
 	uint32_t battle_sub_425D29;
 	uint32_t display_battle_damage_5BB410;
@@ -2455,13 +2455,14 @@ struct ff7_externals
 	uint32_t battle_sub_5BCD42;
 	uint32_t battle_sub_5BD050;
 	uint32_t battle_smoke_move_handler_5BE4E2;
-	uint32_t battle_smoke_move_effects_5BE5A9;
 	uint32_t battle_sub_42A72D;
 	uint32_t run_tifa_limit_effects;
-	uint32_t tifa_limit_1_2_main_4E2DF3;
 	uint32_t tifa_limit_1_2_sub_4E3D51;
-	uint32_t tifa_limit_2_1_main_4E401E;
 	uint32_t tifa_limit_2_1_sub_4E48D4;
+	uint32_t aerith_limit_2_1_sub_45B0CF;
+	uint32_t run_shiva_camera_58E60D;
+	uint32_t run_ramuh_camera_597206;
+	uint32_t run_odin_gunge_camera_4A0F52;
 
 	battle_model_state *g_battle_model_state;
 	battle_model_state_small *g_small_battle_model_state;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -896,7 +896,8 @@ struct effect100_data
     int field_14;
     byte field_18;
     byte field_19;
-    byte field_1A[6];
+	short field_1A;
+    byte field_1C[4];
 };
 
 struct effect60_data
@@ -2456,6 +2457,11 @@ struct ff7_externals
 	uint32_t battle_smoke_move_handler_5BE4E2;
 	uint32_t battle_smoke_move_effects_5BE5A9;
 	uint32_t battle_sub_42A72D;
+	uint32_t run_tifa_limit_effects;
+	uint32_t tifa_limit_1_2_main_4E2DF3;
+	uint32_t tifa_limit_1_2_sub_4E3D51;
+	uint32_t tifa_limit_2_1_main_4E401E;
+	uint32_t tifa_limit_2_1_sub_4E48D4;
 
 	battle_model_state *g_battle_model_state;
 	battle_model_state_small *g_small_battle_model_state;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -706,8 +706,8 @@ struct bcamera_position{
 	short location_y;
 	short location_z;
 	WORD unused_6;
-	WORD current_position;
-	WORD frames_to_wait;
+	short current_position;
+	short frames_to_wait;
 	byte field_C;
 	byte field_D;
 };
@@ -2435,6 +2435,13 @@ struct ff7_externals
 	uint32_t battle_move_character_sub_42739D;
 	uint32_t battle_move_character_sub_426F58;
 	uint32_t battle_move_character_sub_4270DE;
+	uint32_t handle_aura_effects_425520;
+	uint32_t run_aura_effects_5C0230;
+	uint32_t magic_aura_effects_5C0300;
+	uint32_t limit_break_aura_effects_5C0572;
+	uint32_t enemy_skill_aura_effects_5C06BF;
+	uint32_t handle_summon_aura_5C0850;
+	uint32_t summon_aura_effects_5C0953;
 	uint32_t battle_sub_5C18BC;
 	uint32_t battle_sub_4276B6;
 	uint32_t battle_sub_4255B7;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2429,8 +2429,6 @@ struct ff7_externals
 	uint32_t battle_sub_426899;
 	uint32_t battle_sub_4267F1;
 	uint32_t battle_sub_5C1C8F;
-	uint32_t battle_sub_42C66D;
-	uint32_t battle_sub_42C823;
 	uint32_t battle_move_character_sub_426A26;
 	uint32_t battle_move_character_sub_42739D;
 	uint32_t battle_move_character_sub_426F58;
@@ -2456,6 +2454,7 @@ struct ff7_externals
 	uint32_t battle_sub_5BCD42;
 	uint32_t battle_sub_5BD050;
 	uint32_t battle_sub_5BE4E2;
+	uint32_t battle_sub_42A72D;
 
 	battle_model_state *g_battle_model_state;
 	battle_model_state_small *g_small_battle_model_state;

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -386,8 +386,10 @@ void ff7_execute_effect100_fn()
     {
         if ((ff7_externals.effect100_array_fn[fn_index] == 0) || (ff7_externals.field_dword_9AD1AC == 0))
         {
-            if (isNewEffect100Function[fn_index])
+            if (isNewEffect100Function[fn_index]){
+                ff7_externals.effect100_array_data[fn_index].field_6 *= frame_multiplier;
                 isNewEffect100Function[fn_index] = false;
+            } 
 
             if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.display_battle_action_text_42782A)
                 ((void (*)())ff7_externals.effect100_array_fn[fn_index])();
@@ -396,7 +398,11 @@ void ff7_execute_effect100_fn()
         {
             if (isNewEffect100Function[fn_index])
             {
-                if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_425D29)
+                if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.display_battle_action_text_42782A)
+                {
+                    ff7_externals.effect100_array_data[fn_index].field_6 *= frame_multiplier;
+                }
+                else if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_425D29)
                 {
                     ff7_externals.effect100_array_data[fn_index].n_frames *= frame_multiplier;
                 }
@@ -412,8 +418,7 @@ void ff7_execute_effect100_fn()
                          ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_disintegrate_2_death_5BBA82 ||
                          ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_morph_death_5BC812 ||
                          ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_5C0E4B ||
-                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_5D4240 ||
-                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.display_battle_action_text_42782A)
+                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_sub_5D4240)
                 {
                     // these are already fixed functions 
                 }

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -688,22 +688,9 @@ void ff7_boss_death_animation_5BC5EC()
         if (fn_data.n_frames == (58 * frame_multiplier) || fn_data.n_frames == (64 * frame_multiplier))
             *ff7_externals.field_battle_BFB2E0 = ((uint32_t(*)(byte, byte, byte))ff7_externals.battle_boss_death_call_5BD436)(0xFA, 0xFA, 0xFA);
 
-        int sign = ((fn_data.n_frames & 1) == 0) ? -1 : 1;
-        getBattleModelState(fn_data.field_8)->restingZPosition = fn_data.field_A + sign * 0x40;
-        fn_data.n_frames--;
-    }
-}
-
-void ff7_battle_sub_5BD96D()
-{
-    auto &fn_data = ff7_externals.effect60_array_data[*ff7_externals.effect60_array_idx];
-    if (fn_data.n_frames == 0)
-    {
-        fn_data.field_0 = 0xFFFF;
-    }
-    else
-    {
-        getBattleModelState(fn_data.field_6)->field_6 += fn_data.field_2;
+        std::array<short, 8> offset_z_position {64, 32, 0, -32, -64, -32, 0, 32};
+        int index = ((fn_data.n_frames * (4 / frame_multiplier)) % offset_z_position.size());
+        getBattleModelState(fn_data.field_8)->restingZPosition = fn_data.field_A + offset_z_position[index];
         fn_data.n_frames--;
     }
 }

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -371,7 +371,7 @@ int ff7_add_fn_to_effect100_fn(uint32_t function)
     ff7_externals.effect100_array_data[idx].field_0 = *ff7_externals.effect100_array_idx;
     *ff7_externals.effect100_counter = *ff7_externals.effect100_counter + 1;
 
-    aux_effect100_data[idx].frameCounter = 1;
+    aux_effect100_data[idx].frameCounter = 0;
     aux_effect100_data[idx].useFrameCounter = false;
     aux_effect100_data[idx].isFirstTimeRunning = true;
     aux_effect100_data[idx].finalFrame = -1;
@@ -410,6 +410,11 @@ void ff7_execute_effect100_fn()
                     ff7_externals.effect100_array_data[fn_index].field_2 /= frame_multiplier;
                     ff7_externals.effect100_array_data[fn_index].n_frames *= frame_multiplier;
                 }
+                else if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.tifa_limit_1_2_sub_4E3D51 ||
+                         ff7_externals.effect100_array_fn[fn_index] == ff7_externals.tifa_limit_2_1_sub_4E48D4)
+                {
+                    ff7_externals.effect100_array_data[fn_index].field_1A *= frame_multiplier;
+                }
                 else if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_enemy_death_5BBD24 ||
                          ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_iainuki_death_5BCAAA ||
                          ff7_externals.effect100_array_fn[fn_index] == ff7_externals.battle_boss_death_5BC48C ||
@@ -427,7 +432,7 @@ void ff7_execute_effect100_fn()
                 }
 
                 if (trace_all || trace_battle_animation)
-                    ffnx_trace("%s - executing new function: 0x%x (actor_id: %d,last command: 0x%02X, 0x%04X)\n", __func__,
+                    ffnx_trace("%s - begin function[%d]: 0x%x (actor_id: %d,last command: 0x%02X, 0x%04X)\n", __func__, fn_index,
                                ff7_externals.effect100_array_fn[fn_index], ff7_externals.anim_event_queue[0].attackerID,
                                ff7_externals.battle_context->lastCommandIdx, ff7_externals.battle_context->lastActionIdx);
 
@@ -436,7 +441,7 @@ void ff7_execute_effect100_fn()
 
             if (aux_effect100_data[fn_index].useFrameCounter)
             {
-                if(aux_effect100_data[fn_index].frameCounter % frame_multiplier == 1)
+                if(aux_effect100_data[fn_index].frameCounter % frame_multiplier == 0)
                 {
                     ((void (*)())ff7_externals.effect100_array_fn[fn_index])();
                 }
@@ -456,6 +461,11 @@ void ff7_execute_effect100_fn()
 
             if (ff7_externals.effect100_array_data[fn_index].field_0 == (uint16_t)-1)
             {
+                if (trace_all || trace_battle_animation)
+                    ffnx_trace("%s - end function[%d]: 0x%x (actor_id: %d,last command: 0x%02X, 0x%04X)\n", __func__, fn_index,
+                               ff7_externals.effect100_array_fn[fn_index], ff7_externals.anim_event_queue[0].attackerID,
+                               ff7_externals.battle_context->lastCommandIdx, ff7_externals.battle_context->lastActionIdx);
+
                 ff7_externals.effect100_array_data[fn_index].field_0 = 0;
                 ff7_externals.effect100_array_data[fn_index].field_2 = 0;
                 ff7_externals.effect100_array_fn[fn_index] = 0;
@@ -558,7 +568,7 @@ void ff7_execute_effect10_fn()
                     effect10_data.field_14 /= frame_multiplier;
                 }
                 if (trace_all || trace_battle_animation)
-                    ffnx_trace("%s - executing new function: 0x%x (actor_id: %d,last command: 0x%02X, 0x%04X)\n", __func__,
+                    ffnx_trace("%s - begin function[%d]: 0x%x (actor_id: %d,last command: 0x%02X, 0x%04X)\n", __func__, fn_index,
                                ff7_externals.effect10_array_fn[fn_index], ff7_externals.anim_event_queue[0].attackerID,
                                ff7_externals.battle_context->lastCommandIdx, ff7_externals.battle_context->lastActionIdx);
 
@@ -569,6 +579,11 @@ void ff7_execute_effect10_fn()
 
             if (effect10_data.field_0 == (uint16_t)-1)
             {
+                if (trace_all || trace_battle_animation)
+                    ffnx_trace("%s - end function[%d]: 0x%x (actor_id: %d,last command: 0x%02X, 0x%04X)\n", __func__, fn_index,
+                               ff7_externals.effect10_array_fn[fn_index], ff7_externals.anim_event_queue[0].attackerID,
+                               ff7_externals.battle_context->lastCommandIdx, ff7_externals.battle_context->lastActionIdx);
+
                 effect10_data.field_0 = 0;
                 effect10_data.field_2 = 0;
                 ff7_externals.effect10_array_fn[fn_index] = 0;
@@ -646,7 +661,7 @@ void ff7_execute_effect60_fn()
                 }
 
                 if (trace_all || trace_battle_animation)
-                    ffnx_trace("%s - executing new function: 0x%x (actor_id: %d,last command: 0x%02X, 0x%04X)\n", __func__,
+                    ffnx_trace("%s - begin function[%d]: 0x%x (actor_id: %d,last command: 0x%02X, 0x%04X)\n", __func__, fn_index,
                                ff7_externals.effect60_array_fn[fn_index], ff7_externals.anim_event_queue[0].attackerID,
                                ff7_externals.battle_context->lastCommandIdx, ff7_externals.battle_context->lastActionIdx);
 
@@ -655,15 +670,17 @@ void ff7_execute_effect60_fn()
 
             if (aux_effect60_data[fn_index].useFrameCounter)
             {
-                auto data_prev = ff7_externals.effect60_array_data[fn_index];
-                if (aux_effect60_data[fn_index].frameCounter % frame_multiplier != 0)
-                    isAddFunctionDisabled = true;
-
-                ((void (*)())ff7_externals.effect60_array_fn[fn_index])();
-
-                isAddFunctionDisabled = false;
-                if (aux_effect60_data[fn_index].frameCounter % frame_multiplier != 0){
-                    ff7_externals.effect60_array_data[fn_index].field_0 = data_prev.field_0;
+                if(aux_effect60_data[fn_index].frameCounter % frame_multiplier == 0)
+                {
+                    ((void (*)())ff7_externals.effect60_array_fn[fn_index])();
+                }
+                else
+                {
+                    auto data_prev = ff7_externals.effect60_array_data[fn_index];
+                    byte was_paused = *ff7_externals.g_is_battle_paused;
+                    *ff7_externals.g_is_battle_paused = 1;
+                    ((void (*)())ff7_externals.effect60_array_fn[fn_index])();
+                    *ff7_externals.g_is_battle_paused = was_paused;
                     ff7_externals.effect60_array_data[fn_index].field_2 = data_prev.field_2;
                 }
                 
@@ -676,6 +693,11 @@ void ff7_execute_effect60_fn()
 
             if (ff7_externals.effect60_array_data[fn_index].field_0 == (uint16_t)-1)
             {
+                if (trace_all || trace_battle_animation)
+                    ffnx_trace("%s - end function[%d]: 0x%x (actor_id: %d,last command: 0x%02X, 0x%04X)\n", __func__, fn_index,
+                               ff7_externals.effect60_array_fn[fn_index], ff7_externals.anim_event_queue[0].attackerID,
+                               ff7_externals.battle_context->lastCommandIdx, ff7_externals.battle_context->lastActionIdx);
+
                 ff7_externals.effect60_array_data[fn_index].field_0 = 0;
                 ff7_externals.effect60_array_data[fn_index].field_2 = 0;
                 ff7_externals.effect60_array_fn[fn_index] = 0;

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -507,18 +507,6 @@ void ff7_execute_effect10_fn()
                     effect10_data.n_frames *= frame_multiplier;
                     effect10_data.field_A /= frame_multiplier;
                 }
-                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_42C66D ||
-                         ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_42C823)
-                {
-                    // 42C66D is the transparent level fade out of the character
-                    // 42C823 is the transparent level fade in of the characters
-                    // TODO: fix vanishing model bug when there is fade in and fade out in sequence
-                    effect10_data.n_frames *= frame_multiplier;
-                    effect10_data.field_E /= frame_multiplier;
-                    effect10_data.field_8 /= frame_multiplier;
-                    effect10_data.field_A /= frame_multiplier;
-                    effect10_data.field_C /= frame_multiplier;
-                }
                 else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_move_character_sub_426A26)
                 {
                     // Animation of moving characters from attacker to attacked

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -373,7 +373,7 @@ int ff7_add_fn_to_effect100_fn(uint32_t function)
     ff7_externals.effect100_array_data[idx].field_0 = *ff7_externals.effect100_array_idx;
     *ff7_externals.effect100_counter = *ff7_externals.effect100_counter + 1;
 
-    extFramesCounterEffect100[idx] = 0;
+    extFramesCounterEffect100[idx] = 1;
     useExtFramesCounterEffect100[idx] = false;
     isNewEffect100Function[idx] = true;
     return idx;
@@ -520,7 +520,7 @@ void ff7_execute_effect10_fn()
                     effect10_data.field_A /= frame_multiplier;
                     effect10_data.field_C /= frame_multiplier;
                 }
-                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_move_character_to_enemy_426A26)
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_move_character_sub_426A26)
                 {
                     // Animation of moving characters from attacker to attacked
                     effect10_data.n_frames *= frame_multiplier;
@@ -528,7 +528,7 @@ void ff7_execute_effect10_fn()
                     effect10_data.field_C /= frame_multiplier;
                     effect10_data.field_E /= frame_multiplier;
                 }
-                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_42739D)
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_move_character_sub_42739D)
                 {
                     // Animation of moving characters from attacker to attacked
                     effect10_data.n_frames *= frame_multiplier;
@@ -537,12 +537,12 @@ void ff7_execute_effect10_fn()
                     effect10_data.field_C /= frame_multiplier;
                     effect10_data.field_E /= frame_multiplier;
                 }
-                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_sub_426F58)
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_move_character_sub_426F58)
                 {
                     effect10_data.n_frames *= frame_multiplier;
                     // Do not modify the others, already done elsewhere
                 }
-                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_move_character_to_enemy_4270DE)
+                else if (ff7_externals.effect10_array_fn[fn_index] == ff7_externals.battle_move_character_sub_4270DE)
                 {
                     // Animation of moving characters for some limit breaks from attacker to attacked
                     effect10_data.n_frames *= frame_multiplier;
@@ -589,7 +589,7 @@ int ff7_add_fn_to_effect60_fn(uint32_t function)
     ff7_externals.effect60_array_data[idx].field_0 = *ff7_externals.effect60_array_idx;
     *ff7_externals.effect60_counter = *ff7_externals.effect60_counter + 1;
 
-    extFramesCounterEffect60[idx] = 0;
+    extFramesCounterEffect60[idx] = 1;
     useExtFramesCounterEffect60[idx] = false;
     isNewEffect60Function[idx] = true;
     return idx;
@@ -625,6 +625,7 @@ void ff7_execute_effect60_fn()
                          ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_boss_death_sub_5BC5EC ||
                          ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5BCD42 ||
                          ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5BE4E2 ||
+                         ff7_externals.effect60_array_fn[fn_index] == ff7_externals.display_battle_damage_5BB410 ||
                          ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5C18BC)
                 {
                     // these are already fixed functions 
@@ -651,9 +652,11 @@ void ff7_execute_effect60_fn()
                 ((void (*)())ff7_externals.effect60_array_fn[fn_index])();
 
                 isAddFunctionDisabled = false;
-                if (extFramesCounterEffect60[fn_index] % frame_multiplier != 0)
+                if (extFramesCounterEffect60[fn_index] % frame_multiplier != 0){
+                    ff7_externals.effect60_array_data[fn_index].field_0 = data_prev.field_0;
                     ff7_externals.effect60_array_data[fn_index].field_2 = data_prev.field_2;
-
+                }
+                
                 extFramesCounterEffect60[fn_index]++;
             }
             else
@@ -740,7 +743,7 @@ void ff7_battle_disintegrate_1_death_sub_5BC04D(byte effect10_array_idx)
     }
 }
 
-void ff7_battle_sub_426F58()
+void ff7_battle_move_character_sub_426F58()
 {
     auto &fn_data = ff7_externals.effect10_array_data[*ff7_externals.effect10_array_idx];
     if (fn_data.n_frames == 0)

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -80,7 +80,7 @@ void ff7_execute_effect60_fn();
 void ff7_execute_effect10_fn();
 void ff7_boss_death_animation_5BC5EC();
 void ff7_battle_sub_5BD96D();
-void ff7_battle_sub_426F58();
+void ff7_battle_move_character_sub_426F58();
 int ff7_get_n_frames_display_action_string();
 void ff7_battle_disintegrate_1_death_sub_5BC04D(byte effect10_array_idx);
 

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -79,7 +79,6 @@ void ff7_execute_effect100_fn();
 void ff7_execute_effect60_fn();
 void ff7_execute_effect10_fn();
 void ff7_boss_death_animation_5BC5EC();
-void ff7_battle_sub_5BD96D();
 void ff7_battle_move_character_sub_426F58();
 int ff7_get_n_frames_display_action_string();
 void ff7_battle_disintegrate_1_death_sub_5BC04D(byte effect10_array_idx);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -689,27 +689,25 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_sub_42C0A7 = get_relative_call(ff7_externals.battle_disintegrate_1_death_sub_5BC04D, 0x8D);
 	ff7_externals.effect10_array_data_8FE1F6 = (short*)get_absolute_value(ff7_externals.battle_disintegrate_1_death_sub_5BC04D, 0x123);
 
-	// unknowns
-	uint32_t battle_sub_5C0E39 = get_relative_call(ff7_externals.battle_sub_427C22, 0x4DE);
-	ff7_externals.battle_sub_5C0E4B = get_absolute_value(battle_sub_5C0E39, 0x4);
-
-	uint32_t* battle_anim_functions_8FE860 = (uint32_t*)get_absolute_value(ff7_externals.battle_sub_427C22, 0x40E);
-	ff7_externals.battle_sub_5D4240 = battle_anim_functions_8FE860[56];
-	ff7_externals.battle_sub_5BD96D = get_absolute_value(ff7_externals.battle_sub_5D4240, 0x27);
-
-	ff7_externals.battle_sub_425D29 = get_absolute_value(ff7_externals.run_animation_script, 0x2850);
-
-	ff7_externals.battle_sub_5BDA0F = get_absolute_value(ff7_externals.run_animation_script, 0x240);
-
-	ff7_externals.battle_sub_5C1C8F = get_absolute_value(battle_sub_5C1B81, 0x3F);
-	uint32_t battle_sub_42C31C = get_relative_call(ff7_externals.battle_sub_5C1C8F, 0xEC);
-	ff7_externals.battle_sub_42C66D = get_absolute_value(battle_sub_42C31C, 0x45);
-	ff7_externals.battle_sub_42C823 = get_absolute_value(battle_sub_42C31C, 0x198);
-
 	// display string for actor actions
 	ff7_externals.display_battle_action_text_42782A = get_absolute_value(ff7_externals.run_animation_script, 0x4906);
 	ff7_externals.get_n_frames_display_action_string = get_relative_call(ff7_externals.run_animation_script, 0x4918);
 	ff7_externals.field_byte_DC0E11 = (byte*)get_absolute_value(ff7_externals.get_n_frames_display_action_string, 0x6);
+
+	// unknowns
+	ff7_externals.battle_sub_425D29 = get_absolute_value(ff7_externals.run_animation_script, 0x2850);
+	ff7_externals.battle_sub_5BDA0F = get_absolute_value(ff7_externals.run_animation_script, 0x240);
+
+	// character fade in/out
+	uint32_t battle_sub_5C0E39 = get_relative_call(ff7_externals.battle_sub_427C22, 0x4DE);
+	ff7_externals.battle_sub_5C0E4B = get_absolute_value(battle_sub_5C0E39, 0x4);
+	uint32_t* battle_anim_functions_8FE860 = (uint32_t*)get_absolute_value(ff7_externals.battle_sub_427C22, 0x40E);
+	ff7_externals.battle_sub_5D4240 = battle_anim_functions_8FE860[56];
+	ff7_externals.battle_sub_5BD96D = get_absolute_value(ff7_externals.battle_sub_5D4240, 0x27);
+	ff7_externals.battle_sub_5C1C8F = get_absolute_value(battle_sub_5C1B81, 0x3F);
+	uint32_t handle_fade_character_42C31C = get_relative_call(ff7_externals.battle_sub_5C1C8F, 0xEC);
+	ff7_externals.battle_sub_5C18BC = get_absolute_value(battle_sub_5C1B81, 0x30);
+	ff7_externals.battle_sub_42A72D = get_relative_call(ff7_externals.battle_sub_429AC0, 0xD0);
 
 	// resting positions and rotations
 	uint32_t battle_sub_426C9B = get_relative_call(ff7_externals.run_animation_script, 0x14C7);
@@ -735,9 +733,6 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.summon_aura_effects_5C0953 = get_absolute_value(ff7_externals.handle_summon_aura_5C0850, 0x31);
 
 	// effect 60 related
-	ff7_externals.battle_sub_5C18BC = get_absolute_value(battle_sub_5C1B81, 0x30);
-	uint32_t battle_sub_5BD847 = get_relative_call(battle_sub_5B9EC2, 0x4D);
-	ff7_externals.battle_sub_5BD96D = get_absolute_value(battle_sub_5BD847, 0xE0);
 	ff7_externals.battle_sub_4276B6 = get_absolute_value(ff7_externals.run_animation_script, 0x3091);
 	ff7_externals.battle_sub_4255B7 = get_absolute_value(ff7_externals.run_animation_script, 0x390);
 	ff7_externals.battle_sub_425E5F = get_absolute_value(ff7_externals.battle_sub_425D29, 0xA8);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -699,11 +699,9 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_sub_5BDA0F = get_absolute_value(ff7_externals.run_animation_script, 0x240);
 
 	// character fade in/out
-	uint32_t battle_sub_5C0E39 = get_relative_call(ff7_externals.battle_sub_427C22, 0x4DE);
-	ff7_externals.battle_sub_5C0E4B = get_absolute_value(battle_sub_5C0E39, 0x4);
-	uint32_t* battle_anim_functions_8FE860 = (uint32_t*)get_absolute_value(ff7_externals.battle_sub_427C22, 0x40E);
-	ff7_externals.battle_sub_5D4240 = battle_anim_functions_8FE860[56];
-	ff7_externals.battle_sub_5BD96D = get_absolute_value(ff7_externals.battle_sub_5D4240, 0x27);
+	uint32_t* limit_effect_callback_table_8FE860 = (uint32_t*)get_absolute_value(ff7_externals.battle_sub_427C22, 0x40E);
+	ff7_externals.vincent_limit_fade_effect_sub_5D4240 = limit_effect_callback_table_8FE860[56];
+	ff7_externals.battle_sub_5BD96D = get_absolute_value(ff7_externals.vincent_limit_fade_effect_sub_5D4240, 0x27);
 	ff7_externals.battle_sub_5C1C8F = get_absolute_value(battle_sub_5C1B81, 0x3F);
 	uint32_t handle_fade_character_42C31C = get_relative_call(ff7_externals.battle_sub_5C1C8F, 0xEC);
 	ff7_externals.battle_sub_5C18BC = get_absolute_value(battle_sub_5C1B81, 0x30);
@@ -749,16 +747,37 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_sub_5BCD42 = get_absolute_value(ff7_externals.run_animation_script, 0x66F);
 	uint32_t battle_sub_5BE490 = get_relative_call(ff7_externals.run_animation_script, 0x3E6E);
 	ff7_externals.battle_smoke_move_handler_5BE4E2 = get_absolute_value(battle_sub_5BE490, 0x5);
-	ff7_externals.battle_smoke_move_effects_5BE5A9 = get_absolute_value(ff7_externals.battle_smoke_move_handler_5BE4E2, 0x46);
 
-	// Tifa limit stuff
+	// Tifa limit breaks
 	uint32_t battle_sub_4E1627 = get_relative_call(ff7_externals.run_animation_script, 0x3848);
 	ff7_externals.run_tifa_limit_effects = get_relative_call(battle_sub_4E1627, 0xD);
-	ff7_externals.tifa_limit_1_2_main_4E2DF3 = get_absolute_value(ff7_externals.run_tifa_limit_effects, 0x47);
-	ff7_externals.tifa_limit_1_2_sub_4E3D51 = get_absolute_value(ff7_externals.tifa_limit_1_2_main_4E2DF3, 0x4BB);
-	ff7_externals.tifa_limit_2_1_main_4E401E = get_absolute_value(ff7_externals.run_tifa_limit_effects, 0x67);
-	ff7_externals.tifa_limit_2_1_sub_4E48D4 = get_absolute_value(ff7_externals.tifa_limit_2_1_main_4E401E, 0x41A);
+	uint32_t tifa_limit_1_2_main_4E2DF3 = get_absolute_value(ff7_externals.run_tifa_limit_effects, 0x47);
+	ff7_externals.tifa_limit_1_2_sub_4E3D51 = get_absolute_value(tifa_limit_1_2_main_4E2DF3, 0x4BB);
+	uint32_t tifa_limit_2_1_main_4E401E = get_absolute_value(ff7_externals.run_tifa_limit_effects, 0x67);
+	ff7_externals.tifa_limit_2_1_sub_4E48D4 = get_absolute_value(tifa_limit_2_1_main_4E401E, 0x41A);
 
+	// Aerith limit breaks
+	uint32_t aerith_limit_2_1_main_45AE80 = limit_effect_callback_table_8FE860[16];
+	uint32_t aerith_limit_2_1_sub_45AEA6 = get_relative_call(aerith_limit_2_1_main_45AE80, 0x1A);
+	uint32_t aerith_limit_2_1_sub_45AEE8 = get_absolute_value(aerith_limit_2_1_sub_45AEA6, 0xE);
+	uint32_t aerith_limit_2_1_sub_45AF39 = get_absolute_value(aerith_limit_2_1_sub_45AEE8, 0x5);
+	ff7_externals.aerith_limit_2_1_sub_45B0CF = get_absolute_value(aerith_limit_2_1_sub_45AF39, 0x4A);
+
+	// Summons
+	uint32_t battle_sub_5C0E39 = get_relative_call(ff7_externals.battle_sub_427C22, 0x4DE);
+	ff7_externals.run_summon_animations_5C0E4B = get_absolute_value(battle_sub_5C0E39, 0x4);
+	uint32_t run_summon_shiva_main_58E411 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x267);
+	uint32_t run_summon_shiva_sub_58E4D8 = get_relative_call(run_summon_shiva_main_58E411, 0xBB);
+	uint32_t run_summon_shiva_sub_58E5CD = get_relative_call(run_summon_shiva_sub_58E4D8, 0xBB);
+	ff7_externals.run_shiva_camera_58E60D = get_absolute_value(run_summon_shiva_sub_58E5CD, 0x5);
+	uint32_t run_summon_ramuh_main_596FF1 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x311);
+	uint32_t run_summon_ramuh_sub_59706F = get_relative_call(run_summon_ramuh_main_596FF1, 0x70);
+	uint32_t run_summon_ramuh_sub_5971C6 = get_relative_call(run_summon_ramuh_sub_59706F, 0x13C);
+	ff7_externals.run_ramuh_camera_597206 = get_absolute_value(run_summon_ramuh_sub_5971C6, 0x5);
+	uint32_t run_summon_odin_gunge_main_4A0AE1 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x3DD);
+	uint32_t run_summon_odin_gunge_sub_4A0B6D = get_relative_call(run_summon_odin_gunge_main_4A0AE1, 0x7F);
+	uint32_t run_summon_odin_gunge_sub_4A0F12 = get_relative_call(run_summon_odin_gunge_sub_4A0B6D, 0x1C0);
+	ff7_externals.run_odin_gunge_camera_4A0F52 = get_absolute_value(run_summon_odin_gunge_sub_4A0F12, 0x5);
 	// --------------------------------
 
 	// battle dialogues

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -725,6 +725,15 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.resting_Y_array_data = (short*)get_absolute_value(ff7_externals.battle_move_character_sub_426F58, 0x122);
 	ff7_externals.battle_move_character_sub_4270DE = get_absolute_value(ff7_externals.run_animation_script, 0x2357);
 
+	// aura animations (magic, limit breaks, enemy skill and summon)
+	ff7_externals.handle_aura_effects_425520 = get_absolute_value(ff7_externals.run_animation_script, 0x3F7A);
+	ff7_externals.run_aura_effects_5C0230 = get_relative_call(ff7_externals.handle_aura_effects_425520, 0x42);
+	ff7_externals.magic_aura_effects_5C0300 = get_absolute_value(ff7_externals.run_aura_effects_5C0230, 0x66);
+	ff7_externals.limit_break_aura_effects_5C0572 = get_absolute_value(ff7_externals.run_aura_effects_5C0230, 0x72);
+	ff7_externals.enemy_skill_aura_effects_5C06BF = get_absolute_value(ff7_externals.run_aura_effects_5C0230, 0x7E);
+	ff7_externals.handle_summon_aura_5C0850 = get_absolute_value(ff7_externals.run_aura_effects_5C0230, 0x8F);
+	ff7_externals.summon_aura_effects_5C0953 = get_absolute_value(ff7_externals.handle_summon_aura_5C0850, 0x31);
+
 	// effect 60 related
 	ff7_externals.battle_sub_5C18BC = get_absolute_value(battle_sub_5C1B81, 0x30);
 	uint32_t battle_sub_5BD847 = get_relative_call(battle_sub_5B9EC2, 0x4D);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -748,7 +748,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_sub_4277B1 = get_absolute_value(ff7_externals.run_animation_script, 0x472B);
 	ff7_externals.battle_sub_5BCD42 = get_absolute_value(ff7_externals.run_animation_script, 0x66F);
 	uint32_t battle_sub_5BE490 = get_relative_call(ff7_externals.run_animation_script, 0x3E6E);
-	ff7_externals.battle_sub_5BE4E2 = get_absolute_value(battle_sub_5BE490, 0x5);
+	ff7_externals.battle_smoke_move_handler_5BE4E2 = get_absolute_value(battle_sub_5BE490, 0x5);
+	ff7_externals.battle_smoke_move_effects_5BE5A9 = get_absolute_value(ff7_externals.battle_smoke_move_handler_5BE4E2, 0x46);
 	// --------------------------------
 
 	// battle dialogues

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -750,6 +750,15 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	uint32_t battle_sub_5BE490 = get_relative_call(ff7_externals.run_animation_script, 0x3E6E);
 	ff7_externals.battle_smoke_move_handler_5BE4E2 = get_absolute_value(battle_sub_5BE490, 0x5);
 	ff7_externals.battle_smoke_move_effects_5BE5A9 = get_absolute_value(ff7_externals.battle_smoke_move_handler_5BE4E2, 0x46);
+
+	// Tifa limit stuff
+	uint32_t battle_sub_4E1627 = get_relative_call(ff7_externals.run_animation_script, 0x3848);
+	ff7_externals.run_tifa_limit_effects = get_relative_call(battle_sub_4E1627, 0xD);
+	ff7_externals.tifa_limit_1_2_main_4E2DF3 = get_absolute_value(ff7_externals.run_tifa_limit_effects, 0x47);
+	ff7_externals.tifa_limit_1_2_sub_4E3D51 = get_absolute_value(ff7_externals.tifa_limit_1_2_main_4E2DF3, 0x4BB);
+	ff7_externals.tifa_limit_2_1_main_4E401E = get_absolute_value(ff7_externals.run_tifa_limit_effects, 0x67);
+	ff7_externals.tifa_limit_2_1_sub_4E48D4 = get_absolute_value(ff7_externals.tifa_limit_2_1_main_4E401E, 0x41A);
+
 	// --------------------------------
 
 	// battle dialogues

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -717,13 +717,13 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_sub_426941 = get_absolute_value(ff7_externals.run_animation_script, 0x1A5D);
 	ff7_externals.battle_sub_426899 = get_absolute_value(ff7_externals.run_animation_script, 0x821);
 	ff7_externals.battle_sub_4267F1 = get_absolute_value(ff7_externals.run_animation_script, 0xFF6);
-	ff7_externals.battle_move_character_to_enemy_426A26 = get_absolute_value(ff7_externals.run_animation_script, 0x1568);
-	ff7_externals.field_battle_byte_BF2E1C = (byte*)get_absolute_value(ff7_externals.battle_move_character_to_enemy_426A26, 0x86);
-	ff7_externals.field_battle_byte_BE10B4 = (byte*)get_absolute_value(ff7_externals.battle_move_character_to_enemy_426A26, 0x148);
-	ff7_externals.battle_sub_42739D = get_absolute_value(ff7_externals.run_animation_script, 0x248E);
-	ff7_externals.battle_sub_426F58 = get_absolute_value(ff7_externals.run_animation_script, 0x26AF);
-	ff7_externals.resting_Y_array_data = (short*)get_absolute_value(ff7_externals.battle_sub_426F58, 0x122);
-	ff7_externals.battle_move_character_to_enemy_4270DE = get_absolute_value(ff7_externals.run_animation_script, 0x2357);
+	ff7_externals.battle_move_character_sub_426A26 = get_absolute_value(ff7_externals.run_animation_script, 0x1568);
+	ff7_externals.field_battle_byte_BF2E1C = (byte*)get_absolute_value(ff7_externals.battle_move_character_sub_426A26, 0x86);
+	ff7_externals.field_battle_byte_BE10B4 = (byte*)get_absolute_value(ff7_externals.battle_move_character_sub_426A26, 0x148);
+	ff7_externals.battle_move_character_sub_42739D = get_absolute_value(ff7_externals.run_animation_script, 0x248E);
+	ff7_externals.battle_move_character_sub_426F58 = get_absolute_value(ff7_externals.run_animation_script, 0x26AF);
+	ff7_externals.resting_Y_array_data = (short*)get_absolute_value(ff7_externals.battle_move_character_sub_426F58, 0x122);
+	ff7_externals.battle_move_character_sub_4270DE = get_absolute_value(ff7_externals.run_animation_script, 0x2357);
 
 	// effect 60 related
 	ff7_externals.battle_sub_5C18BC = get_absolute_value(battle_sub_5C1B81, 0x30);
@@ -732,6 +732,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_sub_4276B6 = get_absolute_value(ff7_externals.run_animation_script, 0x3091);
 	ff7_externals.battle_sub_4255B7 = get_absolute_value(ff7_externals.run_animation_script, 0x390);
 	ff7_externals.battle_sub_425E5F = get_absolute_value(ff7_externals.battle_sub_425D29, 0xA8);
+	ff7_externals.display_battle_damage_5BB410 = get_absolute_value(ff7_externals.battle_sub_425D29, 0x3D);
 	ff7_externals.battle_sub_425520 = get_absolute_value(ff7_externals.run_animation_script, 0x3F7A);
 	ff7_externals.battle_sub_5BCF9D = get_absolute_value(ff7_externals.battle_sub_429AC0, 0xDB);
 	ff7_externals.battle_sub_5BD050 = get_relative_call(ff7_externals.battle_sub_5BCF9D, 0x95);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -31,6 +31,9 @@
 
 unsigned char midi_fix[] = {0x8B, 0x4D, 0x14};
 WORD snowboard_fix[] = {0x0F, 0x10, 0x0F};
+byte y_pos_offset_display_damage_30[] = {0, 1, 2, 3, 4, 5, 6, 6, 7, 7, 8, 8, 8, 8, 7, 7, 6, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0};
+byte y_pos_offset_display_damage_60[] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8,
+										 7, 7, 7, 7, 6, 6, 6, 6, 5, 5, 4, 4, 3, 3, 2, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 void ff7_init_hooks(struct game_obj *_game_object)
 {
@@ -276,9 +279,22 @@ void ff7_init_hooks(struct game_obj *_game_object)
 				replace_function(ff7_externals.get_n_frames_display_action_string, ff7_get_n_frames_display_action_string);
 
 				// Character movement (e.g. movement animation for attacks)
-				replace_function(ff7_externals.battle_sub_426F58, ff7_battle_sub_426F58);
+				replace_function(ff7_externals.battle_move_character_sub_426F58, ff7_battle_move_character_sub_426F58);
 
-				// Effect60 related (Show damage (0x5BB410 TODO replace function), limit break aura animation, summon aura animation, ...)
+				// Show Damage
+				patch_multiply_code<WORD>(ff7_externals.display_battle_damage_5BB410 + 0x54, frame_multiplier);
+				if(frame_multiplier == 2)
+				{
+					patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x1E2, (DWORD)y_pos_offset_display_damage_30);
+					patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x2D7, (DWORD)y_pos_offset_display_damage_30);
+				}
+				else if(frame_multiplier == 4)
+				{
+					patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x1E2, (DWORD)y_pos_offset_display_damage_60);
+					patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x2D7, (DWORD)y_pos_offset_display_damage_60);
+				}
+
+				// Effect60 related (limit break aura animation, summon aura animation, ...)
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C18BC + 0xDC, frame_multiplier);
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C1C8F + 0x55, frame_multiplier);
 

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -325,6 +325,9 @@ void ff7_init_hooks(struct game_obj *_game_object)
 				patch_code_byte(ff7_externals.summon_aura_effects_5C0953 + 0x4D, 0xC - frame_multiplier / 2);
 				patch_multiply_code<byte>(ff7_externals.summon_aura_effects_5C0953 + 0x19D, frame_multiplier);
 
+				// Tifa limit break effects
+				patch_multiply_code<byte>(ff7_externals.tifa_limit_2_1_sub_4E48D4 + 0x1FE, frame_multiplier);
+
 				// Effect60 related
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_425E5F + 0x3A, frame_multiplier);
 

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -294,7 +294,32 @@ void ff7_init_hooks(struct game_obj *_game_object)
 					patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x2D7, (DWORD)y_pos_offset_display_damage_60);
 				}
 
-				// Effect60 related (limit break aura animation, summon aura animation, ...)
+				// Aura animation (magic, limit break, enemy skill, summon)
+				patch_code_byte(ff7_externals.magic_aura_effects_5C0300 + 0x4C, 0x7 - frame_multiplier / 2);
+				patch_code_byte(ff7_externals.magic_aura_effects_5C0300 + 0x6A, 0xA - frame_multiplier / 2);
+				patch_multiply_code<byte>(ff7_externals.magic_aura_effects_5C0300 + 0x88, frame_multiplier);
+				patch_code_byte(ff7_externals.magic_aura_effects_5C0300 + 0xA2, 0xC - frame_multiplier / 2);
+				patch_multiply_code<byte>(ff7_externals.magic_aura_effects_5C0300 + 0x138, frame_multiplier);
+				patch_divide_code<DWORD>(ff7_externals.limit_break_aura_effects_5C0572 + 0x4C, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.limit_break_aura_effects_5C0572 + 0x6E, frame_multiplier);
+				patch_divide_code<DWORD>(ff7_externals.limit_break_aura_effects_5C0572 + 0x7A, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.limit_break_aura_effects_5C0572 + 0x98, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.limit_break_aura_effects_5C0572 + 0xAD, frame_multiplier);
+				patch_code_byte(ff7_externals.limit_break_aura_effects_5C0572 + 0xB0, 0x9 - frame_multiplier / 2);
+				patch_multiply_code<byte>(ff7_externals.limit_break_aura_effects_5C0572 + 0x13E, frame_multiplier);
+				patch_multiply_code<DWORD>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0x5C, frame_multiplier);
+				patch_code_byte(ff7_externals.enemy_skill_aura_effects_5C06BF + 0x64, 0x7 - frame_multiplier / 2);
+				patch_multiply_code<DWORD>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0x81, frame_multiplier);
+				patch_code_byte(ff7_externals.enemy_skill_aura_effects_5C06BF + 0x89, 0xA - frame_multiplier / 2);
+				patch_multiply_code<byte>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0xA7, frame_multiplier);
+				patch_divide_code<int>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0xB3, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0xD6, frame_multiplier);
+				patch_code_byte(ff7_externals.enemy_skill_aura_effects_5C06BF + 0xD9, 0xC - frame_multiplier / 2);
+				patch_multiply_code<byte>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0x182, frame_multiplier);
+				patch_code_byte(ff7_externals.summon_aura_effects_5C0953 + 0x4D, 0xC - frame_multiplier / 2);
+				patch_multiply_code<byte>(ff7_externals.summon_aura_effects_5C0953 + 0x19D, frame_multiplier);
+
+				// Effect60 related
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C18BC + 0xDC, frame_multiplier);
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C1C8F + 0x55, frame_multiplier);
 

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -33,8 +33,7 @@ unsigned char midi_fix[] = {0x8B, 0x4D, 0x14};
 WORD snowboard_fix[] = {0x0F, 0x10, 0x0F};
 byte y_pos_offset_display_damage_30[] = {0, 1, 2, 3, 4, 5, 6, 6, 7, 7, 8, 8, 8, 8, 7, 7, 6, 6, 5, 4, 3, 2};
 //byte y_pos_offset_display_damage_60[] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 7, 7, 7, 7, 6, 6, 6, 6, 5, 5, 4, 3, 2, 1, 0, 0};
-byte y_pos_offset_display_damage_60[] = {0, 1, 2, 3, 4, 5, 6, 6, 7, 7, 7, 8, 8, 8, 8, 8, 7, 7, 7, 6, 6, 5, 4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 4, 4, 3, 2, 1, 0, 0, 1, 1, 0, 0, 0};
-										
+byte y_pos_offset_display_damage_60[] = {0, 1, 2, 3, 4, 5, 6, 6, 7, 7, 7, 8, 8, 8, 8, 8, 7, 7, 7, 6, 6, 5, 4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 4, 4, 3, 2, 1, 0, 0, 1, 1, 0, 0, 0};			
 
 void ff7_init_hooks(struct game_obj *_game_object)
 {
@@ -276,16 +275,23 @@ void ff7_init_hooks(struct game_obj *_game_object)
 
 				// Character fade in/out (i.e. multiply g_script_wait_frames and other things)
 				patch_multiply_code<byte>(ff7_externals.battle_sub_42A72D + 0x11A, frame_multiplier);
-				patch_multiply_code<WORD>(ff7_externals.battle_sub_5D4240 + 0x24, frame_multiplier);
-				patch_multiply_code<WORD>(ff7_externals.battle_sub_5D4240 + 0x57, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.battle_sub_5D4240 + 0x6E, frame_multiplier);
+				patch_multiply_code<WORD>(ff7_externals.vincent_limit_fade_effect_sub_5D4240 + 0x24, frame_multiplier);
+				patch_multiply_code<WORD>(ff7_externals.vincent_limit_fade_effect_sub_5D4240 + 0x57, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.vincent_limit_fade_effect_sub_5D4240 + 0x6E, frame_multiplier);
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C18BC + 0xDC, frame_multiplier);
 				patch_multiply_code<byte>(ff7_externals.battle_sub_5C18BC + 0xE4, frame_multiplier);
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C1C8F + 0x55, frame_multiplier);
 				patch_multiply_code<byte>(ff7_externals.battle_sub_5C1C8F + 0x5D, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.battle_sub_5C0E4B + 0x75, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.battle_sub_5C0E4B + 0x6D, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.battle_sub_5C0E4B + 0x15B, frame_multiplier);
+
+				// Summons
+				patch_multiply_code<byte>(ff7_externals.run_summon_animations_5C0E4B + 0x75, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.run_summon_animations_5C0E4B + 0x6D, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.run_summon_animations_5C0E4B + 0x15B, frame_multiplier);
+				patch_code_dword(ff7_externals.run_shiva_camera_58E60D + 0xC2D, 0x90909090);
+				patch_code_word(ff7_externals.run_shiva_camera_58E60D + 0xC31, 0x9090);
+				patch_code_dword(ff7_externals.run_ramuh_camera_597206 + 0x44, 0x000B9585);
+				patch_code_dword(ff7_externals.run_odin_gunge_camera_4A0F52 + 0xC0C, 0x90909090);
+				patch_code_word(ff7_externals.run_odin_gunge_camera_4A0F52 + 0xC10, 0x9090);
 
 				// Show Damage
 				patch_multiply_code<WORD>(ff7_externals.display_battle_damage_5BB410 + 0x54, frame_multiplier);
@@ -325,8 +331,11 @@ void ff7_init_hooks(struct game_obj *_game_object)
 				patch_code_byte(ff7_externals.summon_aura_effects_5C0953 + 0x4D, 0xC - frame_multiplier / 2);
 				patch_multiply_code<byte>(ff7_externals.summon_aura_effects_5C0953 + 0x19D, frame_multiplier);
 
-				// Tifa limit break effects
+				// Limit break effects
 				patch_multiply_code<byte>(ff7_externals.tifa_limit_2_1_sub_4E48D4 + 0x1FE, frame_multiplier);
+				patch_code_dword(ff7_externals.aerith_limit_2_1_sub_45B0CF + 0xCE, 0x90909090);
+				patch_code_word(ff7_externals.aerith_limit_2_1_sub_45B0CF + 0xD2, 0x9090);
+				patch_multiply_code<byte>(ff7_externals.aerith_limit_2_1_sub_45B0CF + 0xE2, frame_multiplier);
 
 				// Effect60 related
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_425E5F + 0x3A, frame_multiplier);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -31,9 +31,10 @@
 
 unsigned char midi_fix[] = {0x8B, 0x4D, 0x14};
 WORD snowboard_fix[] = {0x0F, 0x10, 0x0F};
-byte y_pos_offset_display_damage_30[] = {0, 1, 2, 3, 4, 5, 6, 6, 7, 7, 8, 8, 8, 8, 7, 7, 6, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0};
-byte y_pos_offset_display_damage_60[] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8,
-										 7, 7, 7, 7, 6, 6, 6, 6, 5, 5, 4, 4, 3, 3, 2, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+byte y_pos_offset_display_damage_30[] = {0, 1, 2, 3, 4, 5, 6, 6, 7, 7, 8, 8, 8, 8, 7, 7, 6, 6, 5, 4, 3, 2};
+//byte y_pos_offset_display_damage_60[] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 7, 7, 7, 7, 6, 6, 6, 6, 5, 5, 4, 3, 2, 1, 0, 0};
+byte y_pos_offset_display_damage_60[] = {0, 1, 2, 3, 4, 5, 6, 6, 7, 7, 7, 8, 8, 8, 8, 8, 7, 7, 7, 6, 6, 5, 4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 4, 4, 3, 2, 1, 0, 0, 1, 1, 0, 0, 0};
+										
 
 void ff7_init_hooks(struct game_obj *_game_object)
 {
@@ -273,7 +274,6 @@ void ff7_init_hooks(struct game_obj *_game_object)
 
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_5D4240 + 0x24, frame_multiplier);
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_5D4240 + 0x57, frame_multiplier);
-				replace_function(ff7_externals.battle_sub_5BD96D, ff7_battle_sub_5BD96D);
 
 				// Display string related
 				replace_function(ff7_externals.get_n_frames_display_action_string, ff7_get_n_frames_display_action_string);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -268,18 +268,24 @@ void ff7_init_hooks(struct game_obj *_game_object)
 				patch_multiply_code<WORD>(ff7_externals.battle_disintegrate_1_death_5BBF31 + 0x40, frame_multiplier);
 				replace_function(ff7_externals.battle_disintegrate_1_death_sub_5BC04D, ff7_battle_disintegrate_1_death_sub_5BC04D);
 
-				// Unknown (+ 2 other fixed in ff7_execute_effect100_fn)
-				patch_multiply_code<byte>(ff7_externals.battle_sub_5C0E4B + 0x6D, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.battle_sub_5C0E4B + 0x15B, frame_multiplier);
-
-				patch_multiply_code<WORD>(ff7_externals.battle_sub_5D4240 + 0x24, frame_multiplier);
-				patch_multiply_code<WORD>(ff7_externals.battle_sub_5D4240 + 0x57, frame_multiplier);
-
 				// Display string related
 				replace_function(ff7_externals.get_n_frames_display_action_string, ff7_get_n_frames_display_action_string);
 
 				// Character movement (e.g. movement animation for attacks)
 				replace_function(ff7_externals.battle_move_character_sub_426F58, ff7_battle_move_character_sub_426F58);
+
+				// Character fade in/out (i.e. multiply g_script_wait_frames and other things)
+				patch_multiply_code<byte>(ff7_externals.battle_sub_42A72D + 0x11A, frame_multiplier);
+				patch_multiply_code<WORD>(ff7_externals.battle_sub_5D4240 + 0x24, frame_multiplier);
+				patch_multiply_code<WORD>(ff7_externals.battle_sub_5D4240 + 0x57, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.battle_sub_5D4240 + 0x6E, frame_multiplier);
+				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C18BC + 0xDC, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.battle_sub_5C18BC + 0xE4, frame_multiplier);
+				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C1C8F + 0x55, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.battle_sub_5C1C8F + 0x5D, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.battle_sub_5C0E4B + 0x75, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.battle_sub_5C0E4B + 0x6D, frame_multiplier);
+				patch_multiply_code<byte>(ff7_externals.battle_sub_5C0E4B + 0x15B, frame_multiplier);
 
 				// Show Damage
 				patch_multiply_code<WORD>(ff7_externals.display_battle_damage_5BB410 + 0x54, frame_multiplier);
@@ -320,9 +326,6 @@ void ff7_init_hooks(struct game_obj *_game_object)
 				patch_multiply_code<byte>(ff7_externals.summon_aura_effects_5C0953 + 0x19D, frame_multiplier);
 
 				// Effect60 related
-				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C18BC + 0xDC, frame_multiplier);
-				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C1C8F + 0x55, frame_multiplier);
-
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_425E5F + 0x3A, frame_multiplier);
 
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_5BCF9D + 0x3A, frame_multiplier);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -334,8 +334,6 @@ void ff7_init_hooks(struct game_obj *_game_object)
 
 				patch_multiply_code<WORD>(ff7_externals.battle_sub_5BCD42 + 0x5B, frame_multiplier); 
 				patch_divide_code<WORD>(ff7_externals.battle_sub_5BCD42 + 0x6E, frame_multiplier);
-
-				patch_multiply_code<byte>(ff7_externals.battle_sub_5BE4E2 + 0xB8, frame_multiplier);
 			}
 			//
 


### PR DESCRIPTION
This new update should makes battle almost 60 fps non-progressive with glitches on camera and glitches when using summons. Testing right now is not really useful since there could be huge changes when tweaking the pause trick. If you need to group it as a single commit, feel free to tell me. I thought it was better to leave them as multiple commits since it is clearer.