### PR TITLE
60FPS: Fix FIELD bugs and softlocks

### DIFF
--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -192,6 +192,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		{
 			battle_frame_multiplier = (ff7_fps_limiter == FF7_LIMITER_30FPS) ? 2 : 4;
 
+			// TODO: Fix menu battle FPS in another way because this introduce a softlock in Bizzarro Sephiroth battle
 			patch_divide_code<byte>(ff7_externals.battle_fps_menu_multiplier, battle_frame_multiplier);
 
 			ff7_battle_camera_hook_init();

--- a/src/movies.cpp
+++ b/src/movies.cpp
@@ -61,16 +61,6 @@ int16_t script_OFST_get_speed(int16_t bank, int16_t address)
 	return ret;
 }
 
-int16_t script_ASPED_get_speed(int16_t bank, int16_t address)
-{
-	int16_t ret = ff7_externals.get_bank_value(bank, address);
-
-	if (is_overlapping_movie_playing() && ff7_fps_limiter == FF7_LIMITER_60FPS)
-		ret /= common_frame_multiplier;
-
-	return ret;
-}
-
 int script_WAIT()
 {
 	int result = 0;
@@ -484,7 +474,6 @@ void movie_init()
 		patch_code_dword((uint32_t)&common_externals.execute_opcode_table[0x27], (DWORD)&script_BGMOVIE);
 
 		patch_code_dword((uint32_t)&common_externals.execute_opcode_table[0x24], (DWORD)&script_WAIT);
-		replace_call_function(common_externals.execute_opcode_table[0xBD] + 0x1E, script_ASPED_get_speed);
 		replace_call_function(common_externals.execute_opcode_table[0xC3] + 0x46, script_OFST_get_speed);
 
 		replace_function(ff7_externals.sub_611BAE, ff7_compare_ifsw);


### PR DESCRIPTION
- Fix partial animation (opcode CANM1, CANM2, CANIM1, CANIM2) wrong final frame value
- Fix scripted movement for field models by interpolating the position without checking for collision
- Fix FMVs animation for 60 FPS by removing script_ASPED modification because the problem was actually in non-interpolated animations