### PR TITLE
60 FPS and Voice updates

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2545,7 +2545,8 @@ struct ff7_externals
 	uint32_t battle_sub_42E275;
 	uint32_t battle_sub_42E34A;
 	uint32_t battle_sub_5BD5E9;
-	uint32_t battle_sub_5C1D9A;
+	uint32_t run_summon_animations_script_5C1B81;
+	uint32_t run_summon_animations_script_sub_5C1D9A;
 	uint32_t run_animation_script;
 	uint32_t add_fn_to_effect100_fn;
 	uint32_t execute_effect100_fn;
@@ -2616,6 +2617,8 @@ struct ff7_externals
 	uint32_t run_odin_gunge_camera_4A0F52;
 	uint32_t run_summon_odin_steel_sub_4A9908;
 	uint32_t run_summon_kotr_sub_476857;
+	uint32_t run_summon_kotr_main_loop_478031;
+	std::array<uint32_t, 13> run_summon_kotr_knight_script;
 	void(*add_kotr_camera_fn_to_effect100_fn_476AAB)(DWORD, DWORD, WORD);
 	uint32_t run_kotr_camera_476AFB;
 	uint32_t run_bahamut_zero_main_loop_484A16;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2204,7 +2204,7 @@ struct ff7_externals
 	uint32_t battle_sub_42D992;
 	uint32_t battle_sub_42DAE5;
 	uint32_t battle_sub_427C22;
-	uint32_t battle_sub_6CE8B3;
+	uint32_t battle_menu_update_6CE8B3;
 	uint32_t battle_sub_6DB0EE;
 	char* is_battle_paused;
 	std::span<uint32_t> battle_menu_state_fn_table;
@@ -2511,7 +2511,9 @@ struct ff7_externals
 	uint32_t battle_camera_focal_sub_5C5714;
 	uint32_t battle_sub_430DD0;
 	uint32_t battle_sub_429D8A;
-	uint32_t battle_sub_6E3135;
+	uint32_t display_battle_menu_6D797C;
+	uint32_t display_cait_sith_slots_handler_6E2170;
+	uint32_t display_tifa_slots_handler_6E3135;
 	uint32_t update_battle_camera_sub_5C20CE;
 	uint32_t set_battle_camera_sub_5C22BD;
 	uint32_t battle_camera_sub_5C22A9;
@@ -2665,6 +2667,13 @@ struct ff7_externals
 	uint32_t** global_game_data_90AAF0;
 	std::span<uint32_t> limit_break_effects_fn_table;
 	std::span<uint32_t> enemy_atk_effects_fn_table;
+
+	// battle menu
+	uint32_t battle_set_do_render_menu;
+	int *g_do_render_menu;
+	uint32_t battle_menu_update_call;
+	int *battle_menu_animation_idx;
+	uint32_t set_battle_speed_4385CC;
 
 	// battle dialogue
 	uint32_t battle_sub_42CBF9;

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -1295,6 +1295,26 @@ void ff7_battle_sub_6CE81E()
     }
 }
 
+void ff7_update_battle_menu()
+{
+	((void(*)())ff7_externals.battle_menu_update_6CE8B3)();
+	if(*ff7_externals.g_do_render_menu)
+		(*ff7_externals.battle_menu_animation_idx)++;
+}
+
+void ff7_display_tifa_slots_handler()
+{
+	if(*ff7_externals.g_do_render_menu)
+		((void(*)())ff7_externals.display_tifa_slots_handler_6E3135)();
+}
+
+void ff7_display_cait_sith_slots_handler()
+{
+	if(*ff7_externals.g_do_render_menu)
+		((void(*)())ff7_externals.display_cait_sith_slots_handler_6E2170)();
+}
+
+
 void ff7_battle_animations_hook_init()
 {
     // 3d model animation
@@ -1440,8 +1460,8 @@ void ff7_battle_animations_hook_init()
     patch_divide_code<WORD>(ff7_externals.battle_sub_5BCD42 + 0x6E, battle_frame_multiplier);
 
     // Tifa slots speed patch (bitwise and with 0x7 changed to 0x3)
-    patch_code_byte(ff7_externals.battle_sub_6E3135 + 0x168, 0x3);
-    patch_code_byte(ff7_externals.battle_sub_6E3135 + 0x16B, 0xCA);
+    patch_code_byte(ff7_externals.display_tifa_slots_handler_6E3135 + 0x168, 0x3);
+    patch_code_byte(ff7_externals.display_tifa_slots_handler_6E3135 + 0x16B, 0xCA);
 
     // Texture material animation
     replace_function(ff7_externals.battle_animate_material_texture, ff7_battle_animate_material_texture);
@@ -1449,4 +1469,14 @@ void ff7_battle_animations_hook_init()
 
     // Toggle variable related to gun effect
     replace_call_function(ff7_externals.battle_sub_42D808 + 0x117, ff7_battle_sub_6CE81E);
+
+    if(ff7_fps_limiter == FF7_LIMITER_60FPS)
+    {
+        // Fix battle speed and menu for 60 FPS only
+        patch_divide_code<int>(ff7_externals.set_battle_speed_4385CC + 0x2E, battle_frame_multiplier / 2);
+        replace_call_function(ff7_externals.battle_menu_update_call, ff7_update_battle_menu);
+        replace_call_function(ff7_externals.display_battle_menu_6D797C + 0x1BB, ff7_display_cait_sith_slots_handler);
+        replace_call_function(ff7_externals.display_battle_menu_6D797C + 0x1C2, ff7_display_tifa_slots_handler);
+        memset_code(ff7_externals.battle_menu_update_6CE8B3 + 0x148, 0x90, 3);
+    }
 }

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -25,7 +25,6 @@
 void magic_thread_start(void (*func)());
 void ff7_load_battle_stage(int param_1, int battle_location_id, int **param_3);
 void ff7_battle_sub_5C7F94(int param_1, int param_2);
