### PR TITLE
Lighting: Fix field shadow glitch for 3d models

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 - Ambient global volume is now linked to the SFX global volume
 - Misc 60 FPS bugfixes
 - XInput: Fix deadzone bug for analog triggers
+- Lighting: Fix field 3D models shadow glitch
 
 ## FF8
 

--- a/misc/FFNx.lighting.vert
+++ b/misc/FFNx.lighting.vert
@@ -59,7 +59,6 @@ void main()
         pos = mul(mul(d3dViewport, d3dProjection), v_position0);
 
         if (color.a > 0.5) color.a = 0.5;
-        else if(color.r + color.g + color.b == 0.0 && a_position.y == 0.0) pos = vec4_splat(0.0);
     }
 
     if (blendMode == 4.0) color.a = 1.0;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2754,6 +2754,7 @@ struct ff7_externals
 	int *battle_menu_animation_idx;
 	uint32_t set_battle_speed_4385CC;
 	uint32_t battle_set_actor_timer_data_4339C2;
+	uint32_t battle_sub_42F3E8;
 	uint32_t battle_handle_player_mark_5B9C8E;
 	uint32_t battle_handle_status_effect_anim_5BA7C0;
 	uint32_t battle_update_targeting_info_6E6291;

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1025,8 +1025,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_set_actor_timer_data_4339C2 = get_relative_call(ff7_externals.battle_sub_437DB0, 0x1C7);
 	uint32_t battle_sub_4297B9 = get_relative_call(ff7_externals.battle_sub_42D992, 0x59);
 	uint32_t battle_sub_42952E = get_relative_call(battle_sub_4297B9, 0x10);
-	uint32_t battle_sub_42F3E8 = get_relative_call(battle_sub_42952E, 0xCD);
-	uint32_t battle_sub_5B9B30 = get_relative_call(battle_sub_42F3E8, 0x756);
+	ff7_externals.battle_sub_42F3E8 = get_relative_call(battle_sub_42952E, 0xCD);
+	uint32_t battle_sub_5B9B30 = get_relative_call(ff7_externals.battle_sub_42F3E8, 0x756);
 	ff7_externals.battle_handle_status_effect_anim_5BA7C0 = get_relative_call(battle_sub_5B9B30, 0xB2);
 	ff7_externals.battle_handle_player_mark_5B9C8E = get_relative_call(battle_sub_5B9B30, 0x123);
 	ff7_externals.battle_update_targeting_info_6E6291 = get_relative_call(ff7_externals.battle_sub_6DB0EE, 0x1F9);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -260,6 +260,12 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	replace_call_function(ff7_externals.timer_menu_sub + 0x72F, ff7_menu_sub_6F5C0C);
 	replace_call_function(ff7_externals.timer_menu_sub + 0xD77, ff7_menu_sub_6FAC38);
 
+	//######################
+	// shadow lighting fix
+	//######################
+	if(enable_lighting)
+	    memset_code(ff7_externals.battle_sub_42F3E8 + 0xD7D, 0x90, 78); // Disable battle shadow draw call
+
 	//#############################
 	// steam save game preservation
 	//#############################


### PR DESCRIPTION
Remove the special condition, in lighting vertex shader, used to skip original battle shadow that caused the field shadow triangle glitch