### PR TITLE
60FPS: Implement smooth FIELD background movement

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1940,7 +1940,7 @@ struct ff7_shake_bg_data
 	uint8_t do_shake;
 	uint8_t shake_phase;
 	char amp_index;
-	uint8_t shake_curr_value;
+	char shake_curr_value;
 	short shake_amplitude;
 	short shake_initial;
 	short shake_final;
@@ -1964,8 +1964,7 @@ struct ff7_modules_global_object
   uint8_t field_13;
   uint8_t field_14;
   uint8_t field_15;
-  uint8_t field_16;
-  uint8_t field_17;
+  short field_16;
   uint16_t field_18;
   uint16_t field_1A;
   uint8_t field_1C;
@@ -2122,6 +2121,86 @@ struct field_animation_data
 	uint32_t *anim_frame_object;
 	uint32_t *field_17C;
 	byte field_180[16];
+};
+
+struct ff7_field_camera
+{
+	int16_t eye_x;
+	int16_t eye_y;
+	int16_t eye_z;
+	int16_t target_x;
+	int16_t target_y;
+	int16_t target_z;
+	int16_t up_x;
+	int16_t up_y;
+	int16_t up_z;
+	int16_t pos_x;
+	int16_t pan_x;
+	int16_t pos_y;
+	int16_t pan_y;
+	int16_t pos_z;
+	int16_t zoom;
+};
+
+struct field_gateway
+{
+	vector3<short> v1_exit_line;
+	vector3<short> v2_exit_line;
+	vector3<short> destination_vertex;
+	SHORT field_id;
+	byte unknown[4];
+};
+
+struct field_trigger
+{
+	vector3<short> v_corner1;
+	vector3<short> v_corner2;
+	byte bg_group_id;
+	byte bg_frame_id;
+	byte behavior;
+	byte sound_id;
+};
+
+struct field_arrow
+{
+	int pos_x;
+	int pos_y;
+	int pos_z;
+	int arrow_type;
+};
+
+struct field_camera_range
+{
+	short left;
+	short bottom;
+	short right;
+	short top;
+};
+
+struct field_trigger_header
+{
+	byte field_name[9];
+	byte control_direction;
+	short focus_height;
+	field_camera_range camera_range;
+	byte field_14[4];
+	short bg3_width;
+	short bg3_height;
+	short bg4_width;
+	short bg4_height;
+	short bg3_pos_x;
+	short bg3_pos_y;
+	short bg4_pos_x;
+	short bg4_pos_y;
+	short bg3_speed_x;
+	short bg3_speed_y;
+	short bg4_speed_x;
+	short bg4_speed_y;
+	short field_30[4];
+	field_gateway gateways[12];
+	field_trigger triggers[12];
+	byte show_arrow_flag[12];
+	field_arrow arrows[12];
 };
 
 struct world_event_data
@@ -2285,13 +2364,34 @@ struct ff7_externals
 	uint32_t field_sub_6388EE;
 	uint32_t field_draw_everything;
 	uint32_t field_pick_tiles_make_vertices;
+	uint32_t field_layer1_pick_tiles;
+	uint32_t *field_layer1_tiles_num;
+	uint32_t **field_layer1_palette_sort;
+	field_tile **field_layer1_tiles;
 	uint32_t field_layer2_pick_tiles;
 	uint32_t *field_layer2_tiles_num;
 	uint32_t **field_layer2_palette_sort;
-	struct field_tile **field_layer2_tiles;
+	field_tile **field_layer2_tiles;
+	uint32_t field_layer3_pick_tiles;
+	uint32_t *field_layer3_tiles_num;
+	uint32_t **field_layer3_palette_sort;
+	field_tile **field_layer3_tiles;
+	int *do_draw_layer3_CFFE3C;
+	int *field_layer3_flag_CFFE40;
+	uint32_t field_layer4_pick_tiles;
+	uint32_t *field_layer4_tiles_num;
+	uint32_t **field_layer4_palette_sort;
+	field_tile **field_layer4_tiles;
+	int *do_draw_layer4_CFFEA4;
+	int *field_layer4_flag_CFFEA8;
+	int *field_layer_CFF1D8;
+	uint16_t *field_palette_D00088;
 	uint32_t *field_special_y_offset;
 	uint32_t *field_bg_multiplier;
 	void (*add_page_tile)(float, float, float, float, float, uint32_t, uint32_t);
