### PR TITLE
60FPS: Interpolate animation effects about textures and materials (spells, enemy moves, ...)

### DIFF
--- a/src/common_imports.h
+++ b/src/common_imports.h
@@ -116,6 +116,34 @@ typedef void (gfx_field_EC)(struct game_obj *);
  * downright misleading. Thread with caution!
  */
 
+struct color_ui8
+{
+    byte r;
+    byte g;
+    byte b;
+    byte a;
+};
+
+struct bgra_color
+{
+	float b;
+	float g;
+	float r;
+	float a;
+};
+
+struct abgr_color
+{
+	float a;
+	float b;
+	float g;
+	float r;
+};
+
+typedef struct {
+	short x, y, z, res;		// short is a 2 byte signed integer
+} vertex_3s;
+
 struct struc_81
 {
 	uint32_t field_0;
@@ -141,15 +169,15 @@ struct struc_173
 	unsigned char setrenderstate;
 	unsigned char add_offsets;
 	unsigned char field_7;
-	uint32_t color;
+	color_ui8 color;
 	uint32_t field_C;
 	uint32_t field_10;
 	uint32_t x_offset;
 	uint32_t y_offset;
 	uint32_t z_offset;
 	uint32_t z_offset2;
-	uint32_t u_offset;
-	uint32_t v_offset;
+	float u_offset;
+	float v_offset;
 	uint32_t palette_index;
 	struct p_hundred *hundred_data;
 	unsigned char field_34[16];
@@ -167,26 +195,6 @@ struct struc_77
 	struct matrix *matrix_pointer;
 	struct struc_173 struc_173;
 };
-
-struct bgra_color
-{
-	float b;
-	float g;
-	float r;
-	float a;
-};
-
-struct abgr_color
-{
-	float a;
-	float b;
-	float g;
-	float r;
-};
-
-typedef struct {
-	short x, y, z, res;		// short is a 2 byte signed integer
-} vertex_3s;
 
 // Field camera axis
 typedef struct {
@@ -314,7 +322,7 @@ struct struc_186
 	uint32_t field_8;
 	struct point3d vertices[4];
 	struct texcoords texcoords[4];
-	uint32_t colors[4];
+	color_ui8 colors[4];
 	float w[4];
 	struct nvertex *nvertex_pointer;
 	uint32_t palette_index;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -943,6 +943,77 @@ struct effect10_data
     byte field_1B[5];
 };
 
