### PR TITLE
Camera zoom for controllers without analog triggers and deadzone option

### DIFF
--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -237,6 +237,21 @@ enable_analogue_controls = false
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 enable_inverted_camera_controls = false
 
+#[RIGHT ANALOG STICK DEADZONE]
+# Sets the deadzone for the right analog stick. Values are from 0 to 1.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+right_analog_stick_deadzone = 0.1
+
+#[LEFT ANALOG TRIGGER DEADZONE]
+# Sets the deadzone for the left analog trigger. Values are from 0 to 1.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+left_analog_trigger_deadzone = 0.1
+
+#[RIGHT ANALOG TRIGGER DEADZONE]
+# Sets the deadzone for the right analog trigger. Values are from 0 to 1.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+right_analog_trigger_deadzone = 0.1
+
 ###############################
 # MUST SET FOR VERSIONS BELOW
 # FF7 2012   FF7 STEAM

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -110,6 +110,9 @@ long ff7_fps_limiter;
 bool ff7_footsteps;
 bool enable_analogue_controls;
 bool enable_inverted_camera_controls;
+double right_analog_stick_deadzone;
+double left_analog_trigger_deadzone;
+double right_analog_trigger_deadzone;
 bool enable_steam_achievements;
 bool steam_achievements_debug_mode;
 
@@ -236,6 +239,9 @@ void read_cfg()
 	ff7_footsteps = config["ff7_footsteps"].value_or(false);
 	enable_analogue_controls = config["enable_analogue_controls"].value_or(false);
 	enable_inverted_camera_controls = config["enable_inverted_camera_controls"].value_or(false);
+	right_analog_stick_deadzone = config["right_analog_stick_deadzone"].value_or(0.1);
+	left_analog_trigger_deadzone = config["left_analog_trigger_deadzone"].value_or(0.1);
+	right_analog_trigger_deadzone = config["right_analog_trigger_deadzone"].value_or(0.1);
 	enable_steam_achievements = config["enable_steam_achievements"].value_or(false);
 	steam_achievements_debug_mode = config["steam_achievements_debug_mode"].value_or(false);
 

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -123,6 +123,9 @@ extern long ff7_fps_limiter;
 extern bool ff7_footsteps;
 extern bool enable_analogue_controls;
 extern bool enable_inverted_camera_controls;
+extern double right_analog_stick_deadzone;
+extern double left_analog_trigger_deadzone;
+extern double right_analog_trigger_deadzone;
 extern bool enable_steam_achievements;
 extern bool steam_achievements_debug_mode;
 

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -141,6 +141,7 @@ void ff7_use_analogue_controls()
 	float verticalRotSpeed = 0.0f;
 	float horizontalRotSpeed = 0.0f;
 	float zoomSpeed = 0.0f;
+	float zoomSpeedMax = 1000.0f;
 
 	float invertedCameraScale = 1.0;
 	if(enable_inverted_camera_controls) invertedCameraScale = -1.0;
@@ -168,15 +169,15 @@ void ff7_use_analogue_controls()
 			else if(gamepad.leftStickY < -0.5f && !(gamepad.leftStickX < -0.5f || gamepad.leftStickX > 0.5f))
 				inputDir = {0.0f, -1.0f, 0.0f};
 
-			if(std::abs(gamepad.rightStickY) > 0.1f)
+			if(std::abs(gamepad.rightStickY) > right_analog_stick_deadzone)
 				verticalRotSpeed = invertedCameraScale * -5.0f * gamepad.rightStickY;
-			if(std::abs(gamepad.rightStickX) > 0.1)
+			if(std::abs(gamepad.rightStickX) > right_analog_stick_deadzone)
 				horizontalRotSpeed = 5.0f * gamepad.rightStickX;
 
-			if(gamepad.rightTrigger > -0.9)
-				zoomSpeed += 500.0f * (1.0 + gamepad.rightTrigger);
-			if(gamepad.leftTrigger > -0.9)
-				zoomSpeed -= 500.0f * (1.0 + gamepad.leftTrigger);
+			if(gamepad.rightTrigger > -1.0f + right_analog_trigger_deadzone)
+				zoomSpeed += zoomSpeedMax * (0.5 + 0.5f * gamepad.rightTrigger);
+			if(gamepad.leftTrigger > -1.0 + left_analog_trigger_deadzone)
+				zoomSpeed -= zoomSpeedMax * (0.5f + 0.5f * gamepad.leftTrigger);
 		}
 	}
 	else