+	double (*field_layer_sub_C23C0F)(ff7_field_camera*, int, int, int);
+	field_trigger_header** field_triggers_header;
+	ff7_field_camera* field_camera_CFF3D8;
 	uint32_t field_load_textures;
 	void (*field_convert_type2_layers)();
 	void (*make_struc3)(uint32_t, struct struc_3 *);
@@ -2415,7 +2515,7 @@ struct ff7_externals
 	uint32_t field_battle_toggle;
 	uint32_t worldmap_battle_toggle;
 	uint32_t enter_field;
-	uint32_t sub_63C17F;
+	uint32_t field_loop_sub_63C17F;
 	uint32_t field_update_models_positions;
 	int (*field_update_single_model_position)(short);
 	void (*field_update_model_animation_frame)(short);
@@ -2430,6 +2530,24 @@ struct ff7_externals
 	uint32_t sub_40B27B;
 	WORD* word_CC0DD4;
 	WORD* word_CC1638;
+	void (*field_update_background_positions)();
+	uint32_t field_sub_64314F;
+	void (*engine_sub_661976)(int, int);
+	uint32_t engine_sub_66307D;
+	void (*engine_sub_661465)(short*, float*);
+	void (*engine_sub_66CF7E)(float*, vector3<float>*, vector3<float>*);
+	vector2<int>* field_bg_offset;
+	short* field_world_pos_x;
+	short* field_world_pos_y;
+	short* field_prev_world_pos_x;
+	short* field_prev_world_pos_y;
+	vector2<int>* field_vector2_CFF204;
+	vector2<int>* field_vector2_CFF1F4;
+	WORD* field_bg_flag_CC15E4;
+	uint32_t field_sub_640EB7;
+	uint32_t field_sub_661B68;
+	void (*engine_sub_661B23)(int, int);
+	void (*engine_sub_67CCDE)(float, float, float, float, float, float, float, ff7_game_obj*);
 	uint32_t sub_630D50;
 	uint32_t sub_631945;
 	WORD* opcode_message_loop_code;
@@ -2676,8 +2794,8 @@ struct ff7_externals
 	void(*add_kotr_camera_fn_to_effect100_fn_476AAB)(DWORD, DWORD, WORD);
 	uint32_t run_kotr_camera_476AFB;
 	vector3<int>* (*battle_sub_661000)(int);
-	void (*battle_sub_663673)(WORD*);
-	void (*battle_sub_663707)(DWORD*);
+	void (*engine_sub_663673)(WORD*);
+	void (*engine_sub_663707)(DWORD*);
 	void (*battle_sub_662ECC)(vector3<short>*, vector3<int>*, int*);
 	uint32_t run_chocobuckle_main_loop_560C32;
 	uint32_t run_confu_main_loop_5600BE;

--- a/src/ff7/animations.cpp
+++ b/src/ff7/animations.cpp
@@ -1219,8 +1219,8 @@ void ff7_ifrit_movement_596702()
             return;
         }
 
-        ff7_externals.battle_sub_663673(ff7_externals.word_array_BCC768);
-        ff7_externals.battle_sub_663707((DWORD*)ff7_externals.word_array_BCC768);
+        ff7_externals.engine_sub_663673(ff7_externals.word_array_BCC768);
+        ff7_externals.engine_sub_663707((DWORD*)ff7_externals.word_array_BCC768);
         ff7_externals.battle_sub_662ECC(ff7_externals.battle_ifrit_model_position, *ff7_externals.vector3_int_ptr_BCC6A8, &(*ff7_externals.vector3_int_ptr_BCC6A8)[1].y);
         getBattleModelState(3)->modelPosition.x = (*ff7_externals.vector3_int_ptr_BCC6A8)->x;
         getBattleModelState(3)->modelPosition.y = (*ff7_externals.vector3_int_ptr_BCC6A8)->y;

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -76,7 +76,10 @@ void ff7_battle_animations_hook_init();
 // field
 void ff7_field_hook_init();
 void field_load_textures(struct ff7_game_obj *game_object, struct struc_3 *struc_3);
