### PR TITLE
Lighting: Fixed lighting shader output

### DIFF
--- a/misc/FFNx.lighting.frag
+++ b/misc/FFNx.lighting.frag
@@ -286,8 +286,6 @@ void main()
 
     if (!(isHDR)) {
         // SDR screens require the Gamma output to properly render light scenes
-        color.rgb = toGamma(color.rgb);
+        gl_FragColor.rgb = toGamma(gl_FragColor.rgb);
     }
-
-    gl_FragColor = color;
 }


### PR DESCRIPTION
Fixed a little mistake from the previous fix where it was setting the wrong output variable.