@@ -206,16 +207,23 @@ void ff7_use_analogue_controls()
 				!(joystick.GetState()->lX < joystick.GetDeadZone(-0.5f) || joystick.GetState()->lX > joystick.GetDeadZone(0.5f)))
 				inputDir = {0.0f, -1.0f, 0.0f};
 
-			if(std::abs(joystick.GetState()->lRz) > joystick.GetDeadZone(0.1f))
+			if(std::abs(joystick.GetState()->lRz) > joystick.GetDeadZone(right_analog_stick_deadzone))
 				verticalRotSpeed = invertedCameraScale * 5.0f * static_cast<float>(joystick.GetState()->lRz) / static_cast<float>(SHRT_MAX);
-			if(std::abs(joystick.GetState()->lZ) > joystick.GetDeadZone(0.1f))
+			if(std::abs(joystick.GetState()->lZ) > joystick.GetDeadZone(right_analog_stick_deadzone))
 				horizontalRotSpeed = 5.0f * static_cast<float>(joystick.GetState()->lZ) / static_cast<float>(SHRT_MAX);
 
-
-			if(joystick.GetState()->lRy > -static_cast<float>(SHRT_MAX) + joystick.GetDeadZone(0.1f))
-				zoomSpeed += 500.0f * (1.0 + static_cast<float>(joystick.GetState()->lRy) / static_cast<float>(SHRT_MAX)) ;
-			if(joystick.GetState()->lRx > -static_cast<float>(SHRT_MAX) + joystick.GetDeadZone(0.1f))
-				zoomSpeed -= 500.0f * (1.0 + static_cast<float>(joystick.GetState()->lRx) / static_cast<float>(SHRT_MAX)) ;
+			if(joystick.HasAnalogTriggers())
+			{
+				if(joystick.GetState()->lRy > -static_cast<float>(SHRT_MAX) + joystick.GetDeadZone(right_analog_trigger_deadzone))
+					zoomSpeed += zoomSpeedMax * (0.5f + 0.5f * static_cast<float>(joystick.GetState()->lRy) / static_cast<float>(SHRT_MAX));
+				if(joystick.GetState()->lRx > -static_cast<float>(SHRT_MAX) + joystick.GetDeadZone(left_analog_trigger_deadzone))
+					zoomSpeed -= zoomSpeedMax * (0.5f + 0.5f * static_cast<float>(joystick.GetState()->lRx) / static_cast<float>(SHRT_MAX));
+			}
+			else
+			{
+				if(joystick.GetState()->rgbButtons[7] & 0x80) zoomSpeed += zoomSpeedMax;
+				if(joystick.GetState()->rgbButtons[6] & 0x80) zoomSpeed -= zoomSpeedMax;
+			}
 		}
 	}
 

--- a/src/joystick.cpp
+++ b/src/joystick.cpp
@@ -117,6 +117,12 @@ bool Joystick::CheckConnection()
 
     gameController = gameControllers.at(0);
 
+    // Get controller capabilities
+    caps.dwSize = sizeof(DIDEVCAPS);
+
+    if (FAILED(gameController->GetCapabilities(&caps)))
+      return false;
+
     if (trace_all || trace_gamepad)
     {
       // get game controller name
@@ -177,6 +183,11 @@ bool Joystick::Refresh()
     return false;
 
   return true;
+}
+
+bool Joystick::HasAnalogTriggers()
+{
+  return caps.dwAxes >=6;
 }
 
 void Joystick::Clean()

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -33,6 +33,7 @@ class Joystick
 private:
   LPDIRECTINPUT8 dev = nullptr;                   // dinput interface
   LPDIRECTINPUTDEVICE8 gameController = nullptr;  // the actual joystick device
+  DIDEVCAPS caps;                                 // the device capabilities
   DIJOYSTATE2 currentState;			                  // the state of the joystick in the current frame
 
   BOOL enumerateGameControllers(LPCDIDEVICEINSTANCE devInst);
@@ -47,6 +48,7 @@ public:
   LPDIJOYSTATE2 GetState();
   bool CheckConnection();
   bool Refresh();
+  bool HasAnalogTriggers();
   void Clean();
 
   LONG GetDeadZone(float percent);


### PR DESCRIPTION
Added camera zoom support for controllers without analog triggers as requested by Satsuki.
Also added analog deadzone options for the right stick and analog triggers.