+void field_layer1_pick_tiles(short x_offset, short y_offset);
 void field_layer2_pick_tiles(short x_offset, short y_offset);
+void field_layer3_pick_tiles(short x_offset, short y_offset);
+void field_layer4_pick_tiles(short x_offset, short y_offset);
 uint32_t field_open_flevel_siz();
 
 // world

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -305,13 +305,34 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.field_sub_6388EE = get_relative_call(field_main_loop, 0xFF);
 	ff7_externals.field_draw_everything = get_relative_call(ff7_externals.field_sub_6388EE, 0x11);
 	ff7_externals.field_pick_tiles_make_vertices = get_relative_call(ff7_externals.field_draw_everything, 0xC9);
+	ff7_externals.field_layer1_pick_tiles = get_relative_call(ff7_externals.field_pick_tiles_make_vertices, 0x2D);
+	ff7_externals.field_layer1_tiles_num = (uint32_t *)get_absolute_value(ff7_externals.field_layer1_pick_tiles, 0x8B);
+	ff7_externals.field_layer1_palette_sort = (uint32_t **)get_absolute_value(ff7_externals.field_layer1_pick_tiles, 0xA2);
+	ff7_externals.field_layer1_tiles = (field_tile **)get_absolute_value(ff7_externals.field_layer1_pick_tiles, 0xBF);
 	ff7_externals.field_layer2_pick_tiles = get_relative_call(ff7_externals.field_pick_tiles_make_vertices, 0x48);
 	ff7_externals.field_layer2_tiles_num = (uint32_t *)get_absolute_value(ff7_externals.field_layer2_pick_tiles, 0x8C);
 	ff7_externals.field_layer2_palette_sort = (uint32_t **)get_absolute_value(ff7_externals.field_layer2_pick_tiles, 0xA3);
 	ff7_externals.field_layer2_tiles = (field_tile **)get_absolute_value(ff7_externals.field_layer2_pick_tiles, 0xC0);
+	ff7_externals.field_layer3_pick_tiles = get_relative_call(ff7_externals.field_pick_tiles_make_vertices, 0x12);
+	ff7_externals.field_layer3_tiles_num = (uint32_t *)get_absolute_value(ff7_externals.field_layer3_pick_tiles, 0xAB);
+	ff7_externals.field_layer3_palette_sort = (uint32_t **)get_absolute_value(ff7_externals.field_layer3_pick_tiles, 0xC1);
+	ff7_externals.field_layer3_tiles = (field_tile **)get_absolute_value(ff7_externals.field_layer3_pick_tiles, 0xDD);
+	ff7_externals.do_draw_layer3_CFFE3C = (int*)get_absolute_value(ff7_externals.field_layer3_pick_tiles, 0x9);
+	ff7_externals.field_layer3_flag_CFFE40 = (int*)get_absolute_value(ff7_externals.field_layer3_pick_tiles, 0x3B1);
+	ff7_externals.field_layer4_pick_tiles = get_relative_call(ff7_externals.field_pick_tiles_make_vertices, 0x5F);
+	ff7_externals.field_layer4_tiles_num = (uint32_t *)get_absolute_value(ff7_externals.field_layer4_pick_tiles, 0x90);
+	ff7_externals.field_layer4_palette_sort = (uint32_t **)get_absolute_value(ff7_externals.field_layer4_pick_tiles, 0xA6);
+	ff7_externals.field_layer4_tiles = (field_tile **)get_absolute_value(ff7_externals.field_layer4_pick_tiles, 0xC2);
+	ff7_externals.do_draw_layer4_CFFEA4 = (int*)get_absolute_value(ff7_externals.field_layer4_pick_tiles, 0x9);
+	ff7_externals.field_layer4_flag_CFFEA8 = (int*)get_absolute_value(ff7_externals.field_layer4_pick_tiles, 0x3F3);
+	ff7_externals.field_layer_sub_C23C0F = (double(*)(ff7_field_camera*, int, int, int))get_relative_call(ff7_externals.field_layer3_pick_tiles, 0x7E);
+	ff7_externals.field_layer_CFF1D8 = (int *)get_absolute_value(ff7_externals.field_layer4_pick_tiles, 0x264);
+	ff7_externals.field_palette_D00088 = (uint16_t *)get_absolute_value(ff7_externals.field_layer4_pick_tiles, 0x28A);
 	ff7_externals.field_special_y_offset = (uint32_t *)get_absolute_value(ff7_externals.field_layer2_pick_tiles, 0x43);
 	ff7_externals.field_bg_multiplier = (uint32_t *)get_absolute_value(ff7_externals.field_layer2_pick_tiles, 0x23);
 	ff7_externals.add_page_tile = (void (*)(float, float, float, float, float, uint32_t, uint32_t))get_relative_call(ff7_externals.field_layer2_pick_tiles, 0x327);
