### PR TITLE
60FPS: Fix limits in turn movement opcode (#347)

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2425,7 +2425,8 @@ struct ff7_externals
 	int (*field_update_single_model_position)(short);
 	void (*field_update_model_animation_frame)(short);
 	int (*field_check_collision_with_target)(field_event_data*, short);
-	uint32_t field_check_collision_with_models;
+	int (*field_get_linear_interpolated_value)(int, int, int, int);
+	int (*field_get_smooth_interpolated_value)(int, int, int, int);
 	void (*field_evaluate_encounter_rate_60B2C6)();
 	short *field_player_model_id;
 	WORD *field_n_models;

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -505,7 +505,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.field_update_single_model_position = (int (*)(int16_t))get_relative_call(ff7_externals.field_update_models_positions, 0x8BC);
 	ff7_externals.field_update_model_animation_frame = (void (*)(int16_t))get_relative_call(ff7_externals.field_update_models_positions, 0x68D);
 	ff7_externals.field_check_collision_with_target = (int (*)(field_event_data*, short))get_relative_call(ff7_externals.field_update_models_positions, 0x9AA);
-	ff7_externals.field_check_collision_with_models = get_relative_call((uint32_t)ff7_externals.field_update_single_model_position, 0x4CF);
+	ff7_externals.field_get_linear_interpolated_value = (int (*)(int, int, int, int))get_relative_call(ff7_externals.field_update_models_positions, 0x122);
+	ff7_externals.field_get_smooth_interpolated_value = (int (*)(int, int, int, int))get_relative_call(ff7_externals.field_update_models_positions, 0x1EC);
 	ff7_externals.field_evaluate_encounter_rate_60B2C6 = (void (*)())get_relative_call(ff7_externals.field_update_models_positions, 0x90F);
 	ff7_externals.field_player_model_id = (short*)get_absolute_value(ff7_externals.field_update_models_positions, 0x45D);
 	ff7_externals.field_n_models = (WORD*)get_absolute_value(ff7_externals.field_update_models_positions, 0x25);


### PR DESCRIPTION
This fixes the limitation in TURNGEN and TURN opcode in about 8 cases if running double the speed.
It uses external rotation steps index and number of steps when it a special flag is set, otherwise the legacy code is still implemented and works.

Also refactor some FIELD 60 FPS fix functions.