### PR TITLE
FF7: Fix deadzone bug for XINPUT analog triggers

### DIFF
--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -201,10 +201,10 @@ void ff7_use_analogue_controls()
 			if(std::abs(gamepad.rightStickX) > right_analog_stick_deadzone)
 				horizontalRotSpeed = 5.0f * gamepad.rightStickX;
 
-			if(gamepad.rightTrigger > -1.0f + right_analog_trigger_deadzone)
-				zoomSpeed += zoomSpeedMax * (0.5 + 0.5f * gamepad.rightTrigger);
-			if(gamepad.leftTrigger > -1.0 + left_analog_trigger_deadzone)
-				zoomSpeed -= zoomSpeedMax * (0.5f + 0.5f * gamepad.leftTrigger);
+			if(gamepad.rightTrigger > right_analog_trigger_deadzone)
+				zoomSpeed += zoomSpeedMax * (0.5f * gamepad.rightTrigger);
+			if(gamepad.leftTrigger > left_analog_trigger_deadzone)
+				zoomSpeed -= zoomSpeedMax * (0.5f * gamepad.leftTrigger);
 		}
 	}
 	else


### PR DESCRIPTION
Always find it strange that deadzone never worked. The value of rightTrigger and leftTrigger is actually in between `[0, 1]`. https://github.com/julianxhokaxhiu/FFNx/blob/master/src/gamepad.cpp#L114-L115