+struct material_anim_ctx
+{
+    uint32_t *materialRSD;
+    uint32_t negateColumnFlags;
+    WORD field_8;
+    short transparency;
+    short field_C;
+    short paletteIdx;
+};
+
+struct palette_extra
+{
+    int x_offset;
+    p_hundred *aux_gfx_ptr;
+    int z_offset_2;
+    int y_offset;
+    int scroll_v;
+    int v_offset;
+    int z_offset;
+    int field_1C;
+    int field_20;
+    int field_24;
+    int field_28;
+};
+
+struct page_spt
+{
+    int field_0;
+    short field_4;
+    short field_6;
+    short uScale;
+    short vScale;
+    short field_C;
+    short palette_something;
+    short field_10;
+    short field_12;
+};
+
+struct tex_page_list
+{
+    WORD *field_0;
+    page_spt *page_spt_ptr;
+};
+
+struct texture_spt
+{
+    int *spt_handle_copy;
+    tex_page_list *pages;
+    byte *spt_handle;
+    int tex_page_count;
+    uint32_t field_10[4];
+    ff7_graphics_object *game_drawable[4];
+};
+
+struct texture_spt_anim_ctx
+{
+    texture_spt *effect_spt;
+    ff7_graphics_object *effectDrawable;
+    color_ui8 color;
+    WORD field_C;
+    WORD field_E;
+};
+
+#pragma pack(push, 1)
+struct rotation_matrix
+{
+    short r3_sub_matrix[3][3];
+    int position[3];
+};
+#pragma pack(pop)
+
 struct battle_text_data
 {
 	short buffer_idx;
@@ -2549,6 +2620,16 @@ struct ff7_externals
 	uint32_t run_summon_phoenix_sub_515127;
 	uint32_t run_phoenix_main_loop_516297;
 	uint32_t battle_update_3d_model_data;
+	uint32_t battle_animate_material_texture;
+	uint32_t battle_animate_texture_spt;
+	rotation_matrix* (*get_global_model_matrix_buffer_66100D)();
+	struc_84* (*get_draw_chain_68F860)(struc_49*, graphics_instance*);
+	p_hundred* (*battle_sub_5D1AAA)(int, ff7_polygon_set*);
+	int (*get_alpha_from_transparency_429343)(int);
+	color_ui8 (*get_stored_color_66101A)();
+	void (*battle_sub_68CF75)(char, struc_173*);
+	void (*create_rot_matrix_from_word_matrix_6617E9)(rotation_matrix*, matrix*);
+	struc_84* (*get_draw_chain_671C71)(ff7_graphics_object*);
 
 	battle_model_state *g_battle_model_state;
 	battle_model_state_small *g_small_battle_model_state;
@@ -2579,6 +2660,8 @@ struct ff7_externals
 	byte* field_battle_byte_BE10B4;
 	short* resting_Y_array_data;
 	WORD* field_odin_frames_AEEC14;
+	palette_extra* palette_extra_data_C06A00;
+	uint32_t** global_game_data_90AAF0;
 
 	// battle dialogue
 	uint32_t battle_sub_42CBF9;
@@ -2586,7 +2669,7 @@ struct ff7_externals
 	uint32_t update_display_text_queue;
 	uint32_t set_battle_text_active;
 	uint32_t battle_sfx_play_effect_430D14;
-	uint32_t battle_sub_66C3BF;
+	int (*battle_sub_66C3BF)();
 	uint32_t battle_sub_43526A;
 	uint32_t battle_sub_5C8931;
 	uint32_t run_enemy_ai_script;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2610,6 +2610,9 @@ struct ff7_externals
 	uint32_t world_animate_single_model;
 	uint32_t run_world_snake_ai_script_7562FF;
 	uint32_t update_world_snake_position_7564CD;
+	uint32_t world_sub_767540;
+	uint32_t world_sub_767641;
+	int (*get_world_encounter_rate)();
 	void (*world_compute_delta_position_753D00)(short* values, short z_value);
 	int (*pop_world_script_stack)();
 

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2546,6 +2546,7 @@ struct ff7_externals
 	uint32_t run_bahamut_zero_main_loop_484A16;
 	uint32_t run_summon_phoenix_sub_515127;
 	uint32_t run_phoenix_main_loop_516297;
+	uint32_t battle_update_3d_model_data;
 
 	battle_model_state *g_battle_model_state;
 	battle_model_state_small *g_small_battle_model_state;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2333,6 +2333,8 @@ struct ff7_externals
 	uint32_t field_update_models_positions;
 	int (*field_update_single_model_position)(short);
 	void (*field_update_model_animation_frame)(short);
+	void (*field_evaluate_encounter_rate_60B2C6)();
+	short *field_player_model_id;
 	uint32_t sub_40B27B;
 	WORD* word_CC0DD4;
 	WORD* word_CC1638;

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -815,6 +815,13 @@ void ff7_battle_move_character_sub_426F58()
 
 void ff7_battle_animations_hook_init()
 {
+    // 3d model animation
+    if(ff7_fps_limiter == FF7_LIMITER_30FPS)
+    {
+        patch_multiply_code<byte>(ff7_externals.battle_update_3d_model_data + 0x13E, battle_frame_multiplier);
+        patch_multiply_code<byte>(ff7_externals.battle_update_3d_model_data + 0x316, battle_frame_multiplier);
+    }
+
     replace_call_function(ff7_externals.battle_sub_42A5EB + 0xB8, ff7_run_animation_script);
     replace_call_function(ff7_externals.battle_sub_42E275 + 0xB2, ff7_run_animation_script);
     replace_call_function(ff7_externals.battle_sub_42E34A + 0x76, ff7_run_animation_script);

--- a/src/ff7/animations.h
+++ b/src/ff7/animations.h
@@ -1,0 +1,90 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 myst6re                                            //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//    Copyright (C) 2020 John Pritchard                                     //
+//    Copyright (C) 2022 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2022 Tang-Tang Zhou                                     //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+class EffectDecorator
+{
+public:
+    virtual void callEffectFunction(uint32_t function) = 0;
+};
+
+class NoEffectDecorator: public EffectDecorator
+{
+public:
+    NoEffectDecorator() = default;
+    void callEffectFunction(uint32_t function) override;
+};
+
+class OneCallEffectDecorator: public EffectDecorator
+{
+private:
+    int frameCounter;
+    int frequency;
+
+public:
+    OneCallEffectDecorator(int frequency): frameCounter(0), frequency(frequency) {};
+    void callEffectFunction(uint32_t function) override;
+};
+
+class PauseEffectDecorator: public EffectDecorator
+{
+private:
+    int frameCounter;
+    int frequency;
+    byte* isBattlePaused;
+
+public:
+    PauseEffectDecorator(int frequency, byte* isBattlePausedExt): frameCounter(0), frequency(frequency), isBattlePaused(isBattlePausedExt) {};
+    void callEffectFunction(uint32_t function) override;
+};
+
+class FixCounterEffectDecorator: public EffectDecorator
+{
+private:
+    int frameCounter;
+    int frequency;
+    uint16_t *effectCounter;
+    bool *isAddFunctionDisabled;
+
+public:
+    FixCounterEffectDecorator(int frequency, uint16_t* effectCounter, bool* isAddFunctionDisabled): frameCounter(0),
+                                                                                                    frequency(frequency),
+                                                                                                    effectCounter(effectCounter),
+                                                                                                    isAddFunctionDisabled(isAddFunctionDisabled) {};
+    void callEffectFunction(uint32_t function) override;
+};
+
+class AuxiliaryEffectHandler
+{
+private:
+    bool isFirstTimeRunning;
+    std::unique_ptr<EffectDecorator> effectDecorator;
+
+public:
+    AuxiliaryEffectHandler();
+
+    inline bool isFirstFrame() {return isFirstTimeRunning;}
+
+    inline void setEffectDecorator(std::unique_ptr<EffectDecorator> effectDecorator) {this->effectDecorator = std::move(effectDecorator);}
+    inline void disableFirstFrame() {this->isFirstTimeRunning = false;}
+    inline void executeEffectFunction(uint32_t effectFunction) {effectDecorator->callEffectFunction(effectFunction);}
+};
+

--- a/src/ff7/field.cpp
+++ b/src/ff7/field.cpp
@@ -421,6 +421,15 @@ void ff7_field_update_model_animation_frame(short model_id)
 	model_event_data.animation_speed = original_animation_speed;
 }
 
+void ff7_field_evaluate_encounter_rate()
+{
+	field_event_data* field_event_data_array = (*ff7_externals.field_event_data_ptr);
+	int original_movement_speed = field_event_data_array[*ff7_externals.field_player_model_id].movement_speed;
+	field_event_data_array[*ff7_externals.field_player_model_id].movement_speed = original_movement_speed / common_frame_multiplier;
+	ff7_externals.field_evaluate_encounter_rate_60B2C6();
+	field_event_data_array[*ff7_externals.field_player_model_id].movement_speed = original_movement_speed;
+}
+
 void ff7_field_hook_init()
 {
 	std::copy(common_externals.execute_opcode_table, &common_externals.execute_opcode_table[0xFF], &old_opcode_table[0]);
@@ -445,6 +454,9 @@ void ff7_field_hook_init()
 		patch_code_dword((uint32_t)&common_externals.execute_opcode_table[CANM2], (DWORD)&opcode_script_partial_animation_wrapper);
 		patch_code_dword((uint32_t)&common_externals.execute_opcode_table[CANIM1], (DWORD)&opcode_script_partial_animation_wrapper);
 		patch_code_dword((uint32_t)&common_externals.execute_opcode_table[CANIM2], (DWORD)&opcode_script_partial_animation_wrapper);
+
+		// Fix encounter rate
+		replace_call_function(ff7_externals.field_update_models_positions + 0x90F, ff7_field_evaluate_encounter_rate);
 	}
 
 	// Background scroll fps fix

--- a/src/ff7/world.cpp
+++ b/src/ff7/world.cpp
@@ -46,6 +46,12 @@ int ff7_pop_world_stack_divide_wrapper()
     return ret / common_frame_multiplier;
 }
 