-
 void ff7_display_battle_action_text_sub_6D71FA(short command_id, short action_id);
 
 // menu

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -641,8 +641,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	uint32_t battle_sub_5B9EC2 = get_relative_call(battle_sub_42F21F, 0x38);
 	ff7_externals.battle_sub_5BD5E9 = get_relative_call(battle_sub_5B9EC2, 0x41);
 	uint32_t battle_sub_42DE61 = get_relative_call(ff7_externals.battle_sub_42D992, 0x9F);
-	uint32_t battle_sub_5C1B81 = get_absolute_value(battle_sub_42DE61, 0x17E);
-	ff7_externals.battle_sub_5C1D9A = get_relative_call(battle_sub_5C1B81, 0xA4);
+	ff7_externals.run_summon_animations_script_5C1B81 = get_absolute_value(battle_sub_42DE61, 0x17E);
+	ff7_externals.run_summon_animations_script_sub_5C1D9A = get_relative_call(ff7_externals.run_summon_animations_script_5C1B81, 0xA4);
 	ff7_externals.run_animation_script = get_relative_call(ff7_externals.battle_sub_42A5EB, 0xB8);
 	ff7_externals.add_fn_to_effect100_fn = get_relative_call(ff7_externals.run_animation_script, 0x48C2);
 	ff7_externals.execute_effect100_fn = get_relative_call(ff7_externals.battle_sub_42D992, 0x12E);
@@ -729,9 +729,9 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	// Character fade in/out
 	ff7_externals.vincent_limit_fade_effect_sub_5D4240 = ff7_externals.limit_break_effects_fn_table[56];
 	ff7_externals.battle_sub_5BD96D = get_absolute_value(ff7_externals.vincent_limit_fade_effect_sub_5D4240, 0x27);
-	ff7_externals.battle_sub_5C1C8F = get_absolute_value(battle_sub_5C1B81, 0x3F);
+	ff7_externals.battle_sub_5C1C8F = get_absolute_value(ff7_externals.run_summon_animations_script_5C1B81, 0x3F);
 	uint32_t handle_fade_character_42C31C = get_relative_call(ff7_externals.battle_sub_5C1C8F, 0xEC);
-	ff7_externals.battle_sub_5C18BC = get_absolute_value(battle_sub_5C1B81, 0x30);
+	ff7_externals.battle_sub_5C18BC = get_absolute_value(ff7_externals.run_summon_animations_script_5C1B81, 0x30);
 	ff7_externals.battle_sub_42A72D = get_relative_call(ff7_externals.battle_sub_429AC0, 0xD0);
 
 	// resting positions and rotations
@@ -807,6 +807,20 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.field_odin_frames_AEEC14 = (WORD*)get_absolute_value(ff7_externals.run_summon_odin_steel_sub_4A9908, 0x316);
 	uint32_t run_summon_kotr_main_476842 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x43A);
 	ff7_externals.run_summon_kotr_sub_476857 = get_relative_call(run_summon_kotr_main_476842, 0xB);
