### PR TITLE
FF7: Fix warning and errors when hooking FF7 calls

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2049,14 +2049,6 @@ struct ff7_field_script_header {
 	char szName[8];			// Field name (never shown)
 };
 
-struct ff7_field_ad_object {
-	int32_t field_0;
-	int32_t actor_x;
-	int32_t actor_y;
-	int32_t actor_z;
-	char buffer[384]; // to be mapped to real fields
-};
-
 struct field_event_data
 {
 	WORD field_0;
@@ -2118,7 +2110,11 @@ struct field_event_data
 
 struct field_animation_data
 {
-	byte field_0[34];
+	int field_0;
+	int actor_x;
+	int actor_y;
+	int actor_z;
+	byte field_10[18];
 	__int16 field_22;
 	byte field_24[336];
 	WORD field_174;
@@ -2392,7 +2388,6 @@ struct ff7_externals
 	uint32_t opcode_wmode;
 	uint32_t *sfx_initialized;
 	uint32_t sfx_play_summon;
-	uint32_t sfx_fill_buffer_from_audio_dat;
 	uint32_t sfx_load_and_play_with_speed;
 	uint32_t sfx_fmt_header;
 	DWORD *sfx_play_effects_id_channel_6;
@@ -2478,7 +2473,6 @@ struct ff7_externals
 	WORD* field_game_moment; //0xDC08DC
 	ff7_modules_global_object *modules_global_object; // 0xCC0D88
 	ff7_modules_global_object **field_global_object_ptr; // 0xCBF9D8
-	uint32_t sub_74DB8C;
 	void (*sub_767039)(DWORD*,DWORD*,DWORD*);
 	uint32_t play_battle_music_call;
 	uint32_t (*play_battle_end_music)();
@@ -2490,12 +2484,10 @@ struct ff7_externals
 	int (*sub_630C48)(int16_t, int16_t, int16_t, int16_t, int16_t);
 	uint32_t sub_408074;
 	uint32_t sub_60BB58;
-	uint32_t sub_630734;
 	byte** field_level_data_pointer;
 	uint32_t sub_408116;
 	char *word_CC16E8;
 	int16_t* current_triangle_id;
-	struct ff7_field_ad_object* field_current_actor;
 	uint16_t* menu_battle_end_mode;
 	uint32_t* pointer_functions_7C2980;
 	uint32_t battle_enemy_killed_sub_433BD2;
@@ -2506,7 +2498,7 @@ struct ff7_externals
 	uint32_t display_battle_action_text_42782A;
 	uint32_t display_battle_action_text_sub_6D71FA;
 	uint32_t menu_decrease_item_quantity;
-	uint32_t sub_610973, sub_611098;
+	uint32_t opcode_setbyte, opcode_biton;
 	uint32_t sub_60FA7D;
 	uint32_t menu_sub_7212FB;
 	uint32_t load_save_file;
@@ -2625,7 +2617,6 @@ struct ff7_externals
 	uint32_t battle_sub_4276B6;
 	uint32_t battle_sub_4255B7;
 	uint32_t battle_sub_425E5F;
-	uint32_t battle_sub_425520;
 	uint32_t battle_sub_5BCF9D;
 	uint32_t battle_sub_425AAD;
 	uint32_t battle_sub_427A6C;
@@ -2740,7 +2731,6 @@ struct ff7_externals
 	byte* field_byte_DC0E11;
 	byte* field_battle_byte_BF2E1C;
 	byte* field_battle_byte_BE10B4;
-	byte* field_battle_byte_BE1170;
 	short* resting_Y_array_data;
 	WORD* field_odin_frames_AEEC14;
 	palette_extra* palette_extra_data_C06A00;
@@ -2812,7 +2802,6 @@ struct ff7_externals
 	uint32_t world_opcode_message_update_box_769050;
 	uint32_t world_opcode_message_update_text_769C02;
 	int (*get_world_encounter_rate)();
-	void (*world_compute_delta_position_753D00)(short*, short);
 	int (*pop_world_script_stack)();
 	uint32_t world_update_player_74EA48;
 	int (*world_get_player_model_id)();

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -1013,7 +1013,7 @@ void ff7_execute_effect60_fn()
                 else if (ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_425E5F ||
                          ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5C1C8F ||
                          ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5BCF9D ||
-                         ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_425520 ||
+                         ff7_externals.effect60_array_fn[fn_index] == ff7_externals.handle_aura_effects_425520 ||
                          ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_boss_death_sub_5BC5EC ||
                          ff7_externals.effect60_array_fn[fn_index] == ff7_externals.battle_sub_5BCD42 ||
                          ff7_externals.effect60_array_fn[fn_index] == ff7_externals.display_battle_damage_5BB410 ||
@@ -1163,7 +1163,7 @@ void ff7_battle_play_sfx_delayed_427737()
         }
         else
         {
-            ff7_externals.battle_play_sfx_sound_430D32(fn_data.field_6, *ff7_externals.field_battle_byte_BE1170, 0);
+            ff7_externals.battle_play_sfx_sound_430D32(fn_data.field_6, *ff7_externals.g_active_actor_id, 0);
             fn_data.field_0 = 0xFFFF;
         }
     }

--- a/src/ff7/world.cpp
+++ b/src/ff7/world.cpp
@@ -64,14 +64,14 @@ void ff7_world_init_variables(short param_1)
     ((void(*)(short))ff7_externals.world_init_variables_74E1E9)(param_1);
 }
 