+int ff7_get_world_encounter_rate()
+{
+    int encounter_rate = ff7_externals.get_world_encounter_rate();
+    return encounter_rate / common_frame_multiplier;
+}
+
 void ff7_world_hook_init()
 {
     // Movement related fix
@@ -62,6 +68,9 @@ void ff7_world_hook_init()
     replace_call_function(ff7_externals.update_world_snake_position_7564CD + 0x26, ff7_world_snake_compute_delta_position);
     replace_call_function(ff7_externals.update_world_snake_position_7564CD + 0x195, ff7_world_snake_compute_delta_position);
     replace_call_function(ff7_externals.update_world_snake_position_7564CD + 0x2B4, ff7_world_snake_compute_delta_position);
+
+    // World Encounter rate fix
+    replace_call_function(ff7_externals.world_sub_767641 + 0x110, ff7_get_world_encounter_rate);
 
     // Others
     replace_call_function(ff7_externals.run_world_event_scripts_system_operations + 0x8DF, ff7_pop_world_stack_multiply_wrapper);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -860,6 +860,9 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.world_animate_all_models = get_relative_call(ff7_externals.world_update_sub_74DB8C, 0x5A1);
 	ff7_externals.world_animate_single_model = get_relative_call(ff7_externals.world_animate_all_models, 0x20);
 	ff7_externals.run_world_snake_ai_script_7562FF = get_relative_call(ff7_externals.world_update_sub_74DB8C, 0x5AB);
+	ff7_externals.world_sub_767540 = get_relative_call(ff7_externals.world_update_sub_74DB8C, 0x5BE);
+	ff7_externals.world_sub_767641 = get_relative_call(ff7_externals.world_sub_767540, 0xCB);
+	ff7_externals.get_world_encounter_rate = (int(*)())get_relative_call(ff7_externals.world_sub_767641, 0x110);
 	ff7_externals.update_world_snake_position_7564CD = get_relative_call(ff7_externals.run_world_snake_ai_script_7562FF, 0x151);
 	ff7_externals.world_compute_delta_position_753D00 = (void(*)(short*, short))get_relative_call(ff7_externals.update_world_snake_position_7564CD, 0x26);
 

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -494,6 +494,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.field_update_models_positions = get_relative_call(ff7_externals.sub_63C17F, 0x5DD);
 	ff7_externals.field_update_single_model_position = (int (*)(int16_t))get_relative_call(ff7_externals.field_update_models_positions, 0x8BC);
 	ff7_externals.field_update_model_animation_frame = (void (*)(int16_t))get_relative_call(ff7_externals.field_update_models_positions, 0x68D);
+	ff7_externals.field_evaluate_encounter_rate_60B2C6 = (void (*)())get_relative_call(ff7_externals.field_update_models_positions, 0x90F);
+	ff7_externals.field_player_model_id = (short*)get_absolute_value(ff7_externals.field_update_models_positions, 0x45D);
 	ff7_externals.sub_40B27B = get_relative_call(ff7_externals.sub_63C17F, 0xEE);
 	ff7_externals.word_CC0DD4 = (WORD*)get_absolute_value(ff7_externals.enter_field, 0x124);
 	ff7_externals.word_CC1638 = (WORD*)get_absolute_value(ff7_externals.sub_40B27B, 0x25);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -649,6 +649,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.add_fn_to_effect10_fn = get_relative_call(ff7_externals.run_animation_script, 0x825);
 	ff7_externals.execute_effect10_fn = get_relative_call(ff7_externals.battle_sub_42D992, 0x4D);
 	uint32_t battle_sub_42B66A = get_relative_call(ff7_externals.run_animation_script, 0x460A);
+	ff7_externals.battle_update_3d_model_data = get_relative_call(ff7_externals.run_animation_script, 0x623);
 
 	ff7_externals.effect100_array_data = (effect100_data*)get_absolute_value(ff7_externals.add_fn_to_effect100_fn, 0x5D);
 	ff7_externals.effect100_array_fn = (uint32_t*)get_absolute_value(ff7_externals.add_fn_to_effect100_fn, 0x48);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -827,6 +827,22 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	uint32_t run_summon_phoenix_main_515101 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x2AB);
 	uint32_t run_summon_phoenix_sub_515127 = get_relative_call(run_summon_phoenix_main_515101, 0x1A);
 	ff7_externals.run_phoenix_main_loop_516297 = get_absolute_value(run_summon_phoenix_sub_515127, 0xB2);
