### PR TITLE
60FPS: Set ideal precision to 1/10 for background positions

### DIFF
--- a/src/ff7/field.cpp
+++ b/src/ff7/field.cpp
@@ -100,7 +100,7 @@ std::set<field_bank_address> field_bank_address_to_be_fixed = {{14, 6}};
 field_bank_address mvief_bank_address;
 
 constexpr float INVALID_VALUE = -1000000;
-constexpr float MIN_STEP_INVERSE = 32.f;
+constexpr float MIN_STEP_INVERSE = 10.f;
 vector2<float> field_curr_delta_world_pos, field_3d_world_pos, bg_main_layer_pos, bg_layer3_pos, bg_layer4_pos;
 
 int call_original_opcode_function(byte opcode)


### PR DESCRIPTION
This together with the centroid UV coordinate qualifier should avoid all tearing lines for whatever
combination of internal resolution scale (from 1x to 8x) and MSAA values.