+	ff7_externals.field_triggers_header = (field_trigger_header**)get_absolute_value(ff7_externals.field_layer3_pick_tiles, 0x134);
+	ff7_externals.field_camera_CFF3D8 = (ff7_field_camera*)get_absolute_value(ff7_externals.field_layer3_pick_tiles, 0x7A);
 
 	ff7_externals.field_load_textures = get_relative_call(ff7_externals.field_sub_60DCED, 0x107);
 	ff7_externals.field_convert_type2_layers = (void (*)())get_relative_call(ff7_externals.field_load_textures, 0xD);
@@ -501,8 +522,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.on_gameover_exit = ff7_externals.exit_gameover + 0x21;
 
 	ff7_externals.enter_field = get_absolute_value(main_loop, 0x90D);
-	ff7_externals.sub_63C17F = get_relative_call(field_main_loop, 0x59);
-	ff7_externals.field_update_models_positions = get_relative_call(ff7_externals.sub_63C17F, 0x5DD);
+	ff7_externals.field_loop_sub_63C17F = get_relative_call(field_main_loop, 0x59);
+	ff7_externals.field_update_models_positions = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x5DD);
 	ff7_externals.field_update_single_model_position = (int (*)(int16_t))get_relative_call(ff7_externals.field_update_models_positions, 0x8BC);
 	ff7_externals.field_update_model_animation_frame = (void (*)(int16_t))get_relative_call(ff7_externals.field_update_models_positions, 0x68D);
 	ff7_externals.field_check_collision_with_target = (int (*)(field_event_data*, short))get_relative_call(ff7_externals.field_update_models_positions, 0x9AA);
@@ -511,18 +532,36 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.field_evaluate_encounter_rate_60B2C6 = (void (*)())get_relative_call(ff7_externals.field_update_models_positions, 0x90F);
 	ff7_externals.field_player_model_id = (short*)get_absolute_value(ff7_externals.field_update_models_positions, 0x45D);
 	ff7_externals.field_n_models = (WORD*)get_absolute_value(ff7_externals.field_update_models_positions, 0x25);
-	ff7_externals.field_update_camera_data = get_relative_call(ff7_externals.sub_63C17F, 0xFD);
+	ff7_externals.field_update_camera_data = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0xFD);
 	ff7_externals.field_camera_data = (ff7_camdata**)get_absolute_value(ff7_externals.field_update_camera_data, 0x84);
-	ff7_externals.sub_40B27B = get_relative_call(ff7_externals.sub_63C17F, 0xEE);
+	ff7_externals.sub_40B27B = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0xEE);
 	ff7_externals.word_CC0DD4 = (WORD*)get_absolute_value(ff7_externals.enter_field, 0x124);
 	ff7_externals.word_CC1638 = (WORD*)get_absolute_value(ff7_externals.sub_40B27B, 0x25);