+
+	// Texture/Material animation
+	uint32_t battle_leviathan_sub_5B2F18 = get_absolute_value(ff7_externals.battle_summon_leviathan_loop, 0x50E);
+	ff7_externals.battle_animate_material_texture = get_relative_call(battle_leviathan_sub_5B2F18, 0x19F);
+	ff7_externals.get_global_model_matrix_buffer_66100D = (rotation_matrix*(*)())get_relative_call(ff7_externals.battle_animate_material_texture, 0x5E);
+	ff7_externals.get_draw_chain_68F860 = (struc_84*(*)(struc_49*, graphics_instance*))get_relative_call(ff7_externals.battle_animate_material_texture, 0x85);
+	ff7_externals.battle_sub_5D1AAA = (p_hundred*(*)(int, ff7_polygon_set*))get_relative_call(ff7_externals.battle_animate_material_texture, 0xB3);
+	ff7_externals.get_alpha_from_transparency_429343 = (int(*)(int))get_relative_call(ff7_externals.battle_animate_material_texture, 0xDF);
+	ff7_externals.get_stored_color_66101A = (color_ui8(*)())get_relative_call(ff7_externals.battle_animate_material_texture, 0x110);
+	ff7_externals.battle_sub_68CF75 = (void(*)(char, struc_173*))get_relative_call(ff7_externals.battle_animate_material_texture, 0x1CD);
+	ff7_externals.create_rot_matrix_from_word_matrix_6617E9 = (void(*)(rotation_matrix*, matrix*))get_relative_call(ff7_externals.battle_animate_material_texture, 0x38B);
+	ff7_externals.battle_animate_texture_spt = get_relative_call(ff7_externals.summon_aura_effects_5C0953, 0x16A);
+	ff7_externals.get_draw_chain_671C71 = (struc_84*(*)(ff7_graphics_object*))get_relative_call(ff7_externals.battle_animate_texture_spt, 0x15F);
+	ff7_externals.palette_extra_data_C06A00 = (palette_extra*)get_absolute_value(ff7_externals.battle_animate_material_texture, 0x2FA);
+	ff7_externals.global_game_data_90AAF0 = (uint32_t**)get_absolute_value((uint32_t)ff7_externals.get_global_model_matrix_buffer_66100D, 0x4);
+
 	// --------------------------------
 
 	// battle dialogues
