### PR TITLE
60 FPS: Minor updates on battle mode remaining interpolations

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2754,6 +2754,12 @@ struct ff7_externals
 	uint32_t battle_handle_player_mark_5B9C8E;
 	uint32_t battle_handle_status_effect_anim_5BA7C0;
 
+	//battle 3d battleground
+	uint32_t update_3d_battleground;
+	uint32_t battleground_shake_train_42F088;
+	uint32_t battleground_vertical_scrolling_42F126;
+	uint32_t battleground_midgar_flashback_rain_5BDC4F;
+
 	// battle dialogue
 	uint32_t battle_sub_42CBF9;
 	uint32_t add_text_to_display_queue;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2602,6 +2602,8 @@ struct ff7_externals
 	uint32_t display_battle_damage_5BB410;
 	uint32_t battle_sub_5BDA0F;
 	uint32_t get_n_frames_display_action_string;
+	uint32_t battle_sub_434C8B;
+	uint32_t battle_sub_435D81;
 	uint32_t battle_sub_426DE3;
 	uint32_t battle_sub_426941;
 	uint32_t battle_sub_426899;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2567,6 +2567,7 @@ struct ff7_externals
 	uint32_t battle_sub_42A5EB;
 	uint32_t battle_sub_42E275;
 	uint32_t battle_sub_42E34A;
+	uint32_t battle_sub_5B9EC2;
 	uint32_t battle_sub_5BD5E9;
 	uint32_t run_summon_animations_script_5C1B81;
 	uint32_t run_summon_animations_script_sub_5C1D9A;
@@ -2683,6 +2684,7 @@ struct ff7_externals
 	void (*battle_sub_663707)(DWORD*);
 	void (*battle_sub_662ECC)(vector3<short>*, vector3<int>*, int*);
 	uint32_t run_chocobuckle_main_loop_560C32;
+	uint32_t run_confu_main_loop_5600BE;
 	uint32_t bomb_blast_black_bg_effect_537427;
 	uint32_t goblin_punch_flash_573291;
 	uint32_t roulette_skill_main_loop_566287;
@@ -2749,6 +2751,8 @@ struct ff7_externals
 	uint32_t battle_menu_update_call;
 	int *battle_menu_animation_idx;
 	uint32_t set_battle_speed_4385CC;
+	uint32_t battle_handle_player_mark_5B9C8E;
+	uint32_t battle_handle_status_effect_anim_5BA7C0;
 
 	// battle dialogue
 	uint32_t battle_sub_42CBF9;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1999,9 +1999,9 @@ struct ff7_modules_global_object
   uint16_t fade_type;
   uint16_t fade_adjustment;
   uint16_t fade_speed;
-  uint16_t fade_r;
-  uint16_t fade_g;
-  uint16_t fade_b;
+  short fade_r;
+  short fade_g;
+  short fade_b;
   uint16_t field_58;
   uint16_t field_5A;
   uint16_t field_5C;
@@ -2064,12 +2064,8 @@ struct field_event_data
 	byte field_8;
 	byte padding_9;
 	WORD field_A;
-	int model_pos_x;
-	int model_pos_y;
-	int model_pos_z;
-	int initial_pos_x;
-	int initial_pos_y;
-	int initial_pos_z;
+	vector3<int> model_pos;
+	vector3<int> model_initial_pos;
 	byte field_24[8];
 	int field_2C;
 	__int16 movement_ladder_jump_steps;
@@ -2078,10 +2074,10 @@ struct field_event_data
 	byte field_35;
 	byte rotation_value;
 	byte field_37;
-	byte rotation_value_2;
+	byte rotation_curr_value;
 	byte rotation_n_steps;
 	byte rotation_step_idx;
-	byte rotation_type;
+	byte rotation_steps_type;
 	__int16 rotation_initial;
 	__int16 rotation_final;
 	int field_40;
@@ -2116,9 +2112,7 @@ struct field_event_data
 	WORD movement_speed;
 	__int16 field_triangle_id;
 	__int16 field_7A;
-	int final_pos_x;
-	int final_pos_y;
-	int final_pos_z;
+	vector3<int> model_final_pos;
 };
 
 struct field_animation_data
@@ -2376,9 +2370,13 @@ struct ff7_externals
 	uint32_t opcode_fmusc;
 	uint32_t opcode_cmusc;
 	uint32_t opcode_canm1_canm2;
