### PR TITLE
60FPS: Fix MSAA tiles tearing by using centroid UV texture coords

### DIFF
--- a/misc/FFNx.varying.flat.def.sc
+++ b/misc/FFNx.varying.flat.def.sc
@@ -1,5 +1,5 @@
 flat vec4 v_color0    : COLOR0    = vec4(0.0, 0.0, 0.0, 0.0);
-vec2 v_texcoord0 : TEXCOORD0 = vec2(0.0, 0.0);
+centroid vec2 v_texcoord0 : TEXCOORD0 = vec2(0.0, 0.0);
 vec4 v_position0 : TEXCOORD4 = vec4(0.0, 0.0, 0.0, 0.0);
 vec4 v_shadow0 : TEXCOORD5 = vec4(0.0, 0.0, 0.0, 0.0);
 vec3 v_normal0 : NORMAL = vec3(0.0, 0.0, 0.0);

--- a/misc/FFNx.varying.smooth.def.sc
+++ b/misc/FFNx.varying.smooth.def.sc
@@ -1,5 +1,5 @@
 smooth vec4 v_color0    : COLOR0    = vec4(0.0, 0.0, 0.0, 0.0);
-vec2 v_texcoord0 : TEXCOORD0 = vec2(0.0, 0.0);
+centroid vec2 v_texcoord0 : TEXCOORD0 = vec2(0.0, 0.0);
 vec4 v_position0 : TEXCOORD4 = vec4(0.0, 0.0, 0.0, 0.0);
 vec4 v_shadow0 : TEXCOORD5 = vec4(0.0, 0.0, 0.0, 0.0);
 vec3 v_normal0 : NORMAL = vec3(0.0, 0.0, 0.0);


### PR DESCRIPTION
@CosmosXIII found this fix (https://www.opengl.org/pipeline/article/vol003_6/) for MSAA issue. This centroid evaluation is more computationally intensive and also less accurate, but it avoids the bad pixels. The best might be to use centroid evaluation only on 2D elements, but from testing, there is no much difference. For now, we could test and see what the users think and feel with this.

Since MSAA is no more problem, I increased the background position precision to 1/32. I don't think a higher precision is gonna make the background smoother.