### PR TITLE
Implemented analogue camera controls in battle mode

### DIFF
--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -223,9 +223,14 @@ ffmpeg_video_ext = "avi"
 ###########################
 
 #[ANALOGUE CONTROLS]
-# This flag will enable analogue joystick input for controlling the player.
+# This flag will enable analogue joystick input for controlling the player in fields and the camera in battles.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 enable_analogue_controls = false
+
+#[INVERT CAMERA CONTROLS]
+# This flag will enable inverted camera vertical movement when controlling the camera in battles.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+enable_inverted_camera_controls = false
 
 ###############################
 # MUST SET FOR VERSIONS BELOW

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -107,6 +107,7 @@ bool enable_animated_textures;
 long ff7_fps_limiter;
 bool ff7_footsteps;
 bool enable_analogue_controls;
+bool enable_inverted_camera_controls;
 bool enable_steam_achievements;
 bool steam_achievements_debug_mode;
 
@@ -230,6 +231,7 @@ void read_cfg()
 	ff7_fps_limiter = config["ff7_fps_limiter"].value_or(FF7_LIMITER_DEFAULT);
 	ff7_footsteps = config["ff7_footsteps"].value_or(false);
 	enable_analogue_controls = config["enable_analogue_controls"].value_or(false);
+	enable_inverted_camera_controls = config["enable_inverted_camera_controls"].value_or(false);
 	enable_steam_achievements = config["enable_steam_achievements"].value_or(false);
 	steam_achievements_debug_mode = config["steam_achievements_debug_mode"].value_or(false);
 

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -120,6 +120,7 @@ extern bool enable_animated_textures;
 extern long ff7_fps_limiter;
 extern bool ff7_footsteps;
 extern bool enable_analogue_controls;
+extern bool enable_inverted_camera_controls;
 extern bool enable_steam_achievements;
 extern bool steam_achievements_debug_mode;
 

--- a/src/ff7/camera.h
+++ b/src/ff7/camera.h
@@ -1,0 +1,42 @@
+/****************************************************************************/
+//    Copyright (C) 2021 Cosmos                                             //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#pragma once
+
+#include "../ff7.h"
+
+class Camera
+{
+    public:
+        Camera() = default;
+        ~Camera() = default;
+
+        void setRotationSpeed(float rotX, float rotY, float rotZ);
+        void setZoomSpeed(float speed);
+        void reset();
+
+        void controlCamera(camera_vec3* cameraPosition, camera_vec3* cameraFocusPosition);
+    private:
+        struct point3d rotationSpeed = { 0.0, 0.0, 0.0 };
+        struct point3d rotationOffset = { 0.0, 0.0, 0.0 };
+        float zoomSpeed = 0.0f;
+        float zoomOffset = 0.0f;
+        const float minZoomDist = 5000.0f;
+        const float maxZoomDist = 30000.0f;
+        const float minVerticalAngle = 5.0f;
+        const float maxVerticalAngle = 85.0f;
+};
+
+extern Camera camera;

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -6,6 +6,7 @@
 //    Copyright (C) 2020 Chris Rizzitello                                   //
 //    Copyright (C) 2020 John Pritchard                                     //
 //    Copyright (C) 2021 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2021 Cosmos                                             //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //
@@ -221,9 +222,11 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	// #####################
 	// control battle camera
 	// #####################
-	// TODO Cosmos
-	//replace_call_function(ff7_externals.battle_sub_42D992 + 0xFB, ff7_update_battle_camera);
-	//replace_function(ff7_externals.battle_camera_sub_5C22A9, ff7_update_idle_battle_camera);
+	if(enable_analogue_controls)
+	{
+		replace_call_function(ff7_externals.battle_sub_42D992 + 0xFB, ff7_update_battle_camera);
+		replace_function(ff7_externals.battle_camera_sub_5C22A9, ff7_update_idle_battle_camera);
+	}
 
 	//######################
 	// menu rendering fix


### PR DESCRIPTION
I added analogue controls for the battle camera. You can rotate the camera with the controller right stick and zoom-in/ zoom-out with the analogue triggers. Controls are only enabled when no camera animation is being executed.