+	uint32_t opcode_fade;
+	uint32_t opcode_shake;
 	uint32_t field_opcode_08_sub_61D0D4;
 	void (*field_opcode_08_09_set_rotation_61DB2C)(short, byte, byte);
 	uint32_t field_opcode_AA_2A_sub_616476;
+	uint32_t field_opcode_turn_character_sub_616CB5;
+	int (*field_get_rotation_final_636515)(vector3<int>*, vector3<int>*, int*);
 	uint32_t field_music_helper;
 	uint32_t field_music_helper_sound_op_call;
 	uint32_t (*field_music_id_to_midi_id)(int16_t);

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -1662,6 +1662,8 @@ void ff7_battle_animations_hook_init()
 
     // Display string related
     replace_function(ff7_externals.get_n_frames_display_action_string, ff7_get_n_frames_display_action_string);
+    patch_multiply_code<WORD>(ff7_externals.battle_sub_434C8B + 0x4F, battle_frame_multiplier); // unknown display text frame to keep
+    patch_multiply_code<WORD>(ff7_externals.battle_sub_435D81 + 0x6A8, battle_frame_multiplier); // all lucky 7s frame to keep the text
 
     // Character movement (e.g. movement animation for attacks)
     replace_function(ff7_externals.battle_move_character_sub_426F58, ff7_battle_move_character_sub_426F58);

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -1565,6 +1565,14 @@ void ff7_battle_sub_6CE81E()
     }
 }
 
