### PR TITLE
60FPS: Fix FIELD movement teleport glitch in special situations + Remove trace_battle_camera toml flag

### DIFF
--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -473,10 +473,6 @@ trace_gamepad = false
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 trace_achievement = false
 
-# trace_battle_camera - Dump in the logs only APIs that has to do with battle camera
-#~~~~~~~~~~~~~~~~~~~~~~~~~~~
-trace_battle_camera = false
-
 # trace_battle_animation - Dump in the logs only APIs that has to do with battle animation
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 trace_battle_animation = false

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -63,7 +63,6 @@ bool trace_voice;
 bool trace_ambient;
 bool trace_gamepad;
 bool trace_achievement;
-bool trace_battle_camera;
 bool trace_battle_animation;
 bool trace_battle_text;
 bool vertex_log;
@@ -197,7 +196,6 @@ void read_cfg()
 	trace_ambient = config["trace_ambient"].value_or(false);
 	trace_gamepad = config["trace_gamepad"].value_or(false);
 	trace_achievement = config["trace_achievement"].value_or(false);
-	trace_battle_camera = config["trace_battle_camera"].value_or(false);
 	trace_battle_animation = config["trace_battle_animation"].value_or(false);
 	trace_battle_text = config["trace_battle_text"].value_or(false);
 	vertex_log = config["vertex_log"].value_or(false);

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -76,7 +76,6 @@ extern bool trace_voice;
 extern bool trace_ambient;
 extern bool trace_gamepad;
 extern bool trace_achievement;
-extern bool trace_battle_camera;
 extern bool trace_battle_animation;
 extern bool trace_battle_text;
 extern bool vertex_log;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2426,6 +2426,7 @@ struct ff7_externals
 	uint32_t field_check_collision_with_models;
 	void (*field_evaluate_encounter_rate_60B2C6)();
 	short *field_player_model_id;
+	WORD *field_n_models;
 	uint32_t field_update_camera_data;
 	ff7_camdata** field_camera_data;
 	uint32_t sub_40B27B;

--- a/src/ff7/camera.cpp
+++ b/src/ff7/camera.cpp
@@ -162,11 +162,6 @@ void ff7_execute_camera_functions()
                     ff7_externals.camera_fn_data[fn_index].field_E /= battle_frame_multiplier;
                 }
 
-                if (trace_all || trace_battle_camera)
-                    ffnx_trace("%s - begin function: 0x%x (actor_id: %d,last command: 0x%02X, 0x%04X)\n", __func__,
-                               ff7_externals.camera_fn_array[fn_index], ff7_externals.anim_event_queue[0].attackerID,
-                               ff7_externals.battle_context->lastCommandIdx, ff7_externals.battle_context->lastActionIdx);
-
                 isNewCameraFunction[fn_index] = false;
             }
 

--- a/src/ff7/field.cpp
+++ b/src/ff7/field.cpp
@@ -235,9 +235,23 @@ void ff7_field_initialize_variables()
 {
 	((void(*)())ff7_externals.field_initialize_variables)();
 
-	// reset movement phase for all models
+	// reset movement frame index for all models
 	for(auto &external_data : external_model_data)
 		external_data.moveFrameIndex = 0;
+}
+
+void ff7_field_update_models_position(int key_input_status)
+{
+	((void(*)(int))ff7_externals.field_update_models_positions)(key_input_status);
+
+	// Reset movement frame index for all models if they are not using walking/running (movement type != 1)
+	for(int model_idx = 0; model_idx < (int)(*ff7_externals.field_n_models); model_idx++)
+	{
+		if((*ff7_externals.field_event_data_ptr)[model_idx].movement_type != 1)
+		{
+			external_model_data[model_idx].moveFrameIndex = 0;
+		}
+	}
 }
 
 int ff7_field_update_player_model_position(short model_id)
@@ -660,6 +674,7 @@ void ff7_field_hook_init()
 	replace_call_function(ff7_externals.field_sub_60DCED + 0x178, ff7_field_initialize_variables);
 
 	// Model movement (walk, run) fps fix + allow footstep sfx
+	replace_call_function(ff7_externals.sub_63C17F + 0x5DD, ff7_field_update_models_position);
 	replace_call_function(ff7_externals.field_update_models_positions + 0x8BC, ff7_field_update_player_model_position);
 	replace_call_function(ff7_externals.field_update_models_positions + 0x9E8, ff7_field_update_single_model_position);
 	replace_call_function(ff7_externals.field_update_models_positions + 0x9AA, ff7_field_check_collision_with_target);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -507,6 +507,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.field_check_collision_with_models = get_relative_call((uint32_t)ff7_externals.field_update_single_model_position, 0x4CF);
 	ff7_externals.field_evaluate_encounter_rate_60B2C6 = (void (*)())get_relative_call(ff7_externals.field_update_models_positions, 0x90F);
 	ff7_externals.field_player_model_id = (short*)get_absolute_value(ff7_externals.field_update_models_positions, 0x45D);
+	ff7_externals.field_n_models = (WORD*)get_absolute_value(ff7_externals.field_update_models_positions, 0x25);
 	ff7_externals.field_update_camera_data = get_relative_call(ff7_externals.sub_63C17F, 0xFD);
 	ff7_externals.field_camera_data = (ff7_camdata**)get_absolute_value(ff7_externals.field_update_camera_data, 0x84);
 	ff7_externals.sub_40B27B = get_relative_call(ff7_externals.sub_63C17F, 0xEE);


### PR DESCRIPTION
For example, it fixes the softlock in HoneyBee Inn bathtub