### PR TITLE
SFX: Add footsteps support to WORLDMAP mode

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2135,6 +2135,38 @@ struct field_animation_data
 	byte field_180[16];
 };
 
+struct world_event_data
+{
+	world_event_data *next_ptr;
+	world_event_data *player_data_ptr;
+	world_event_data *special_data_ptr;
+	vector3<int> position;
+	byte field_18[40];
+	short facing;
+	byte field_42[2];
+	short offset_y;
+	short curr_script_position;
+	byte field_48[2];
+	WORD walkmap_type;
+	short direction;
+	byte field_4E[2];
+	byte model_id;
+	byte animation_is_loop_mask;
+	byte model_id_special;
+	byte animation_frame_idx;
+	byte field_54;
+	byte movement_speed;
+	byte wait_frames;
+	byte is_function_running_maybe;
+	byte animation_speed;
+	byte field_59[3];
+	byte vertical_speed;
+	byte animation_id;
+	byte field_5E;
+	byte vertical_speed_2;
+	byte field_60[104];
+};
+
 // --------------- end of FF7 imports ---------------
 
 struct ff7_channel_6_state
@@ -2713,8 +2745,13 @@ struct ff7_externals
 	uint32_t world_opcode_message_update_box_769050;
 	uint32_t world_opcode_message_update_text_769C02;
 	int (*get_world_encounter_rate)();
-	void (*world_compute_delta_position_753D00)(short* values, short z_value);
+	void (*world_compute_delta_position_753D00)(short*, short);
 	int (*pop_world_script_stack)();
+	uint32_t world_update_player_74EA48;
+	int (*world_get_player_model_id)();
+	int (*world_get_player_walkmap_type)();
+	void(*world_update_model_movement_762E87)(int, int);
+	world_event_data** world_event_current_entity_ptr;
 
 	uint32_t swirl_main_loop;
 	uint32_t swirl_loop_sub_4026D4;

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -79,6 +79,7 @@ uint32_t field_open_flevel_siz();
 
 // world
 void ff7_world_hook_init();
+void ff7_world_update_model_movement(int delta_position_x, int delta_position_z);
 
 // file
 FILE *open_lgp_file(char *filename, uint32_t mode);

--- a/src/ff7/world.cpp
+++ b/src/ff7/world.cpp
@@ -22,6 +22,22 @@
 
 #include "../ff7.h"
 #include "../patch.h"
+#include "../sfx.h"
+
+// For worldmap footsteps
+void ff7_world_update_model_movement(int delta_position_x, int delta_position_z)
+{
+    ff7_externals.world_update_model_movement_762E87(delta_position_x, delta_position_z);
+
+    if(*ff7_externals.world_event_current_entity_ptr && (delta_position_x || delta_position_z))
+    {
+        int player_model_id = ff7_externals.world_get_player_model_id();
+        if(player_model_id >= 0 && player_model_id <= 2 || player_model_id == 4 || player_model_id == 19) // Cloud, Tifa, and Cid
+        {
+            sfx_play_wm_footstep(player_model_id, ff7_externals.world_get_player_walkmap_type());
+        }
+    }
+}
 
 void ff7_world_snake_compute_delta_position(short* delta_position, short z_value)
 {

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -892,6 +892,11 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.world_opcode_message_sub_75EE86 = get_relative_call(ff7_externals.run_world_event_scripts_system_operations, 0xB6D);
 	ff7_externals.world_opcode_message_update_box_769050 = get_relative_call(ff7_externals.world_opcode_message_sub_75EE86, 0x2B);
 	ff7_externals.world_opcode_message_update_text_769C02 = get_relative_call(ff7_externals.world_opcode_message_update_box_769050, 0x6D);
+	ff7_externals.world_update_player_74EA48 = get_relative_call(ff7_externals.world_update_sub_74DB8C, 0x2D7);
+	ff7_externals.world_get_player_model_id = (int(*)())get_relative_call(ff7_externals.world_update_player_74EA48, 0x1B);
+	ff7_externals.world_get_player_walkmap_type = (int(*)())get_relative_call(ff7_externals.world_update_player_74EA48, 0x7DF);
+	ff7_externals.world_update_model_movement_762E87 = (void(*)(int, int))get_relative_call(ff7_externals.world_update_player_74EA48, 0xCDF);
+	ff7_externals.world_event_current_entity_ptr = (world_event_data**)get_absolute_value((uint32_t)ff7_externals.world_update_model_movement_762E87, 0x5);
 
 	ff7_externals.swirl_main_loop = swirl_main_loop;
 	ff7_externals.swirl_loop_sub_4026D4 = get_relative_call(swirl_main_loop, 0xC9);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -219,6 +219,15 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	ff7_field_hook_init();
 
 	// #####################
+	// worldmap footsteps
+	// #####################
+	if(ff7_footsteps)
+	{
+		replace_call_function(ff7_externals.world_update_player_74EA48 + 0xCDF, ff7_world_update_model_movement);
+		replace_call_function(ff7_externals.world_update_player_74EA48 + 0xD17, ff7_world_update_model_movement);
+	}
+
+	// #####################
 	// battle toggle
 	// #####################
 	replace_call_function(ff7_externals.field_battle_toggle, ff7_toggle_battle_field);

--- a/src/sfx.cpp
+++ b/src/sfx.cpp
@@ -526,6 +526,39 @@ void sfx_process_footstep(bool is_player_moving)
 	}
 }
 
+void sfx_play_wm_footstep(int player_model_id, int player_walkmap_type)
+{
+	static time_t last_playback_time, current_playback_time;
+	float pace = 0.3f;
+	constexpr int footstep_id = 159;
+	bool playing;
+
+	if(player_model_id == 4 || player_model_id == 19)
+		pace = 0.5f;
+
+	qpc_get_time(&current_playback_time);
+	if (qpc_diff_time(&current_playback_time, &last_playback_time, NULL) >= ((ff7_game_obj*)common_externals.get_game_object())->countspersecond * pace)
+	{
+		char track_name[64];
+		if (use_external_sfx)
+		{
+			sprintf(track_name, "wm_footsteps_%d_%d_%d", player_model_id, player_walkmap_type, footstep_id);
+			playing = nxAudioEngine.playSFX(track_name, footstep_id, 7, 0.0f);
+
+			if(!playing)
+			{
+				sprintf(track_name, "wm_footsteps_%d_%d", player_walkmap_type, footstep_id);
+				playing = nxAudioEngine.playSFX(track_name, footstep_id, 7, 0.0f);
+			}
+		}
+		else
+		{
+			common_externals.play_sfx(footstep_id);
+		}
+		qpc_get_time(&last_playback_time);
+	}
+}
+
 //=============================================================================
 
 void sfx_init()

--- a/src/sfx.h
+++ b/src/sfx.h
@@ -25,4 +25,5 @@
 #include <stdint.h>
 
 void sfx_process_footstep(bool is_player_moving);
+void sfx_play_wm_footstep(int player_model_id, int player_walkmap_type);
 void sfx_init();


### PR DESCRIPTION
It first checks for "wm_footsteps_x_y_159" where x is player model id (https://wiki.ffrtt.ru/index.php?title=FF7/WorldMap_Module/Script), and y is walkmap type (https://wiki.ffrtt.ru/index.php?title=FF7/WorldMap_Module). Then if there is no specific footsteps for that model id, it looks for "wm_footsteps_y_159".