### PR TITLE
FF7: Fixed field shadows in movies

### DIFF
--- a/src/common_imports.h
+++ b/src/common_imports.h
@@ -196,18 +196,6 @@ struct struc_77
 	struct struc_173 struc_173;
 };
 
-// Field camera axis
-typedef struct {
-	signed short x;
-	signed short y;
-	signed short z;
-} camera_axis;
-
-// Field camera translation
-typedef struct {
-	signed int v;
-} camera_translation;
-
 struct heap
 {
 	struct heap *next;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1920,23 +1920,15 @@ struct ff7_field_sfx_state {
 struct ff7_camdata
 {
 	// EYE
-	int16_t eye_x;
-	int16_t eye_y;
-	int16_t eye_z;
+	vector3<short> eye;
 	// TARGET
-	int16_t target_x;
-	int16_t target_y;
-	int16_t target_z;
+	vector3<short> target;
 	// UP
-	int16_t up_x;
-	int16_t up_y;
-	int16_t up_z;
+	vector3<short> up;
 	// FILLER?
 	int16_t padding;
 	// POSITION
-	int32_t pos_x;
-	int32_t pos_y;
-	int32_t pos_z;
+	vector3<int> position;
 	// PAN
 	int16_t pan_x;
 	int16_t pan_y;
@@ -2405,6 +2397,8 @@ struct ff7_externals
 	uint32_t field_check_collision_with_models;
 	void (*field_evaluate_encounter_rate_60B2C6)();
 	short *field_player_model_id;
+	uint32_t field_update_camera_data;
+	ff7_camdata** field_camera_data;
 	uint32_t sub_40B27B;
 	WORD* word_CC0DD4;
 	WORD* word_CC1638;

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -497,6 +497,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.field_check_collision_with_models = get_relative_call((uint32_t)ff7_externals.field_update_single_model_position, 0x4CF);
 	ff7_externals.field_evaluate_encounter_rate_60B2C6 = (void (*)())get_relative_call(ff7_externals.field_update_models_positions, 0x90F);
 	ff7_externals.field_player_model_id = (short*)get_absolute_value(ff7_externals.field_update_models_positions, 0x45D);
+	ff7_externals.field_update_camera_data = get_relative_call(ff7_externals.sub_63C17F, 0xFD);
+	ff7_externals.field_camera_data = (ff7_camdata**)get_absolute_value(ff7_externals.field_update_camera_data, 0x84);
 	ff7_externals.sub_40B27B = get_relative_call(ff7_externals.sub_63C17F, 0xEE);
 	ff7_externals.word_CC0DD4 = (WORD*)get_absolute_value(ff7_externals.enter_field, 0x124);
 	ff7_externals.word_CC1638 = (WORD*)get_absolute_value(ff7_externals.sub_40B27B, 0x25);

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -223,32 +223,23 @@ void Lighting::ff7_get_field_view_matrix(struct matrix* outViewMatrix)
 	struct matrix viewMatrix;
 	identity_matrix(&viewMatrix);
 
-	byte* level_data = *ff7_externals.field_level_data_pointer;
-	if (!level_data)
+	ff7_camdata* field_camera_data = *ff7_externals.field_camera_data;
+	if (!field_camera_data)
 	{
 		return;
 	}
 
-	uint32_t camera_matrix_offset = *(uint32_t*)(level_data + 0x0A);
-
-	camera_axis* axis_x = (camera_axis*)(level_data + camera_matrix_offset + 4);
-	camera_axis* axis_y = (camera_axis*)(level_data + camera_matrix_offset + 4 + 6);
-	camera_axis* axis_z = (camera_axis*)(level_data + camera_matrix_offset + 4 + 12);
-
-	vector3<float> vx = { (float)(axis_x->x), (float)(axis_x->y), (float)(axis_x->z) };
-	vector3<float> vy = { (float)(axis_y->x), (float)(axis_y->y), (float)(axis_y->z) };
-	vector3<float> vz = { (float)(axis_z->x), (float)(axis_z->y), (float)(axis_z->z) };
+	vector3<float> vx = { (float)(field_camera_data->eye.x), (float)(field_camera_data->eye.y), (float)(field_camera_data->eye.z) };
+	vector3<float> vy = { (float)(field_camera_data->target.x), (float)(field_camera_data->target.y), (float)(field_camera_data->target.z) };
+	vector3<float> vz = { (float)(field_camera_data->up.x), (float)(field_camera_data->up.y), (float)(field_camera_data->up.z) };
 
 	divide_vector(&vx, 4096.0f, &vx);
 	divide_vector(&vy, 4096.0f, &vy);
 	divide_vector(&vz, 4096.0f, &vz);
 
-	camera_translation* pOx = (camera_translation*)(level_data + camera_matrix_offset + 4 + 20);
-	camera_translation* pOy = (camera_translation*)(level_data + camera_matrix_offset + 4 + 24);
-	camera_translation* pOz = (camera_translation*)(level_data + camera_matrix_offset + 4 + 28);
-	float ox = static_cast<float>(pOx->v);
-	float oy = static_cast<float>(pOy->v);
-	float oz = static_cast<float>(pOz->v);
+	float ox = static_cast<float>(field_camera_data->position.x);
+	float oy = static_cast<float>(field_camera_data->position.y);
+	float oz = static_cast<float>(field_camera_data->position.z);
 
 	float tx = ox;
 	float ty = oy;


### PR DESCRIPTION
Thanks to vertex2995 we were able to get the view matrix used in movies. Using this matrix for field shadow rendering fixes the problem where shadows would not be rendered in their correct position.