### PR TITLE
60FPS: Fix bug in Cid attack SFX

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2636,6 +2636,7 @@ struct ff7_externals
 	uint32_t battle_sub_5BD050;
 	uint32_t battle_smoke_move_handler_5BE4E2;
 	uint32_t battle_sub_42A72D;
+	void (*battle_play_sfx_sound_430D32)(uint16_t, short, char);
 	uint32_t run_tifa_limit_effects;
 	uint32_t tifa_limit_1_2_sub_4E3D51;
 	uint32_t tifa_limit_2_1_sub_4E48D4;
@@ -2739,6 +2740,7 @@ struct ff7_externals
 	byte* field_byte_DC0E11;
 	byte* field_battle_byte_BF2E1C;
 	byte* field_battle_byte_BE10B4;
+	byte* field_battle_byte_BE1170;
 	short* resting_Y_array_data;
 	WORD* field_odin_frames_AEEC14;
 	palette_extra* palette_extra_data_C06A00;

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -1142,6 +1142,33 @@ void ff7_battle_move_character_sub_426F58()
     }
 }
 
+void ff7_battle_play_sfx_delayed_427737()
+{
+    constexpr byte cid_id = 0x08;
+    constexpr short cloud_sfx_attack_id = 18;
+
+    byte actor_id = ff7_externals.anim_event_queue[0].attackerID;
+    auto &fn_data = ff7_externals.effect60_array_data[*ff7_externals.effect60_array_idx];
+
+    // Disable bugged battle SFX when Cid is attacking, but SFX ID is cloud's one
+    if(ff7_externals.battle_context->actor_vars[actor_id].index == cid_id && fn_data.field_6 == cloud_sfx_attack_id)
+    {
+        fn_data.field_0 = 0xFFFF;
+    }
+    else
+    {
+        if ( fn_data.n_frames )
+        {
+            fn_data.n_frames--;
+        }
+        else
+        {
+            ff7_externals.battle_play_sfx_sound_430D32(fn_data.field_6, *ff7_externals.field_battle_byte_BE1170, 0);
+            fn_data.field_0 = 0xFFFF;
+        }
+    }
+}
+
 void ff7_ifrit_movement_596702()
 {
     auto &effect_data = ff7_externals.effect100_array_data[*ff7_externals.effect100_array_idx];
@@ -1752,6 +1779,8 @@ void ff7_battle_animations_hook_init()
 
     patch_multiply_code<WORD>(ff7_externals.battle_sub_5BCD42 + 0x5B, battle_frame_multiplier);
     patch_divide_code<WORD>(ff7_externals.battle_sub_5BCD42 + 0x6E, battle_frame_multiplier);
+
+    replace_function(ff7_externals.battle_sub_427737, ff7_battle_play_sfx_delayed_427737);
 
     // Tifa slots speed patch (bitwise and with 0x7 changed to 0x3)
     patch_code_byte((uint32_t)ff7_externals.display_tifa_slots_handler_6E3135 + 0x168, 0x3);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -793,6 +793,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	uint32_t battle_sub_5BE490 = get_relative_call(ff7_externals.run_animation_script, 0x3E6E);
 	ff7_externals.battle_smoke_move_handler_5BE4E2 = get_absolute_value(battle_sub_5BE490, 0x5);
 	ff7_externals.battle_sub_6CE81E = (void(*)())get_relative_call(ff7_externals.battle_sub_42D808, 0x117);
+	ff7_externals.battle_play_sfx_sound_430D32 = (void(*)(uint16_t, short, char))get_relative_call(ff7_externals.battle_sub_427737, 0x35);
+	ff7_externals.field_battle_byte_BE1170 = (byte*)get_absolute_value(ff7_externals.battle_sub_427737, 0x1E);
 
 	// Limit breaks
 	uint32_t battle_sub_4E1627 = get_relative_call(ff7_externals.run_animation_script, 0x3848);


### PR DESCRIPTION
Whenever Cid attacked in 60FPS, it played Cloud attack SFX due to a bug in Cid animation script and mismatch timing in 60FPS. This is fixed by removing this SFX from playing at all only in 60FPS