+	ff7_externals.run_summon_kotr_main_loop_478031 = get_absolute_value(ff7_externals.run_summon_kotr_sub_476857, 0x1AC);
+	ff7_externals.run_summon_kotr_knight_script[0] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x2D3);
+	ff7_externals.run_summon_kotr_knight_script[1] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x341);
+	ff7_externals.run_summon_kotr_knight_script[2] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x3EA);
+	ff7_externals.run_summon_kotr_knight_script[3] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x475);
+	ff7_externals.run_summon_kotr_knight_script[4] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x532);
+	ff7_externals.run_summon_kotr_knight_script[5] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x5BA);
+	ff7_externals.run_summon_kotr_knight_script[6] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x666);
+	ff7_externals.run_summon_kotr_knight_script[7] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x6F3);
+	ff7_externals.run_summon_kotr_knight_script[8] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x79D);
+	ff7_externals.run_summon_kotr_knight_script[9] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x869);
+	ff7_externals.run_summon_kotr_knight_script[10] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x934);
+	ff7_externals.run_summon_kotr_knight_script[11] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0x9CF);
+	ff7_externals.run_summon_kotr_knight_script[12] = get_absolute_value(ff7_externals.run_summon_kotr_main_loop_478031, 0xAB8);
 	ff7_externals.add_kotr_camera_fn_to_effect100_fn_476AAB = (void(*)(DWORD, DWORD, WORD))get_relative_call(ff7_externals.run_summon_kotr_sub_476857, 0x1C6);
 	ff7_externals.run_kotr_camera_476AFB = get_relative_call((uint32_t)ff7_externals.add_kotr_camera_fn_to_effect100_fn_476AAB, 0xA);
 	uint32_t run_summon_bahamut_zero_main_4835C1 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x399);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -161,9 +161,9 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_fight_end = get_relative_call(ff7_externals.battle_sub_42D992, 0xB7);
 	ff7_externals.battle_fanfare_music = get_relative_call(ff7_externals.battle_fight_end, 0x25);
 	ff7_externals.battle_sub_427C22 = get_relative_call(ff7_externals.battle_sub_42DAE5, 0xF);
-	ff7_externals.battle_sub_6CE8B3 = get_relative_call(battle_main_loop, 0x368);
-	ff7_externals.battle_sub_6DB0EE = get_relative_call(ff7_externals.battle_sub_6CE8B3, 0xD9);
-	ff7_externals.is_battle_paused = (char*)get_absolute_value(ff7_externals.battle_sub_6CE8B3, 0xC3);
+	ff7_externals.battle_menu_update_6CE8B3 = get_relative_call(battle_main_loop, 0x368);
+	ff7_externals.battle_sub_6DB0EE = get_relative_call(ff7_externals.battle_menu_update_6CE8B3, 0xD9);
+	ff7_externals.is_battle_paused = (char*)get_absolute_value(ff7_externals.battle_menu_update_6CE8B3, 0xC3);
 	ff7_externals.battle_actor_data = (battle_actor_data*)get_absolute_value(ff7_externals.battle_sub_6DB0EE, 0x276);
 	ff7_externals.battle_menu_state_fn_table = std::span((uint32_t*)get_absolute_value(ff7_externals.battle_sub_6DB0EE, 0x1B4), 64);
 	ff7_externals.magic_effects_fn_table = std::span((uint32_t*)get_absolute_value(ff7_externals.battle_sub_427C22, 0xBF), 54);
@@ -617,10 +617,6 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 
 	ff7_externals.battle_sub_430DD0 = get_relative_call(ff7_externals.battle_loop, 0x99E);
 	ff7_externals.battle_sub_429D8A = get_absolute_value(ff7_externals.battle_loop, 0x59);
-	uint32_t battle_sub_6D83C8 = get_relative_call(ff7_externals.battle_sub_6CE8B3, 0x77);
-	uint32_t battle_sub_6D82EA = get_relative_call(battle_sub_6D83C8, 0xE0);
-	uint32_t battle_sub_6D797C = get_relative_call(battle_sub_6D82EA, 0x59);
-	ff7_externals.battle_sub_6E3135 = get_relative_call(battle_sub_6D797C, 0x1C2);
 	ff7_externals.update_battle_camera_sub_5C20CE = get_relative_call(ff7_externals.battle_sub_42D992, 0xFB);
 	ff7_externals.set_battle_camera_sub_5C22BD = get_relative_call(ff7_externals.update_battle_camera_sub_5C20CE, 0x5A);
 	ff7_externals.battle_camera_sub_5C22A9 = get_relative_call(ff7_externals.update_battle_camera_sub_5C20CE, 0x97);
@@ -841,6 +837,18 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.get_draw_chain_671C71 = (struc_84*(*)(ff7_graphics_object*))get_relative_call(ff7_externals.battle_animate_texture_spt, 0x15F);
 	ff7_externals.palette_extra_data_C06A00 = (palette_extra*)get_absolute_value(ff7_externals.battle_animate_material_texture, 0x2FA);
 	ff7_externals.global_game_data_90AAF0 = (uint32_t**)get_absolute_value((uint32_t)ff7_externals.get_global_model_matrix_buffer_66100D, 0x4);