+	ff7_externals.field_update_background_positions = (void (*)())get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x1A6);
+	ff7_externals.field_sub_64314F = get_relative_call((uint32_t)ff7_externals.field_update_background_positions, 0x288);
+	ff7_externals.engine_sub_661976 = (void (*)(int, int))get_relative_call(ff7_externals.field_sub_64314F, 0x2D);
+	ff7_externals.engine_sub_66307D = get_relative_call(ff7_externals.field_sub_64314F, 0x45);
+	ff7_externals.engine_sub_661465 = (void (*)(short*, float*))get_relative_call(ff7_externals.engine_sub_66307D, 0x23);
+	ff7_externals.engine_sub_66CF7E = (void (*)(float*, vector3<float>*, vector3<float>*))get_relative_call(ff7_externals.engine_sub_66307D, 0x37);
+	ff7_externals.field_bg_offset = (vector2<int>*)get_absolute_value((uint32_t)ff7_externals.field_update_background_positions, 0x3E8);
+	ff7_externals.field_world_pos_x = (short*)get_absolute_value((uint32_t)ff7_externals.field_update_background_positions, 0x403);
+	ff7_externals.field_world_pos_y = (short*)get_absolute_value((uint32_t)ff7_externals.field_update_background_positions, 0x424);
+	ff7_externals.field_vector2_CFF204 = (vector2<int>*)get_absolute_value((uint32_t)ff7_externals.field_sub_64314F, 0x28);
+	ff7_externals.field_vector2_CFF1F4 = (vector2<int>*)get_absolute_value((uint32_t)ff7_externals.field_sub_64314F, 0x58);
+	ff7_externals.field_bg_flag_CC15E4 = (WORD*)get_absolute_value((uint32_t)ff7_externals.field_update_background_positions, 0x129);
+	ff7_externals.field_sub_640EB7 = get_relative_call(ff7_externals.field_draw_everything, 0x34);
+	ff7_externals.field_sub_661B68 = get_relative_call(ff7_externals.field_sub_640EB7, 0x61);
+	ff7_externals.field_prev_world_pos_x = (short*)get_absolute_value((uint32_t)ff7_externals.field_sub_640EB7, 0x6);
+	ff7_externals.field_prev_world_pos_y = (short*)get_absolute_value((uint32_t)ff7_externals.field_sub_640EB7, 0x18);
+	ff7_externals.engine_sub_661B23 = (void (*)(int, int))get_relative_call(ff7_externals.field_sub_661B68, 0x1A);
+	ff7_externals.engine_sub_67CCDE = (void (*)(float, float, float, float, float, float, float, ff7_game_obj*))get_relative_call(ff7_externals.field_sub_661B68, 0x72);
 
 	ff7_externals.sfx_stop_channel_6 = get_relative_call(common_externals.sfx_cleanup, 0x16);
 	ff7_externals.sfx_stop_channel_timer_handle = (UINT *)get_absolute_value(ff7_externals.sfx_stop_channel_6, 0x5);
 
-	ff7_externals.current_movie_frame = (WORD*)get_absolute_value(ff7_externals.sub_63C17F, 0x133);
-	ff7_externals.opening_movie_music_start_frame = (DWORD *)(ff7_externals.sub_63C17F + 0x139);
-	ff7_externals.opening_movie_play_midi_call = ff7_externals.sub_63C17F + 0x145;
+	ff7_externals.current_movie_frame = (WORD*)get_absolute_value(ff7_externals.field_loop_sub_63C17F, 0x133);
+	ff7_externals.opening_movie_music_start_frame = (DWORD *)(ff7_externals.field_loop_sub_63C17F + 0x139);
+	ff7_externals.opening_movie_play_midi_call = ff7_externals.field_loop_sub_63C17F + 0x145;
 
 	ff7_externals.byte_CC164C = (BYTE *)get_absolute_value(main_loop, 0x32A);
 	ff7_externals.word_CC0DC6 = (WORD *)get_absolute_value(main_init_loop, 0x4BD);
@@ -569,7 +608,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.field_game_moment = (WORD*)get_absolute_value(common_externals.execute_opcode_table[0x9D], 0xEA); //0xDC08DC
 
 	ff7_externals.sub_408074 = get_relative_call(main_loop, 0x681);
-	ff7_externals.sub_60BB58 = get_relative_call(ff7_externals.sub_63C17F, 0x16F);
+	ff7_externals.sub_60BB58 = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x16F);
 	common_externals.update_field_entities = get_relative_call(ff7_externals.sub_60BB58, 0x3A); // 0x60C94D
 
 	common_externals.current_field_id = (WORD*)get_absolute_value(ff7_externals.sub_408074, 0x41); // 0xCC15D0
