### PR TITLE
60FPS: Fix split and join opcode movement and rotation

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2354,7 +2354,8 @@ struct ff7_externals
 	uint32_t opcode_fmusc;
 	uint32_t opcode_cmusc;
 	uint32_t opcode_canm1_canm2;
-	uint32_t field_opcode_08_sub_61D4B9;
+	uint32_t field_opcode_08_sub_61D0D4;
+	void (*field_opcode_08_09_set_rotation_61DB2C)(short, byte, byte);
 	uint32_t field_opcode_AA_2A_sub_616476;
 	uint32_t field_music_helper;
 	uint32_t field_music_helper_sound_op_call;

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -446,8 +446,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.opcode_canm1_canm2 = common_externals.execute_opcode_table[0xB1];
 	ff7_externals.opcode_wmode = common_externals.execute_opcode_table[0x52];
 
-	uint32_t field_opcode_08_sub_61D0D4 = get_relative_call(common_externals.execute_opcode_table[0x08], 0x5A);
-	ff7_externals.field_opcode_08_sub_61D4B9 = get_relative_call(field_opcode_08_sub_61D0D4, 0x283);
+	ff7_externals.field_opcode_08_sub_61D0D4 = get_relative_call(common_externals.execute_opcode_table[0x08], 0x5A);
+	ff7_externals.field_opcode_08_09_set_rotation_61DB2C = (void(*)(short, byte, byte))get_relative_call(ff7_externals.field_opcode_08_sub_61D0D4, 0x196);
 	ff7_externals.field_opcode_AA_2A_sub_616476 = get_relative_call(common_externals.execute_opcode_table[0xAA], 0x26);
 
 	ff7_externals.field_event_data_ptr = (field_event_data**)get_absolute_value(ff7_externals.opcode_canm1_canm2, 0xC1);


### PR DESCRIPTION
This makes the movement of characters during split and join opcode like the OG 30 FPS, which should avoid softlocks related to this.
It also fixes a bug that made the movement during split and join even slower.