-void ff7_world_snake_compute_delta_position(short* delta_position, short z_value)
+void ff7_world_snake_compute_delta_position(vector3<short>* delta_position, short z_value)
 {
-    ff7_externals.world_compute_delta_position_753D00(delta_position, z_value);
+    ff7_externals.world_sub_753D00(delta_position, z_value);
     if(delta_position)
     {
-        delta_position[0] /= common_frame_multiplier;
-        delta_position[1] /= common_frame_multiplier;
-        delta_position[2] /= common_frame_multiplier;
+        delta_position->x /= common_frame_multiplier;
+        delta_position->y /= common_frame_multiplier;
+        delta_position->z /= common_frame_multiplier;
     }
 }
 

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -313,8 +313,8 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		replace_function(ff7_externals.menu_decrease_item_quantity, ff7_menu_decrease_item_quantity);
 
 		// GOLD CHOCOBO, YUFFIE, VINCENT: called through update_field_entities
-		replace_call_function(ff7_externals.sub_610973 + 0x14, ff7_chocobo_field_entity_60FA7D);
-		replace_call_function(ff7_externals.sub_611098 + 0x3A, ff7_character_regularly_field_entity_60FA7D);
+		replace_call_function(ff7_externals.opcode_setbyte + 0x14, ff7_chocobo_field_entity_60FA7D);
+		replace_call_function(ff7_externals.opcode_biton + 0x3A, ff7_character_regularly_field_entity_60FA7D);
 
 		// INITIALIZATION AT LOAD SAVE FILE
 		if (version == VERSION_FF7_102_US) {

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -1150,7 +1150,7 @@ void music_init()
 			replace_function(common_externals.midi_cleanup, noop);
 
 			// Allow custom worldmap battle musics
-			replace_call_function(ff7_externals.sub_74DB8C + 0x613, ff7_worldmap_play_custom_battle_music);
+			replace_call_function(ff7_externals.world_mode_loop_sub_74DB8C + 0x613, ff7_worldmap_play_custom_battle_music);
 			// Force channel detection (1) for battle music
 			replace_call(ff7_externals.play_battle_music_call, ff7_battle_music);
 			replace_call(ff7_externals.play_battle_music_win_call, ff7_battle_music_fanfare);

--- a/src/sfx.cpp
+++ b/src/sfx.cpp
@@ -497,10 +497,10 @@ int sfx_play_battle_specific(IDirectSoundBuffer* buffer, uint32_t flags)
 uint32_t sfx_fix_omnislash_sound_loading(int sound_id, int dsound_buffer)
 {
 	// Added by FFNx: Load sound 0x188
-	((uint32_t(*)(int, int))ff7_externals.sfx_fill_buffer_from_audio_dat)(0x188, dsound_buffer);
+	((uint32_t(*)(int, int))common_externals.sfx_load)(0x188, dsound_buffer);
 
 	// Original call (load sound 0x285)
-	return ((uint32_t(*)(int, int))ff7_externals.sfx_fill_buffer_from_audio_dat)(sound_id, dsound_buffer);
+	return ((uint32_t(*)(int, int))common_externals.sfx_load)(sound_id, dsound_buffer);
 }
 
 void sfx_fix_cait_sith_roulette(int sound_id)


### PR DESCRIPTION
 - Fix an enemy attack camera movement hook call
 - Fix Mini status effect animation hook call
 - Fix duplicate sfx_load function (0x745CF3)
 - Fix duplicate field array variable 0xCFF738 (two struct defining the same thing has been put together)
 - Fix other duplicate function hook call (0x425520, 0x74DB8C, 0x753D00, 0x5BF01F, 0x60FA7D)
 - Fix duplicate variables (0xBE1170, 0x9055A0)