@@ -578,11 +617,11 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 
 	ff7_externals.field_level_data_pointer = (byte**)get_absolute_value(ff7_externals.read_field_file, 0xB2); // 0xCFF594
 
-	ff7_externals.sub_408116 = get_relative_call(ff7_externals.sub_63C17F, 0x2A);
+	ff7_externals.sub_408116 = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x2A);
 	ff7_externals.word_CC16E8 = (char *)get_absolute_value(ff7_externals.sub_408116, 0x8E);
 	ff7_externals.current_triangle_id = (int16_t *)((char *)ff7_externals.word_CC16E8 + 136 * ff7_externals.modules_global_object->field_model_id);
 
-	ff7_externals.sub_6499F7 = get_relative_call(ff7_externals.sub_63C17F, 0x10C);
+	ff7_externals.sub_6499F7 = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x10C);
 	ff7_externals.input_ok_button_status = (DWORD*)get_absolute_value(ff7_externals.sub_6499F7, 0x60);
 	ff7_externals.input_run_button_status = (DWORD*)get_absolute_value(ff7_externals.sub_6499F7, 0x55);
 
@@ -937,8 +976,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.run_kotr_camera_476AFB = get_absolute_value((uint32_t)ff7_externals.add_kotr_camera_fn_to_effect100_fn_476AAB, 0xA);
 
 	ff7_externals.battle_sub_661000 = (vector3<int>*(*)(int))get_relative_call(ff7_externals.run_ifrit_movement_596702, 0x38);
-	ff7_externals.battle_sub_663673 = (void(*)(WORD*))get_relative_call(ff7_externals.run_ifrit_movement_596702, 0x169);
-	ff7_externals.battle_sub_663707 = (void(*)(DWORD*))get_relative_call(ff7_externals.run_ifrit_movement_596702, 0x176);
+	ff7_externals.engine_sub_663673 = (void(*)(WORD*))get_relative_call(ff7_externals.run_ifrit_movement_596702, 0x169);
+	ff7_externals.engine_sub_663707 = (void(*)(DWORD*))get_relative_call(ff7_externals.run_ifrit_movement_596702, 0x176);
 	ff7_externals.battle_sub_662ECC = (void(*)(vector3<short>*, vector3<int>*, int*))get_relative_call(ff7_externals.run_ifrit_movement_596702, 0x193);
 	ff7_externals.byte_BCC788 = (byte*)get_absolute_value(ff7_externals.run_ifrit_movement_596702, 0x1C);
 	ff7_externals.vector3_int_ptr_BCC6A8 = (vector3<int>**)get_absolute_value(ff7_externals.run_ifrit_movement_596702, 0x41);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -88,7 +88,10 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	replace_function(common_externals.load_tex_file, load_tex_file);
 
 	replace_function(ff7_externals.field_load_textures, field_load_textures);
+	replace_function(ff7_externals.field_layer1_pick_tiles, field_layer1_pick_tiles);
 	replace_function(ff7_externals.field_layer2_pick_tiles, field_layer2_pick_tiles);
+	replace_function(ff7_externals.field_layer3_pick_tiles, field_layer3_pick_tiles);
+	replace_function(ff7_externals.field_layer4_pick_tiles, field_layer4_pick_tiles);
 	patch_code_byte(ff7_externals.field_draw_everything + 0xE2, 0x1D);
 	patch_code_byte(ff7_externals.field_draw_everything + 0x353, 0x1D);
 	replace_function(ff7_externals.open_flevel_siz, field_open_flevel_siz);

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -52,6 +52,13 @@ struct matrix
 };
 
 template <typename T>
+struct vector2
+{
+	T x;
+	T y;
+};
+
+template <typename T>
 struct vector3
 {
 	T x;


### PR DESCRIPTION
Change the update mechanism related to following the player in FIELD mode by moving the background and the 3d models.
All positions of the 4 layers of the background are computed using floating point variables. This is also done for the 3d model world coordinates.
This removes all the wobbling background and 3d models. To avoid changing the original game, this smoothness in FIELD movement is applied only when using FULL 30 FPS or FULL 60 FPS mode.