### PR TITLE
60FPS: Fix summon animation bugs and glitches + Add barebone for camera battle controls

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -701,10 +701,14 @@ struct battle_anim_event {
     uint16_t damageEventQueueIdx;
 };
 
+struct camera_vec3 {
+	short x;
+	short y;
+	short z;
+};
+
 struct bcamera_position{
-	short location_x;
-	short location_y;
-	short location_z;
+	camera_vec3 point;
 	WORD unused_6;
 	short current_position;
 	short frames_to_wait;
@@ -2359,10 +2363,6 @@ struct ff7_externals
 	uint32_t field_load_models_atoi;
 
 	// battle camera script externals
-	bcamera_fn_data* camera_fn_data;
-	bcamera_position* battle_camera_position;
-	bcamera_position* battle_camera_focal_position;
-	uint32_t* camera_fn_array;
 	uint32_t handle_camera_functions;
 	uint32_t set_camera_focal_position_scripts;
 	uint32_t set_camera_position_scripts;
@@ -2370,6 +2370,20 @@ struct ff7_externals
 	uint32_t execute_camera_functions;
 	uint32_t battle_camera_sub_5C52F8;
 	uint32_t battle_camera_sub_5C3E6F;
+	uint32_t battle_camera_position_sub_5C3D0D;
+	uint32_t battle_camera_position_sub_5C557D;
+	uint32_t battle_camera_position_sub_5C5B9C;
+	uint32_t battle_camera_focal_sub_5C5F5E;
+	uint32_t battle_camera_focal_sub_5C5714;
+	uint32_t battle_sub_430DD0;
+	uint32_t battle_sub_429D8A;
+	uint32_t battle_sub_6E3135;
+	uint32_t update_battle_camera_sub_5C20CE;
+	uint32_t set_battle_camera_sub_5C22BD;
+	bcamera_fn_data* camera_fn_data;
+	bcamera_position* battle_camera_position;
+	bcamera_position* battle_camera_focal_position;
+	uint32_t* camera_fn_array;
 	byte* battle_camera_focal_scripts_8FEE30;
 	byte* battle_camera_position_scripts_8FEE2C;
 	DWORD* battle_camera_global_scripts_9A13BC;
@@ -2379,14 +2393,8 @@ struct ff7_externals
 	DWORD* battle_camera_script_offset;
 	WORD* camera_fn_index;
 	WORD* camera_fn_counter;
-	uint32_t battle_camera_position_sub_5C3D0D;
-	uint32_t battle_camera_position_sub_5C557D;
-	uint32_t battle_camera_position_sub_5C5B9C;
-	uint32_t battle_camera_focal_sub_5C5F5E;
-	uint32_t battle_camera_focal_sub_5C5714;
-	uint32_t battle_sub_430DD0;
-	uint32_t battle_sub_429D8A;
-	uint32_t battle_sub_6E3135;
+	camera_vec3* g_battle_camera_position;
+	camera_vec3* g_battle_camera_focal_point;
 
 	// animation script externals
 	uint32_t battle_sub_42A5EB;
@@ -2463,6 +2471,13 @@ struct ff7_externals
 	uint32_t run_shiva_camera_58E60D;
 	uint32_t run_ramuh_camera_597206;
 	uint32_t run_odin_gunge_camera_4A0F52;
+	uint32_t run_summon_odin_steel_sub_4A9908;
+	uint32_t run_summon_kotr_sub_476857;
+	void(*add_kotr_camera_fn_to_effect100_fn_476AAB)(DWORD, DWORD, WORD);
+	uint32_t run_kotr_camera_476AFB;
+	uint32_t run_bahamut_zero_main_loop_484A16;
+	uint32_t run_summon_phoenix_sub_515127;
+	uint32_t run_phoenix_main_loop_516297;
 
 	battle_model_state *g_battle_model_state;
 	battle_model_state_small *g_small_battle_model_state;
@@ -2493,6 +2508,7 @@ struct ff7_externals
 	byte* field_battle_byte_BF2E1C;
 	byte* field_battle_byte_BE10B4;
 	short* resting_Y_array_data;
+	WORD* field_odin_frames_AEEC14;
 
 	// battle dialogue
 	uint32_t battle_sub_42CBF9;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -707,6 +707,11 @@ struct camera_vec3 {
 	short z;
 };
 
+struct special_battle_camera{
+	camera_vec3 position;
+	camera_vec3 focal_point;
+};
+
 struct bcamera_position{
 	camera_vec3 point;
 	WORD unused_6;
@@ -2380,6 +2385,9 @@ struct ff7_externals
 	uint32_t battle_sub_6E3135;
 	uint32_t update_battle_camera_sub_5C20CE;
 	uint32_t set_battle_camera_sub_5C22BD;
+	uint32_t battle_camera_sub_5C22A9;
+	uint32_t battle_camera_sub_5C655C;
+	uint32_t set_battle_camera_sub_5C2350;
 	bcamera_fn_data* camera_fn_data;
 	bcamera_position* battle_camera_position;
 	bcamera_position* battle_camera_focal_position;
@@ -2395,6 +2403,10 @@ struct ff7_externals
 	WORD* camera_fn_counter;
 	camera_vec3* g_battle_camera_position;
 	camera_vec3* g_battle_camera_focal_point;
+	special_battle_camera* extra_battle_camera;
+	byte* extra_battle_camera_idx;
+	byte* battle_enter_frames_to_wait;
+	byte* g_variation_index;
 
 	// animation script externals
 	uint32_t battle_sub_42A5EB;

--- a/src/ff7/camera.cpp
+++ b/src/ff7/camera.cpp
@@ -211,6 +211,27 @@ void ff7_run_camera_position_script(char variationIndex, DWORD param_2, short ca
         cameraPosition[variationIndex].frames_to_wait = framesToWait;
 }
 
+void ff7_update_battle_camera(short cameraScriptIndex)
+{
+    if(cameraScriptIndex == -2 && *ff7_externals.battle_enter_frames_to_wait == 0)
+    {
+        // TODO Cosmos
+        ff7_externals.battle_camera_position[*ff7_externals.g_variation_index].point.x += 100 / frame_multiplier;
+    }
+
+    ((void(*)(short))ff7_externals.update_battle_camera_sub_5C20CE)(cameraScriptIndex);
+}
+
+void ff7_update_idle_battle_camera()
+{
+    // TODO Cosmos
+    ff7_externals.extra_battle_camera[*ff7_externals.extra_battle_camera_idx].position.x += 100 / frame_multiplier;
+    ff7_externals.battle_camera_position[3].point.x += 100 / frame_multiplier;
+
+    ((void(*)())ff7_externals.battle_camera_sub_5C655C)();
+    ((void(*)(short))ff7_externals.set_battle_camera_sub_5C2350)(3);
+}
+
 void battle_camera_hook_init()
 {
     replace_function(ff7_externals.execute_camera_functions, ff7_execute_camera_functions);

--- a/src/ff7/camera.cpp
+++ b/src/ff7/camera.cpp
@@ -26,6 +26,7 @@
 #include <span>
 
 #include "../ff7.h"
+#include "../patch.h"
 #include "../log.h"
 #include "../globals.h"
 
@@ -208,4 +209,21 @@ void ff7_run_camera_position_script(char variationIndex, DWORD param_2, short ca
 
     if (executedOpCodeF5)
         cameraPosition[variationIndex].frames_to_wait = framesToWait;
+}
+
+void battle_camera_hook_init()
+{
+    replace_function(ff7_externals.execute_camera_functions, ff7_execute_camera_functions);
+    replace_function(ff7_externals.add_fn_to_camera_fn_array, ff7_add_fn_to_camera_fn);
+    replace_call_function(ff7_externals.handle_camera_functions + 0x35, ff7_run_camera_focal_position_script);
+    replace_call_function(ff7_externals.handle_camera_functions + 0x4B, ff7_run_camera_position_script);
+
+    // Battle outro camera frame fix: patch DAT_009AE138 (frames to wait before closing battle mode)
+    patch_multiply_code<byte>(ff7_externals.battle_sub_430DD0 + 0x3DE, frame_multiplier);
+    patch_multiply_code<byte>(ff7_externals.battle_sub_430DD0 + 0x361, frame_multiplier);
+    patch_multiply_code<byte>(ff7_externals.battle_sub_430DD0 + 0x326, frame_multiplier);
+
+    // Battle intro camera frame fix: patch DAT_00BFD0F4 (frames to wait before atb starts)
+    patch_multiply_code<byte>(ff7_externals.battle_sub_429AC0 + 0x152, frame_multiplier);
+    patch_multiply_code<byte>(ff7_externals.battle_sub_429D8A + 0x1D8, frame_multiplier);
 }

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -66,6 +66,8 @@ int ff7_load_save_file(int param_1);
 
 // camera
 void battle_camera_hook_init();
+void ff7_update_battle_camera(short cameraScriptIndex);
+void ff7_update_idle_battle_camera();
 
 // animation
 void battle_animations_hook_init();

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -65,23 +65,10 @@ void ff7_character_regularly_field_entity_60FA7D(WORD param1, short param2, shor
 int ff7_load_save_file(int param_1);
 
 // camera
-int ff7_add_fn_to_camera_fn(uint32_t function);
-void ff7_execute_camera_functions();
-void ff7_run_camera_focal_position_script(char index, DWORD param_2, short param_3);
-void ff7_run_camera_position_script(char index, DWORD param_2, short param_3);
+void battle_camera_hook_init();
 
 // animation
-void ff7_run_animation_script(byte actorID, byte **ptrToScriptTable);
-int ff7_add_fn_to_effect100_fn(uint32_t function);
-int ff7_add_fn_to_effect60_fn(uint32_t function);
-int ff7_add_fn_to_effect10_fn(uint32_t function);
-void ff7_execute_effect100_fn();
-void ff7_execute_effect60_fn();
-void ff7_execute_effect10_fn();
-void ff7_boss_death_animation_5BC5EC();
-void ff7_battle_move_character_sub_426F58();
-int ff7_get_n_frames_display_action_string();
-void ff7_battle_disintegrate_1_death_sub_5BC04D(byte effect10_array_idx);
+void battle_animations_hook_init();
 
 // field
 void field_load_textures(struct ff7_game_obj *game_object, struct struc_3 *struc_3);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -596,8 +596,15 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_sub_6E3135 = get_relative_call(battle_sub_6D797C, 0x1C2);
 	ff7_externals.update_battle_camera_sub_5C20CE = get_relative_call(ff7_externals.battle_sub_42D992, 0xFB);
 	ff7_externals.set_battle_camera_sub_5C22BD = get_relative_call(ff7_externals.update_battle_camera_sub_5C20CE, 0x5A);
+	ff7_externals.battle_camera_sub_5C22A9 = get_relative_call(ff7_externals.update_battle_camera_sub_5C20CE, 0x97);
+	ff7_externals.battle_camera_sub_5C655C = get_relative_call(ff7_externals.battle_camera_sub_5C22A9, 0x3);
+	ff7_externals.set_battle_camera_sub_5C2350 = get_relative_call(ff7_externals.battle_camera_sub_5C22A9, 0xA);
 	ff7_externals.g_battle_camera_position = (camera_vec3*)get_absolute_value(ff7_externals.set_battle_camera_sub_5C22BD, 0x17);
 	ff7_externals.g_battle_camera_focal_point = (camera_vec3*)get_absolute_value(ff7_externals.set_battle_camera_sub_5C22BD, 0x5E);
+	ff7_externals.extra_battle_camera = (special_battle_camera*)get_absolute_value(ff7_externals.set_battle_camera_sub_5C22BD, 0x10);
+	ff7_externals.extra_battle_camera_idx = (byte*)get_absolute_value(ff7_externals.set_battle_camera_sub_5C22BD, 0x6);
+	ff7_externals.battle_enter_frames_to_wait = (byte*)get_absolute_value(ff7_externals.battle_sub_429AC0, 0x14E);
+	ff7_externals.g_variation_index = (byte*)get_absolute_value(ff7_externals.update_battle_camera_sub_5C20CE, 0x6F);
 	// --------------------------------
 
 	// animation 60 fps

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -594,6 +594,10 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	uint32_t battle_sub_6D82EA = get_relative_call(battle_sub_6D83C8, 0xE0);
 	uint32_t battle_sub_6D797C = get_relative_call(battle_sub_6D82EA, 0x59);
 	ff7_externals.battle_sub_6E3135 = get_relative_call(battle_sub_6D797C, 0x1C2);
+	ff7_externals.update_battle_camera_sub_5C20CE = get_relative_call(ff7_externals.battle_sub_42D992, 0xFB);
+	ff7_externals.set_battle_camera_sub_5C22BD = get_relative_call(ff7_externals.update_battle_camera_sub_5C20CE, 0x5A);
+	ff7_externals.g_battle_camera_position = (camera_vec3*)get_absolute_value(ff7_externals.set_battle_camera_sub_5C22BD, 0x17);
+	ff7_externals.g_battle_camera_focal_point = (camera_vec3*)get_absolute_value(ff7_externals.set_battle_camera_sub_5C22BD, 0x5E);
 	// --------------------------------
 
 	// animation 60 fps
@@ -778,6 +782,21 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	uint32_t run_summon_odin_gunge_sub_4A0B6D = get_relative_call(run_summon_odin_gunge_main_4A0AE1, 0x7F);
 	uint32_t run_summon_odin_gunge_sub_4A0F12 = get_relative_call(run_summon_odin_gunge_sub_4A0B6D, 0x1C0);
 	ff7_externals.run_odin_gunge_camera_4A0F52 = get_absolute_value(run_summon_odin_gunge_sub_4A0F12, 0x5);
+	uint32_t run_summon_odin_steel_main_4A5B61 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x3BB);
+	uint32_t run_summon_odin_steel_sub_4A5BE5 = get_relative_call(run_summon_odin_steel_main_4A5B61, 0x77);
+	uint32_t run_summon_odin_steel_sub_4A8B86 = get_absolute_value(run_summon_odin_steel_sub_4A5BE5, 0xA7);
+	ff7_externals.run_summon_odin_steel_sub_4A9908 = get_absolute_value(run_summon_odin_steel_sub_4A8B86, 0x43E);
+	ff7_externals.field_odin_frames_AEEC14 = (WORD*)get_absolute_value(ff7_externals.run_summon_odin_steel_sub_4A9908, 0x316);
+	uint32_t run_summon_kotr_main_476842 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x43A);
+	ff7_externals.run_summon_kotr_sub_476857 = get_relative_call(run_summon_kotr_main_476842, 0xB);
+	ff7_externals.add_kotr_camera_fn_to_effect100_fn_476AAB = (void(*)(DWORD, DWORD, WORD))get_relative_call(ff7_externals.run_summon_kotr_sub_476857, 0x1C6);
+	ff7_externals.run_kotr_camera_476AFB = get_relative_call((uint32_t)ff7_externals.add_kotr_camera_fn_to_effect100_fn_476AAB, 0xA);
+	uint32_t run_summon_bahamut_zero_main_4835C1 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x399);
+	uint32_t run_summon_bahamut_zero_sub_483762 = get_relative_call(run_summon_bahamut_zero_main_4835C1, 0x194);
+	ff7_externals.run_bahamut_zero_main_loop_484A16 = get_absolute_value(run_summon_bahamut_zero_sub_483762, 0x5F);
+	uint32_t run_summon_phoenix_main_515101 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x2AB);
+	uint32_t run_summon_phoenix_sub_515127 = get_relative_call(run_summon_phoenix_main_515101, 0x1A);
+	ff7_externals.run_phoenix_main_loop_516297 = get_absolute_value(run_summon_phoenix_sub_515127, 0xB2);
 	// --------------------------------
 
 	// battle dialogues

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -216,6 +216,13 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	replace_function(ff7_externals.get_gamepad, ff7_get_gamepad);
 	replace_function(ff7_externals.update_gamepad_status, ff7_update_gamepad_status);
 
