### PR TITLE
FF7: Fix var and params type for layer BG tiles

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1392,7 +1392,7 @@ struct field_tile
 {
 	short x;
 	short y;
-	int z;
+	float z;
 	WORD field_8;
 	WORD field_A;
 	WORD img_x;
@@ -2295,7 +2295,7 @@ struct ff7_externals
 	struct field_tile **field_layer2_tiles;
 	uint32_t *field_special_y_offset;
 	uint32_t *field_bg_multiplier;
-	void (*add_page_tile)(float, float, int, int, int, uint32_t, uint32_t);
+	void (*add_page_tile)(float, float, float, float, float, uint32_t, uint32_t);
 	uint32_t field_load_textures;
 	void (*field_convert_type2_layers)();
 	void (*make_struc3)(uint32_t, struct struc_3 *);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -311,7 +311,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.field_layer2_tiles = (field_tile **)get_absolute_value(ff7_externals.field_layer2_pick_tiles, 0xC0);
 	ff7_externals.field_special_y_offset = (uint32_t *)get_absolute_value(ff7_externals.field_layer2_pick_tiles, 0x43);
 	ff7_externals.field_bg_multiplier = (uint32_t *)get_absolute_value(ff7_externals.field_layer2_pick_tiles, 0x23);
-	ff7_externals.add_page_tile = (void (*)(float, float, int, int, int, uint32_t, uint32_t))get_relative_call(ff7_externals.field_layer2_pick_tiles, 0x327);
+	ff7_externals.add_page_tile = (void (*)(float, float, float, float, float, uint32_t, uint32_t))get_relative_call(ff7_externals.field_layer2_pick_tiles, 0x327);
 
 	ff7_externals.field_load_textures = get_relative_call(ff7_externals.field_sub_60DCED, 0x107);
 	ff7_externals.field_convert_type2_layers = (void (*)())get_relative_call(ff7_externals.field_load_textures, 0xD);


### PR DESCRIPTION
Fixes the previous commit where I reverted back some variable type for field_tile. These are the correct variable and parameter type. I printed those values inside the structure and they are clearly float.