### PR TITLE
recalcInternals fix

### DIFF
--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -35,12 +35,13 @@ window_size_y = 0
 
 #[INTERNAL RESOLUTION SCALE]
 # The scale is in multiples of 640x480
-# The scale factor is used to render internally at a larger size then the display, this will then be downscaled to the games current resolution
+# The scale factor is used to multiply the internally used resolution to a given size before it is scaled to the final screen or window resolution.
 # This is required to avoid visual glitches that may happen when the game is not rendered in a 4:3 aspect ratio.
-# This is optional for native 4:3 resolutions, but it will enhance visual quality ( like Nvidia DSR ).
-# Default = 2
+# This is optional for native 4:3 resolutions, but it can enhance visual quality at values higher than the current screen or window resolution ( like Nvidia DSR ).
+# A setting of 0 will attempt to find a scale factor that most closely matches the current screen or window resolution.
+# Default = 0
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
-internal_resolution_scale = 2
+internal_resolution_scale = 0
 
 #[PRESERVE ASPECT]
 # Preserve original game aspect ratio of (4:3) by adding black bars on the left and right side (if needed)

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -203,7 +203,7 @@ void read_cfg()
 	show_version = config["show_version"].value_or(true);
 	window_size_x = config["window_size_x"].value_or(0);
 	window_size_y = config["window_size_y"].value_or(0);
-	internal_resolution_scale = config["internal_resolution_scale"].value_or(2);
+	internal_resolution_scale = config["internal_resolution_scale"].value_or(0);
 	preserve_aspect = config["preserve_aspect"].value_or(true);
 	fullscreen = config["fullscreen"].value_or(false);
 	refresh_rate = config["refresh_rate"].value_or(0);

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -445,8 +445,6 @@ bool Renderer::doesItFitInMemory(size_t size)
 
 void Renderer::recalcInternals()
 {
-    bool is16by9 = false;
-
     viewWidth = window_size_x;
     viewHeight = window_size_y;
 
@@ -469,26 +467,26 @@ void Renderer::recalcInternals()
         }
     }
 
-    if ((viewWidth % game_width) > 0 || (viewHeight % game_height) > 0)
+	// If internal_resolution_scale from settings is less than one, calculate the closest fit for the output resolution, otherwise use the value directly
+    if (internal_resolution_scale < 1)
     {
         long scaleW = ::round(viewWidth / (float)game_width);
         long scaleH = ::round(viewHeight / (float)game_height);
 
         if (scaleH > scaleW) scaleW = scaleH;
-        if (scaleW > internal_resolution_scale) internal_resolution_scale = scaleW + 1;
-
-        is16by9 = true;
+        if (scaleW > internal_resolution_scale) internal_resolution_scale = scaleW;
+		if (internal_resolution_scale < 1) internal_resolution_scale = 1;
     }
 
-    // In order to prevent weird glitches while rendering we need to use the closest resolution to native's game one
-    framebufferWidth = is16by9 ? game_width * internal_resolution_scale : viewWidth * internal_resolution_scale;
-    framebufferHeight = is16by9 ? game_height * internal_resolution_scale : viewHeight * internal_resolution_scale;
+    // Use the set or calculated scaling factor to determine the width and height of the framebuffer according to the original resolution
+    framebufferWidth = game_width * internal_resolution_scale;
+    framebufferHeight = game_height * internal_resolution_scale;
 
     framebufferVertexWidth = (viewWidth * game_width) / window_size_x;
     framebufferVertexOffsetX = (game_width - framebufferVertexWidth) / 2;
 
     // Let the user know about chosen resolutions
-    ffnx_info("Original resolution %ix%i, New resolution %ix%i, Internal resolution %ix%i\n", game_width, game_height, window_size_x, window_size_y, framebufferWidth, framebufferHeight);
+    ffnx_info("Original resolution %ix%i, Scaling factor %i, Internal resolution %ix%i, Output resolution %ix%i\n", game_width, game_height, internal_resolution_scale, framebufferWidth, framebufferHeight, window_size_x, window_size_y);
 }
 
 void Renderer::prepareFramebuffer()


### PR DESCRIPTION
This is intended to fix an issue with inconsistent scaling results with certain resolution combinations.  In addition, it should make the internal resolution scaling from the original game resolution more consistent across the board.

This will require that the default value of internal_resolution_scale in the FFNx.toml be changed to 0 or less, which will make the default behavior of this function attempt to find the closest fitting internal resolution to the desired output resolution.