@@ -835,7 +851,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.update_display_text_queue = get_relative_call(ff7_externals.battle_sub_42D808, 0x2B);
 	ff7_externals.set_battle_text_active = get_relative_call(ff7_externals.update_display_text_queue, 0x14A);
 	ff7_externals.battle_sfx_play_effect_430D14 = get_relative_call(ff7_externals.update_display_text_queue, 0x46);
-	ff7_externals.battle_sub_66C3BF = get_relative_call(ff7_externals.update_display_text_queue, 0x139);
+	ff7_externals.battle_sub_66C3BF = (int(*)())get_relative_call(ff7_externals.update_display_text_queue, 0x139);
 	ff7_externals.battle_sub_43526A = get_relative_call(ff7_externals.battle_loop, 0x475);
 	ff7_externals.battle_sub_5C8931 = get_relative_call(ff7_externals.battle_sub_43526A, 0x1F0);
 	ff7_externals.run_enemy_ai_script = get_relative_call(ff7_externals.battle_sub_5C8931, 0xA0);

--- a/src/voice.cpp
+++ b/src/voice.cpp
@@ -554,7 +554,7 @@ void ff7_update_display_text_queue()
 				return;
 			}
 
-			int show_text = ((int (*)())ff7_externals.battle_sub_66C3BF)();
+			int show_text = (ff7_externals.battle_sub_66C3BF)();
 			if (show_text)
 				((void (*)(short))ff7_externals.set_battle_text_active)(text_data_first.buffer_idx);
 
@@ -632,7 +632,7 @@ void ff7_display_battle_action_text()
 		}
 		else
 		{
-			int show_text = ((int (*)())ff7_externals.battle_sub_66C3BF)();
+			int show_text = (ff7_externals.battle_sub_66C3BF)();
 			if(show_text)
 			{
 				byte command_id = ff7_externals.g_battle_model_state[*ff7_externals.g_active_actor_id].commandID;


### PR DESCRIPTION
Most of the spell, enemy moves, summons, and limit breaks effect should be interpolated. However there is a problem with some effect handler functions that calls the function I replaced with a "for" statement (probably particle effects), so, all those particles cannot be identified univocally.

I also fixed the encounter rate as it was too high for both WORLDMAP and FIELD mode. 

I added support for 30FPS battle using the same animation files, but the summons are not working since they do not have the 60FPS animation files. Could fix it in code by checking the actorID, but if in the future summon model will run in 60 FPS there is no need anymore.