+
+	// Battle menu
+	ff7_externals.battle_menu_update_call = battle_main_loop + 0x368;
+	uint32_t battle_sub_6D83C8 = get_relative_call(ff7_externals.battle_menu_update_6CE8B3, 0x77);
+	uint32_t battle_sub_6D82EA = get_relative_call(battle_sub_6D83C8, 0xE0);
+	ff7_externals.display_battle_menu_6D797C = get_relative_call(battle_sub_6D82EA, 0x59);
+	ff7_externals.display_cait_sith_slots_handler_6E2170 = get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1BB);
+	ff7_externals.display_tifa_slots_handler_6E3135 = get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1C2);
+	ff7_externals.battle_set_do_render_menu = get_relative_call(battle_main_loop, 0x32A);
+	ff7_externals.g_do_render_menu = (int*)get_absolute_value(ff7_externals.battle_set_do_render_menu, 0x7);
+	ff7_externals.battle_menu_animation_idx = (int*)get_absolute_value(ff7_externals.battle_menu_update_6CE8B3, 0x144);
+	ff7_externals.set_battle_speed_4385CC = get_relative_call(ff7_externals.battle_sub_437DB0, 0x17C);
 
 	ff7_externals.world_update_sub_74DB8C = get_relative_call(worldmap_main_loop, 0x114);
 	ff7_externals.world_init_variables_74E1E9 = get_relative_call(ff7_externals.world_update_sub_74DB8C, 0x108);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -192,8 +192,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		{
 			battle_frame_multiplier = (ff7_fps_limiter == FF7_LIMITER_30FPS) ? 2 : 4;
 
-			// TODO: Fix menu battle FPS in another way because this introduce a softlock in Bizzarro Sephiroth battle
-			patch_divide_code<byte>(ff7_externals.battle_fps_menu_multiplier, battle_frame_multiplier);
+			patch_divide_code<byte>(ff7_externals.battle_fps_menu_multiplier, 2); // Works perfectly only in 30 FPS
 
 			ff7_battle_camera_hook_init();
 			ff7_battle_animations_hook_init();
@@ -228,7 +227,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	// #####################
 	// auto attack toggle
 	// #####################
-	replace_call_function(ff7_externals.battle_sub_6CE8B3 + 0xD9, ff7_battle_menu_sub_6DB0EE);
+	replace_call_function(ff7_externals.battle_menu_update_6CE8B3 + 0xD9, ff7_battle_menu_sub_6DB0EE);
 	replace_call_function(ff7_externals.handle_actor_ready + 0x187, ff7_set_battle_menu_state_data_at_full_atb);
 
 	// #####################

--- a/src/voice.cpp
+++ b/src/voice.cpp
@@ -157,18 +157,6 @@ bool play_battle_action_voice(byte char_id, byte command_id, short action_id)
 	return nxAudioEngine.playVoice(name, 0, voice_volume);
 }
 
-bool play_battle_action_support_voice(byte receiving_char_id, byte talking_char_id, byte command_id, short action_id)
-{
-	char name[MAX_PATH];
-
-	sprintf(name, "_battle/char_%02X_to_%02X/cmd_%02X_%04X", talking_char_id, receiving_char_id, command_id, action_id);
-
-	if(!nxAudioEngine.canPlayVoice(name))
-		sprintf(name, "_battle/char_%02X_to_%02X/cmd_%02X", talking_char_id, receiving_char_id, command_id);
-
-	return nxAudioEngine.playVoice(name, 0, voice_volume);
-}
-
 void play_option(char* field_name, byte window_id, byte dialog_id, byte option_count)
 {
 	char name[MAX_PATH];
@@ -612,18 +600,11 @@ void ff7_display_battle_action_text()
 				byte command_id = ff7_externals.g_battle_model_state[actor_id].commandID;
 				uint16_t action_id = ff7_externals.g_small_battle_model_state[actor_id].actionIdx;
 
-				int actor_playing_voice = getRandomInt(0, 2);
 				bool hasStarted = false;
-				if (actor_playing_voice == actor_id)
-					hasStarted = play_battle_action_voice(char_id, command_id, action_id);
-				else
-					hasStarted = play_battle_action_support_voice(char_id, ff7_externals.battle_context->actor_vars[actor_playing_voice].index,
-																  command_id, action_id);
+				hasStarted = play_battle_action_voice(char_id, command_id, action_id);
 
-				if(hasStarted){
+				if(hasStarted)
 					effect_data.field_6 = VOICE_STARTED;
-					begin_voice();
-				}
 				else
 					effect_data.field_6 = VOICE_NOT_STARTED;
 			}
@@ -635,8 +616,6 @@ void ff7_display_battle_action_text()
 
 		if(effect_data.n_frames == 0)
 		{
-			if(effect_data.field_6 = VOICE_STARTED)
-				end_voice();
 			effect_data.field_0 = 0xFFFF;
 		}
 		else


### PR DESCRIPTION
60 FPS: Fix a softlock in battle and add support for summons interpolated animations (now it is possible to use interpolated summon animations since before the code related to that was running at 15 FPS).

Voice: remove for now implementation of support character voice since unneeded