### PR TITLE
60FPS: Fix new rotation steps index not starting from zero in specific situation

### DIFF
--- a/src/ff7/field.cpp
+++ b/src/ff7/field.cpp
@@ -282,6 +282,7 @@ void set_external_rotation_data(int model_idx, int rotation_n_steps)
 	// For implementing higher number of steps
 	external_model_data[model_idx].useExternalRotationData = true;
 	external_model_data[model_idx].rotation_n_steps = rotation_n_steps;
+	external_model_data[model_idx].rotation_steps_idx = 0;
 }
 
 void ff7_field_initialize_variables()
@@ -418,7 +419,7 @@ void ff7_field_update_models_rotation_new()
 					field_event_data.rotation_steps_type = 3;
 				else
 				{
-					if(external_model_data[model_idx].useExternalRotationData)
+					if(canUseExternalRotationData)
 						external_model_data[model_idx].rotation_steps_idx++;
 					else
 						field_event_data.rotation_step_idx++;
@@ -437,7 +438,7 @@ void ff7_field_update_models_rotation_new()
 					field_event_data.rotation_steps_type = 3;
 				else
 				{
-					if(external_model_data[model_idx].useExternalRotationData)
+					if(canUseExternalRotationData)
 						external_model_data[model_idx].rotation_steps_idx++;
 					else
 						field_event_data.rotation_step_idx++;


### PR DESCRIPTION
There are specific occasions where the opcode of turngen and turn rotation is stopped in the middle of the execution. When using 60 FPS, the new `rotation_steps_idx` is not resetted to 0. This will cause a softlock since the `rotation_steps_idx` is greater than `rotation_n_steps` and it won't stop rotating. In original `rotation_steps_idx` this is resetted to 0, otherwise it won't start rotating, so to fix it we just set the new `rotation_steps_idx` to 0 at the start of the rotation.