+void ff7_battleground_shake_train()
+{
+    if(frame_counter % battle_frame_multiplier == 0)
+    {
+        ((void(*)())ff7_externals.battleground_shake_train_42F088)();
+    }
+}
+
 void ff7_update_battle_menu()
 {
 	((void(*)())ff7_externals.battle_menu_update_6CE8B3)();
@@ -1740,6 +1748,30 @@ void ff7_battle_animations_hook_init()
 
     // Toggle variable related to gun effect
     replace_call_function(ff7_externals.battle_sub_42D808 + 0x117, ff7_battle_sub_6CE81E);
+
+    // 3D Battleground (mesh: horizontal, vertical, rotating, midgar flashback rain)
+    // Lifestream final battle with sephiroth cannot be interpolated, it will be left like this which is still good
+    replace_call_function(ff7_externals.update_3d_battleground + 0xBF, ff7_battleground_shake_train);
+    patch_divide_code<int>(ff7_externals.update_3d_battleground + 0x1D4, battle_frame_multiplier);
+    patch_divide_code<int>(ff7_externals.update_3d_battleground + 0x1ED, battle_frame_multiplier);
+    patch_divide_code<int>(ff7_externals.update_3d_battleground + 0x206, battle_frame_multiplier);
+    patch_divide_code<int>(ff7_externals.update_3d_battleground + 0x21C, battle_frame_multiplier);
+    patch_divide_code<int>(ff7_externals.update_3d_battleground + 0x232, battle_frame_multiplier);
+    patch_divide_code<int>(ff7_externals.update_3d_battleground + 0x24B, battle_frame_multiplier);
+    patch_divide_code<int>(ff7_externals.update_3d_battleground + 0x264, battle_frame_multiplier);
+    patch_divide_code<int>(ff7_externals.update_3d_battleground + 0x27D, battle_frame_multiplier);
+    patch_divide_code<WORD>(ff7_externals.update_3d_battleground + 0x617, battle_frame_multiplier);
+    patch_divide_code<WORD>(ff7_externals.update_3d_battleground + 0x6CE, battle_frame_multiplier);
+    patch_multiply_code<byte>(ff7_externals.battleground_vertical_scrolling_42F126 + 0x10, battle_frame_multiplier);
+    patch_divide_code<WORD>(ff7_externals.battleground_vertical_scrolling_42F126 + 0x22, battle_frame_multiplier);
+    patch_divide_code<WORD>(ff7_externals.battleground_vertical_scrolling_42F126 + 0x42, battle_frame_multiplier);
+    patch_code_word(ff7_externals.battleground_vertical_scrolling_42F126 + 0x78, (0x1F + 1) * battle_frame_multiplier - 1);
+    patch_divide_code<WORD>(ff7_externals.update_3d_battleground + 0x881, battle_frame_multiplier);
+    patch_divide_code<byte>(ff7_externals.update_3d_battleground + 0x8C7, battle_frame_multiplier);
+    patch_divide_code<byte>(ff7_externals.update_3d_battleground + 0x90C, battle_frame_multiplier);
+    patch_multiply_code<byte>(ff7_externals.battleground_midgar_flashback_rain_5BDC4F + 0x44, battle_frame_multiplier);
+    patch_divide_code<WORD>(ff7_externals.battleground_midgar_flashback_rain_5BDC4F + 0x71, battle_frame_multiplier);
+    patch_divide_code<byte>(ff7_externals.battleground_midgar_flashback_rain_5BDC4F + 0x156, battle_frame_multiplier);
 
     // Other animations (Status effects: confusion, sleep, and silence; and player mark on top of head)
     patch_divide_code<WORD>(ff7_externals.battle_sub_5B9EC2 + 0x1CB, battle_frame_multiplier);

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -777,7 +777,7 @@ void ff7_execute_effect100_fn()
                 else if (ff7_externals.effect100_array_fn[fn_index] == ff7_externals.run_chocobuckle_main_loop_560C32)
                 {
                     aux_effect100_handler[fn_index].setEffectDecorator(std::make_shared<ModelInterpolationEffectDecorator>(battle_frame_multiplier, ff7_externals.g_is_battle_paused, false,
-                                                                                                                           &ff7_externals.effect100_array_data[fn_index].field_0, 3));
+                                                                                                                           &ff7_externals.effect100_array_data[fn_index].field_0, 3, 10000));
                 }
                 else if(ff7_externals.effect100_array_fn[fn_index] == ff7_externals.barret_limit_4_1_model_movement_4698EF)
                 {
@@ -1741,6 +1741,11 @@ void ff7_battle_animations_hook_init()
     // Toggle variable related to gun effect
     replace_call_function(ff7_externals.battle_sub_42D808 + 0x117, ff7_battle_sub_6CE81E);
 
+    // Other animations (Status effects: confusion, sleep, and silence; and player mark on top of head)
+    patch_divide_code<WORD>(ff7_externals.battle_sub_5B9EC2 + 0x1CB, battle_frame_multiplier);
+    patch_code_byte(ff7_externals.battle_handle_status_effect_anim_5BA7C0 + 0x97, 0x3 + battle_frame_multiplier / 2);
+    patch_divide_code<WORD>(ff7_externals.battle_handle_player_mark_5B9C8E + 0x6A, battle_frame_multiplier);
+
     if(ff7_fps_limiter == FF7_LIMITER_60FPS)
     {
         // Fix battle speed and menu for 60 FPS only
@@ -1767,6 +1772,7 @@ void ff7_battle_animations_hook_init()
     one_call_effect100_addresses.insert(ff7_externals.death_sentence_main_loop_5661A0);
     one_call_effect100_addresses.insert(ff7_externals.roulette_skill_main_loop_566287);
     one_call_effect100_addresses.insert(ff7_externals.bomb_blast_black_bg_effect_537427);
+    one_call_effect100_addresses.insert(ff7_externals.run_confu_main_loop_5600BE);
     model_thresholds_by_address[ff7_externals.run_alexander_movement_5078D8] = 3000;
     camera_thresholds_by_address[ff7_externals.run_ramuh_camera_597206] = 5000;
     camera_thresholds_by_address[ff7_externals.run_typhoon_camera_4D594C] = 5000;

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -451,10 +451,14 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.opcode_ask = common_externals.execute_opcode_table[0x48];
 	ff7_externals.opcode_canm1_canm2 = common_externals.execute_opcode_table[0xB1];
 	ff7_externals.opcode_wmode = common_externals.execute_opcode_table[0x52];
+	ff7_externals.opcode_fade = common_externals.execute_opcode_table[0x6B];
+	ff7_externals.opcode_shake = common_externals.execute_opcode_table[0x5E];
 
 	ff7_externals.field_opcode_08_sub_61D0D4 = get_relative_call(common_externals.execute_opcode_table[0x08], 0x5A);
 	ff7_externals.field_opcode_08_09_set_rotation_61DB2C = (void(*)(short, byte, byte))get_relative_call(ff7_externals.field_opcode_08_sub_61D0D4, 0x196);
 	ff7_externals.field_opcode_AA_2A_sub_616476 = get_relative_call(common_externals.execute_opcode_table[0xAA], 0x26);
+	ff7_externals.field_opcode_turn_character_sub_616CB5 = get_relative_call(common_externals.execute_opcode_table[0xAB], 0x28);
+	ff7_externals.field_get_rotation_final_636515 = (int(*)(vector3<int>*, vector3<int>*, int*))get_relative_call(ff7_externals.field_opcode_turn_character_sub_616CB5, 0x34F);
 
 	ff7_externals.field_event_data_ptr = (field_event_data**)get_absolute_value(ff7_externals.opcode_canm1_canm2, 0xC1);
 	ff7_externals.field_animation_data_ptr = (field_animation_data**)get_absolute_value(ff7_externals.opcode_canm1_canm2, 0x199);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -651,8 +651,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_sub_42E34A = get_relative_call(battle_sub_42E3CA, 0x70);
 	uint32_t battle_sub_42DBD2 = get_relative_call(ff7_externals.battle_sub_42D992, 0x90);
 	uint32_t battle_sub_42F21F = get_relative_call(battle_sub_42DBD2, 0x37);
-	uint32_t battle_sub_5B9EC2 = get_relative_call(battle_sub_42F21F, 0x38);
-	ff7_externals.battle_sub_5BD5E9 = get_relative_call(battle_sub_5B9EC2, 0x41);
+	ff7_externals.battle_sub_5B9EC2 = get_relative_call(battle_sub_42F21F, 0x38);
+	ff7_externals.battle_sub_5BD5E9 = get_relative_call(ff7_externals.battle_sub_5B9EC2, 0x41);
 	uint32_t battle_sub_42DE61 = get_relative_call(ff7_externals.battle_sub_42D992, 0x9F);
 	ff7_externals.run_summon_animations_script_5C1B81 = get_absolute_value(battle_sub_42DE61, 0x17E);
 	ff7_externals.run_summon_animations_script_sub_5C1D9A = get_relative_call(ff7_externals.run_summon_animations_script_5C1B81, 0xA4);
@@ -941,9 +941,11 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	// Enemy attacks
 	uint32_t battle_sub_5C1484 = ff7_externals.magic_effects_fn_table[7];
 	uint32_t battle_sub_55FE60 = get_relative_call(battle_sub_5C1484, 0x33E);
-	uint32_t battle_sub_55FE9C = get_relative_call(battle_sub_55FE60, 0x12);
-	uint32_t handler_chocobuckle_sub_5609DB = get_absolute_value(battle_sub_55FE9C, 0x27);
+	uint32_t battle_handle_chocobuckle_and_confu_sub_55FE9C = get_relative_call(battle_sub_55FE60, 0x12);
+	uint32_t handler_chocobuckle_sub_5609DB = get_absolute_value(battle_handle_chocobuckle_and_confu_sub_55FE9C, 0x27);
+	uint32_t handler_confu_magic_sub_55FEF2 = get_absolute_value(battle_handle_chocobuckle_and_confu_sub_55FE9C, 0x36);
 	ff7_externals.run_chocobuckle_main_loop_560C32 = get_absolute_value(handler_chocobuckle_sub_5609DB, 0x6F);
+	ff7_externals.run_confu_main_loop_5600BE = get_absolute_value(handler_confu_magic_sub_55FEF2, 0x6C);
 	uint32_t bomb_blast_effects_5373D0 = ff7_externals.enemy_atk_effects_fn_table[67];
 	uint32_t bomb_blast_effects_sub_5373E5 = get_relative_call(bomb_blast_effects_5373D0, 0xB);
 	ff7_externals.bomb_blast_black_bg_effect_537427 = get_absolute_value(bomb_blast_effects_sub_5373E5, 0x34);
@@ -1006,6 +1008,12 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.g_do_render_menu = (int*)get_absolute_value(ff7_externals.battle_set_do_render_menu, 0x7);
 	ff7_externals.battle_menu_animation_idx = (int*)get_absolute_value(ff7_externals.battle_menu_update_6CE8B3, 0x144);
 	ff7_externals.set_battle_speed_4385CC = get_relative_call(ff7_externals.battle_sub_437DB0, 0x17C);
+	uint32_t battle_sub_4297B9 = get_relative_call(ff7_externals.battle_sub_42D992, 0x59);
+	uint32_t battle_sub_42952E = get_relative_call(battle_sub_4297B9, 0x10);
+	uint32_t battle_sub_42F3E8 = get_relative_call(battle_sub_42952E, 0xCD);
+	uint32_t battle_sub_5B9B30 = get_relative_call(battle_sub_42F3E8, 0x756);
+	ff7_externals.battle_handle_status_effect_anim_5BA7C0 = get_relative_call(battle_sub_5B9B30, 0xB2);
+	ff7_externals.battle_handle_player_mark_5B9C8E = get_relative_call(battle_sub_5B9B30, 0x123);
 
 	ff7_externals.world_update_sub_74DB8C = get_relative_call(worldmap_main_loop, 0x114);
 	ff7_externals.world_init_variables_74E1E9 = get_relative_call(ff7_externals.world_update_sub_74DB8C, 0x108);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -731,6 +731,11 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.display_battle_action_text_42782A = get_absolute_value(ff7_externals.run_animation_script, 0x4906);
 	ff7_externals.get_n_frames_display_action_string = get_relative_call(ff7_externals.run_animation_script, 0x4918);
 	ff7_externals.field_byte_DC0E11 = (byte*)get_absolute_value(ff7_externals.get_n_frames_display_action_string, 0x6);
+	uint32_t battle_sub_4351BD = get_relative_call(ff7_externals.battle_loop, 0x47C);
+	uint32_t** battle_functions_table_7C2AC0 = (uint32_t**)get_absolute_value(battle_sub_4351BD, 0x3A);
+	ff7_externals.battle_sub_434C8B = battle_functions_table_7C2AC0[1][1];
+	uint32_t battle_sub_435789 = get_relative_call(ff7_externals.battle_loop, 0x3B8);
+	ff7_externals.battle_sub_435D81 = get_relative_call(battle_sub_435789, 0x505);
 
 	// Display battle damage
 	ff7_externals.battle_sub_425D29 = get_absolute_value(ff7_externals.run_animation_script, 0x2850);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1015,6 +1015,13 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_handle_status_effect_anim_5BA7C0 = get_relative_call(battle_sub_5B9B30, 0xB2);
 	ff7_externals.battle_handle_player_mark_5B9C8E = get_relative_call(battle_sub_5B9B30, 0x123);
 
+	// 3D Battleground
+	ff7_externals.update_3d_battleground = get_relative_call(ff7_externals.battle_sub_42D992, 0x4);
+	ff7_externals.battleground_shake_train_42F088 = get_relative_call(ff7_externals.update_3d_battleground, 0xBF);
+	ff7_externals.battleground_vertical_scrolling_42F126 = get_relative_call(ff7_externals.update_3d_battleground, 0x783);
+	ff7_externals.battleground_midgar_flashback_rain_5BDC4F = get_relative_call(ff7_externals.update_3d_battleground, 0x3C);
+
+	// World externals
 	ff7_externals.world_update_sub_74DB8C = get_relative_call(worldmap_main_loop, 0x114);
 	ff7_externals.world_init_variables_74E1E9 = get_relative_call(ff7_externals.world_update_sub_74DB8C, 0x108);
 	ff7_externals.world_sub_7641A7 = get_relative_call(ff7_externals.world_update_sub_74DB8C, 0x210);
@@ -1038,6 +1045,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.world_update_model_movement_762E87 = (void(*)(int, int))get_relative_call(ff7_externals.world_update_player_74EA48, 0xCDF);
 	ff7_externals.world_event_current_entity_ptr = (world_event_data**)get_absolute_value((uint32_t)ff7_externals.world_update_model_movement_762E87, 0x5);
 
+	// Swirl externals
 	ff7_externals.swirl_main_loop = swirl_main_loop;
 	ff7_externals.swirl_loop_sub_4026D4 = get_relative_call(swirl_main_loop, 0xC9);
 

--- a/src/field.h
+++ b/src/field.h
@@ -27,8 +27,6 @@
 void field_init();
 void field_debug(bool *isOpen);
 
-std::unordered_set<void*> fieldPatchedAddress{};
-
 template<typename T>
 T* get_field_parameter_address(int id)
 {
@@ -52,24 +50,3 @@ void set_field_parameter(int id, T value)
 byte get_field_bank_value(int16_t bank);
 
 byte* get_level_data_pointer();
-
-template<typename T>
-void patch_field_parameter(int id, T value)
-{
-	T* field_parameter_address = get_field_parameter_address<T>(id);
-
-	if(!fieldPatchedAddress.contains(field_parameter_address))
-		set_field_parameter<T>(id, value);
-
-	fieldPatchedAddress.insert(field_parameter_address);
-}
-
-template<typename T>
-void patch_generic_field_parameter(int id, byte frame_multiplier, bool is_multiplication)
-{
-	T field_parameter = get_field_parameter<T>(id);
-	if(is_multiplication)
-		patch_field_parameter<T>(id, field_parameter * frame_multiplier);
-	else
-		patch_field_parameter<T>(id, field_parameter / frame_multiplier);
-}


### PR DESCRIPTION
This fixes all known minor issues in battle: 3D battleground movements (elevator, corel train, ...), yellow rotating mark on top of the head of the player, silence, confusion, and sleep animation effects, and also two display text frames length where strings are shown in battle