+	// #####################
+	// control battle camera
+	// #####################
+	// TODO Cosmos
+	//replace_call_function(ff7_externals.battle_sub_42D992 + 0xFB, ff7_update_battle_camera);
+	//replace_function(ff7_externals.battle_camera_sub_5C22A9, ff7_update_idle_battle_camera);
+
 	//######################
 	// menu rendering fix
 	//######################

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -30,10 +30,7 @@
 #include "ff7_data.h"
 
 unsigned char midi_fix[] = {0x8B, 0x4D, 0x14};
-WORD snowboard_fix[] = {0x0F, 0x10, 0x0F};
-byte y_pos_offset_display_damage_30[] = {0, 1, 2, 3, 4, 5, 6, 6, 7, 7, 8, 8, 8, 8, 7, 7, 6, 6, 5, 4, 3, 2};
-//byte y_pos_offset_display_damage_60[] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 7, 7, 7, 7, 6, 6, 6, 6, 5, 5, 4, 3, 2, 1, 0, 0};
-byte y_pos_offset_display_damage_60[] = {0, 1, 2, 3, 4, 5, 6, 6, 7, 7, 7, 8, 8, 8, 8, 8, 7, 7, 7, 6, 6, 5, 4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 4, 4, 3, 2, 1, 0, 0, 1, 1, 0, 0, 0};			
+WORD snowboard_fix[] = {0x0F, 0x10, 0x0F};	
 
 void ff7_init_hooks(struct game_obj *_game_object)
 {
@@ -135,6 +132,14 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	replace_call_function(ff7_externals.on_gameover_exit, ff7_on_gameover_exit);
 
 	// ##################################
+	// animation glitch fixes
+	// ##################################
+
+	// phoenix camera animation glitch
+	memset_code(ff7_externals.run_phoenix_main_loop_516297 + 0x3A5, 0x90, 49);
+    memset_code(ff7_externals.run_phoenix_main_loop_516297 + 0x3F7, 0x90, 49);
+
+	// ##################################
 	// bugfixes to enhance game stability
 	// ##################################
 
@@ -185,180 +190,11 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		if (ff7_fps_limiter >= FF7_LIMITER_30FPS)
 		{
 			frame_multiplier = (ff7_fps_limiter == FF7_LIMITER_30FPS) ? 2 : 4;
+			
+			patch_divide_code<byte>(ff7_externals.battle_fps_menu_multiplier, frame_multiplier);
 
-			// ###############################
-			// Battle camera movement support
-			// ###############################
-			{
-				replace_function(ff7_externals.execute_camera_functions, ff7_execute_camera_functions);
-				replace_function(ff7_externals.add_fn_to_camera_fn_array, ff7_add_fn_to_camera_fn);
-				replace_call_function(ff7_externals.handle_camera_functions + 0x35, ff7_run_camera_focal_position_script);
-				replace_call_function(ff7_externals.handle_camera_functions + 0x4B, ff7_run_camera_position_script);
-
-				// Battle outro camera frame fix: patch DAT_009AE138 (frames to wait before closing battle mode)
-				patch_multiply_code<byte>(ff7_externals.battle_sub_430DD0 + 0x3DE, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.battle_sub_430DD0 + 0x361, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.battle_sub_430DD0 + 0x326, frame_multiplier);
-
-				// Battle intro camera frame fix: patch DAT_00BFD0F4 (frames to wait before atb starts)
-				patch_multiply_code<byte>(ff7_externals.battle_sub_429AC0 + 0x152, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.battle_sub_429D8A + 0x1D8, frame_multiplier);
-			}
-
-			// ##################
-			// Animation scripts
-			// ##################
-			{
-				replace_call_function(ff7_externals.battle_sub_42A5EB + 0xB8, ff7_run_animation_script);
-				replace_call_function(ff7_externals.battle_sub_42E275 + 0xB2, ff7_run_animation_script);
-				replace_call_function(ff7_externals.battle_sub_42E34A + 0x76, ff7_run_animation_script);
-				replace_call_function(ff7_externals.battle_sub_5BD5E9 + 0x22F, ff7_run_animation_script);
-				replace_call_function(ff7_externals.battle_sub_5C1D9A + 0x4A, ff7_run_animation_script);
-				replace_function(ff7_externals.add_fn_to_effect100_fn, ff7_add_fn_to_effect100_fn);
-				replace_function(ff7_externals.add_fn_to_effect10_fn, ff7_add_fn_to_effect10_fn);
-				replace_function(ff7_externals.add_fn_to_effect60_fn, ff7_add_fn_to_effect60_fn);
-				replace_function(ff7_externals.execute_effect100_fn, ff7_execute_effect100_fn);
-				replace_function(ff7_externals.execute_effect10_fn, ff7_execute_effect10_fn);
-				replace_function(ff7_externals.execute_effect60_fn, ff7_execute_effect60_fn);
-				
-				// Normal enemy death
-				patch_multiply_code<WORD>(ff7_externals.battle_enemy_death_5BBD24 + 0x40, frame_multiplier);
-				patch_divide_code<WORD>(ff7_externals.battle_enemy_death_sub_5BBE32 + 0xA8, frame_multiplier);
-				patch_divide_code<byte>(ff7_externals.battle_enemy_death_sub_5BBE32 + 0xCB, frame_multiplier);
-
-				// Enemy death - iainuki
-				patch_multiply_code<WORD>(ff7_externals.battle_iainuki_death_5BCAAA + 0x40, frame_multiplier);
-				patch_divide_code<WORD>(ff7_externals.battle_iainuki_death_sub_5BCBB8 + 0x9F, frame_multiplier);
-				patch_divide_code<byte>(ff7_externals.battle_iainuki_death_sub_5BCBB8 + 0xC2, frame_multiplier);
-				patch_divide_code<byte>(ff7_externals.battle_iainuki_death_sub_5BCBB8 + 0xE3, frame_multiplier);
-				patch_divide_code<byte>(ff7_externals.battle_iainuki_death_sub_5BCBB8 + 0x104, frame_multiplier);
-				patch_divide_code<WORD>(ff7_externals.battle_iainuki_death_sub_5BCBB8 + 0x154, frame_multiplier);
-
-				// Boss death
-				patch_multiply_code<WORD>(ff7_externals.battle_boss_death_5BC48C + 0x40, frame_multiplier);
-				patch_multiply_code<WORD>(ff7_externals.battle_boss_death_5BC48C + 0xCF, frame_multiplier);
-				patch_divide_code<byte>(ff7_externals.battle_boss_death_sub_5BC6ED + 0xCF, frame_multiplier);
-				patch_divide_code<byte>(ff7_externals.battle_boss_death_sub_5BC6ED + 0xF1, frame_multiplier);
-				replace_function(ff7_externals.battle_boss_death_sub_5BC5EC, ff7_boss_death_animation_5BC5EC);
-
-				// Enemy death - melting
-				patch_multiply_code<WORD>(ff7_externals.battle_melting_death_5BC21F + 0x40, frame_multiplier);
-				patch_divide_code<WORD>(ff7_externals.battle_melting_death_sub_5BC32D + 0xAB, frame_multiplier);
-				patch_divide_code<byte>(ff7_externals.battle_melting_death_sub_5BC32D + 0xCE, frame_multiplier);
-				patch_divide_code<WORD>(ff7_externals.battle_melting_death_sub_5BC32D + 0xEE, frame_multiplier);
-				patch_divide_code<WORD>(ff7_externals.battle_melting_death_sub_5BC32D + 0x10D, frame_multiplier);
-				patch_divide_code<WORD>(ff7_externals.battle_melting_death_sub_5BC32D + 0x12C, frame_multiplier);
-
-				// Enemy death - disintegrate 2
-				patch_multiply_code<WORD>(ff7_externals.battle_disintegrate_2_death_5BBA82 + 0x40, frame_multiplier);
-				patch_divide_code<WORD>(ff7_externals.battle_disintegrate_2_death_sub_5BBBDE + 0xB9, frame_multiplier);
-				patch_divide_code<byte>(ff7_externals.battle_disintegrate_2_death_sub_5BBBDE + 0xDB, frame_multiplier);
-				patch_divide_code<float>((uint32_t)ff7_externals.field_float_battle_7B7680, frame_multiplier); // float value used also elsewhere
-
-				// Enemy death - morph
-				patch_multiply_code<WORD>(ff7_externals.battle_morph_death_5BC812 + 0x40, frame_multiplier);
-				patch_divide_code<WORD>(ff7_externals.battle_morph_death_sub_5BC920 + 0x9F, frame_multiplier);
-				patch_divide_code<byte>(ff7_externals.battle_morph_death_sub_5BC920 + 0xC2, frame_multiplier);
-				patch_divide_code<byte>(ff7_externals.battle_morph_death_sub_5BC920 + 0xE3, frame_multiplier);
-				patch_divide_code<byte>(ff7_externals.battle_morph_death_sub_5BC920 + 0x104, frame_multiplier);
-				patch_divide_code<WORD>(ff7_externals.battle_morph_death_sub_5BC920 + 0x154, frame_multiplier);
-
-				// Enemy death - disintegrate 1 
-				patch_multiply_code<WORD>(ff7_externals.battle_disintegrate_1_death_5BBF31 + 0x40, frame_multiplier);
-				replace_function(ff7_externals.battle_disintegrate_1_death_sub_5BC04D, ff7_battle_disintegrate_1_death_sub_5BC04D);
-
-				// Display string related
-				replace_function(ff7_externals.get_n_frames_display_action_string, ff7_get_n_frames_display_action_string);
-
-				// Character movement (e.g. movement animation for attacks)
-				replace_function(ff7_externals.battle_move_character_sub_426F58, ff7_battle_move_character_sub_426F58);
-
-				// Character fade in/out (i.e. multiply g_script_wait_frames and other things)
-				patch_multiply_code<byte>(ff7_externals.battle_sub_42A72D + 0x11A, frame_multiplier);
-				patch_multiply_code<WORD>(ff7_externals.vincent_limit_fade_effect_sub_5D4240 + 0x24, frame_multiplier);
-				patch_multiply_code<WORD>(ff7_externals.vincent_limit_fade_effect_sub_5D4240 + 0x57, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.vincent_limit_fade_effect_sub_5D4240 + 0x6E, frame_multiplier);
-				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C18BC + 0xDC, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.battle_sub_5C18BC + 0xE4, frame_multiplier);
-				patch_multiply_code<WORD>(ff7_externals.battle_sub_5C1C8F + 0x55, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.battle_sub_5C1C8F + 0x5D, frame_multiplier);
-
-				// Summons
-				patch_multiply_code<byte>(ff7_externals.run_summon_animations_5C0E4B + 0x75, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.run_summon_animations_5C0E4B + 0x6D, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.run_summon_animations_5C0E4B + 0x15B, frame_multiplier);
-				patch_code_dword(ff7_externals.run_shiva_camera_58E60D + 0xC2D, 0x90909090);
-				patch_code_word(ff7_externals.run_shiva_camera_58E60D + 0xC31, 0x9090);
-				patch_code_dword(ff7_externals.run_ramuh_camera_597206 + 0x44, 0x000B9585);
-				patch_code_dword(ff7_externals.run_odin_gunge_camera_4A0F52 + 0xC0C, 0x90909090);
-				patch_code_word(ff7_externals.run_odin_gunge_camera_4A0F52 + 0xC10, 0x9090);
-
-				// Show Damage
-				patch_multiply_code<WORD>(ff7_externals.display_battle_damage_5BB410 + 0x54, frame_multiplier);
-				if(frame_multiplier == 2)
-				{
-					patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x1E2, (DWORD)y_pos_offset_display_damage_30);
-					patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x2D7, (DWORD)y_pos_offset_display_damage_30);
-				}
-				else if(frame_multiplier == 4)
-				{
-					patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x1E2, (DWORD)y_pos_offset_display_damage_60);
-					patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x2D7, (DWORD)y_pos_offset_display_damage_60);
-				}
-
-				// Aura animation (magic, limit break, enemy skill, summon)
-				patch_code_byte(ff7_externals.magic_aura_effects_5C0300 + 0x4C, 0x7 - frame_multiplier / 2);
-				patch_code_byte(ff7_externals.magic_aura_effects_5C0300 + 0x6A, 0xA - frame_multiplier / 2);
-				patch_multiply_code<byte>(ff7_externals.magic_aura_effects_5C0300 + 0x88, frame_multiplier);
-				patch_code_byte(ff7_externals.magic_aura_effects_5C0300 + 0xA2, 0xC - frame_multiplier / 2);
-				patch_multiply_code<byte>(ff7_externals.magic_aura_effects_5C0300 + 0x138, frame_multiplier);
-				patch_divide_code<DWORD>(ff7_externals.limit_break_aura_effects_5C0572 + 0x4C, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.limit_break_aura_effects_5C0572 + 0x6E, frame_multiplier);
-				patch_divide_code<DWORD>(ff7_externals.limit_break_aura_effects_5C0572 + 0x7A, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.limit_break_aura_effects_5C0572 + 0x98, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.limit_break_aura_effects_5C0572 + 0xAD, frame_multiplier);
-				patch_code_byte(ff7_externals.limit_break_aura_effects_5C0572 + 0xB0, 0x9 - frame_multiplier / 2);
-				patch_multiply_code<byte>(ff7_externals.limit_break_aura_effects_5C0572 + 0x13E, frame_multiplier);
-				patch_multiply_code<DWORD>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0x5C, frame_multiplier);
-				patch_code_byte(ff7_externals.enemy_skill_aura_effects_5C06BF + 0x64, 0x7 - frame_multiplier / 2);
-				patch_multiply_code<DWORD>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0x81, frame_multiplier);
-				patch_code_byte(ff7_externals.enemy_skill_aura_effects_5C06BF + 0x89, 0xA - frame_multiplier / 2);
-				patch_multiply_code<byte>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0xA7, frame_multiplier);
-				patch_divide_code<int>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0xB3, frame_multiplier);
-				patch_multiply_code<byte>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0xD6, frame_multiplier);
-				patch_code_byte(ff7_externals.enemy_skill_aura_effects_5C06BF + 0xD9, 0xC - frame_multiplier / 2);
-				patch_multiply_code<byte>(ff7_externals.enemy_skill_aura_effects_5C06BF + 0x182, frame_multiplier);
-				patch_code_byte(ff7_externals.summon_aura_effects_5C0953 + 0x4D, 0xC - frame_multiplier / 2);
-				patch_multiply_code<byte>(ff7_externals.summon_aura_effects_5C0953 + 0x19D, frame_multiplier);
-
-				// Limit break effects
-				patch_multiply_code<byte>(ff7_externals.tifa_limit_2_1_sub_4E48D4 + 0x1FE, frame_multiplier);
-				patch_code_dword(ff7_externals.aerith_limit_2_1_sub_45B0CF + 0xCE, 0x90909090);
-				patch_code_word(ff7_externals.aerith_limit_2_1_sub_45B0CF + 0xD2, 0x9090);
-				patch_multiply_code<byte>(ff7_externals.aerith_limit_2_1_sub_45B0CF + 0xE2, frame_multiplier);
-
-				// Effect60 related
-				patch_multiply_code<WORD>(ff7_externals.battle_sub_425E5F + 0x3A, frame_multiplier);
-
-				patch_multiply_code<WORD>(ff7_externals.battle_sub_5BCF9D + 0x3A, frame_multiplier);
-				patch_code_byte(ff7_externals.battle_sub_5BD050 + 0x1DC, 0x2 - frame_multiplier / 2);
-				patch_code_byte(ff7_externals.battle_sub_5BD050 + 0x203, 0x2 - frame_multiplier / 2);
-
-				patch_multiply_code<WORD>(ff7_externals.battle_sub_5BCD42 + 0x5B, frame_multiplier); 
-				patch_divide_code<WORD>(ff7_externals.battle_sub_5BCD42 + 0x6E, frame_multiplier);
-			}
-			//
-
-			// ########################
-			// Other battle animations
-			// ########################
-			{
-				patch_divide_code<byte>(ff7_externals.battle_fps_menu_multiplier, frame_multiplier);
-
-				// Tifa slots speed patch (bitwise and with 0x7 changed to 0x3)
-				patch_code_byte(ff7_externals.battle_sub_6E3135 + 0x168, 0x3);
-				patch_code_byte(ff7_externals.battle_sub_6E3135 + 0x16B, 0xCA);
-			}
+			battle_camera_hook_init();
+			battle_animations_hook_init();
 		}
 	}
 


### PR DESCRIPTION
Now every summon in 60 fps mode should be running with no camera glitches and minimal animation glitches.
The second commit is the barebone for camera battle controls that Cosmos wanted