### PR TITLE
FF7: Added new 16:9 widescreen mode without scretching

### DIFF
--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -53,6 +53,7 @@ internal_resolution_scale = 0
 # When off the game will be stretched to fit the window's aspect ratio; Be aware the game may look wrong though.
 # 0: Preserves original game aspect ratio of (4:3) by adding black bars on the left and right side (if needed)
 # 1: Stretched to fit the window's aspect ratio; Be aware the game may look wrong though.
+# 2: New 16:9 aspect ratio mode without stretching the image. Fields that lack horizontal scrolling will show black bars on the left and right side.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 aspect_ratio = 0
 

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -433,4 +433,7 @@ void read_cfg()
 		external_vibrate_path += "/ff8";
 	else
 		external_vibrate_path += "/ff7";
+
+	// WIDESCREEN
+	if (ff8 && aspect_ratio > AR_STRETCH) aspect_ratio = AR_ORIGINAL;
 }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -507,21 +507,21 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 				switch (LOWORD(wParam))
 				{
 				case VK_LEFT:
-					if(aspect_ratio >= 0 && aspect_ratio < AR_COUNT)
+					if(aspect_ratio >= 0 && aspect_ratio < AR_COUNT - 1)
 					{
-						ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : AR_COUNT - 1);
+						ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : (AR_COUNT - 1) - 1);
 
-						aspect_ratio = aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : AR_COUNT - 1;
+						aspect_ratio = aspect_ratio - 1 >= 0 ? aspect_ratio - 1 : (AR_COUNT - 1) - 1;
 
 						newRenderer.reset();
 					}
 					break;
 				case VK_RIGHT:
-					if(aspect_ratio >= 0 && aspect_ratio < AR_COUNT)
+					if(aspect_ratio >= 0 && aspect_ratio < AR_COUNT - 1)
 					{
-						ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, (aspect_ratio + 1) % AR_COUNT);
+						ffnx_trace("aspect_ratio: %d => %d\n", aspect_ratio, (aspect_ratio + 1) % (AR_COUNT - 1));
 
-						aspect_ratio = (aspect_ratio + 1) % AR_COUNT;
+						aspect_ratio = (aspect_ratio + 1) % (AR_COUNT - 1);
 
 						newRenderer.reset();
 					}

--- a/src/common.h
+++ b/src/common.h
@@ -92,6 +92,7 @@ enum AspectRatioMode
 {
     AR_ORIGINAL = 0,
     AR_STRETCH,
+    AR_WIDESCREEN,
     AR_COUNT
 };
 

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1977,8 +1977,8 @@ struct ff7_modules_global_object
   uint16_t field_model_pos_x;
   uint16_t field_model_pos_y;
   uint16_t field_8;
-  uint16_t field_A;
-  uint16_t field_C;
+  short field_A;
+  short field_C;
   uint16_t field_E;
   int16_t field_10;
   uint8_t field_12;
@@ -2178,9 +2178,9 @@ struct field_arrow
 struct field_camera_range
 {
 	short left;
-	short bottom;
-	short right;
 	short top;
+	short right;
+	short bottom;
 };
 
 struct field_trigger_header
@@ -2275,6 +2275,7 @@ struct ff7_externals
 	uint32_t midi_fix;
 	void *snowboard_fix;
 	uint32_t cdcheck;
+	uint32_t cdcheck_enter_sub;
 	uint32_t get_inserted_cd_sub;
 	DWORD* insertedCD;
 	uint8_t* requiredCD;
@@ -2538,6 +2539,7 @@ struct ff7_externals
 	uint32_t field_battle_toggle;
 	uint32_t worldmap_battle_toggle;
 	uint32_t enter_field;
+	uint32_t field_init_viewport_values;
 	uint32_t field_loop_sub_63C17F;
 	uint32_t field_update_models_positions;
 	int (*field_update_single_model_position)(short);
@@ -2555,6 +2557,7 @@ struct ff7_externals
 	uint32_t sub_40B27B;
 	WORD* word_CC0DD4;
 	WORD* word_CC1638;
+	uint32_t field_init_scripted_bg_movement;
 	uint32_t field_update_scripted_bg_movement;
 	void (*field_update_background_positions)();
 	uint32_t compute_and_submit_draw_gateways_arrows_64DA3B;
@@ -2824,6 +2827,7 @@ struct ff7_externals
 	uint32_t run_phoenix_main_loop_516297;
 	uint32_t run_phoenix_movement_518AFF;
 	uint32_t run_phoenix_camera_515238;
+	uint32_t run_bahamut_neo_main_48C2A1;
 	uint32_t run_bahamut_neo_movement_48D7BC;
 	uint32_t run_bahamut_neo_camera_48C75D;
 	uint32_t run_hades_camera_4B65A8;
@@ -2981,9 +2985,42 @@ struct ff7_externals
 	int* is_wait_frames_zero_E39BC0;
 	uint32_t world_sub_75A1C6;
 	uint32_t world_sub_75A5D5;
+	uint32_t world_draw_fade_quad_75551A;
+	uint32_t world_sub_75079D;
+	uint32_t world_sub_751EFC;
+	uint32_t world_culling_bg_meshes_75F263;
+	uint32_t world_submit_draw_bg_meshes_75F68C;
+	uint32_t world_compute_skybox_data_754100;
+	uint32_t world_submit_draw_clouds_and_meteor_7547A6;
 
 	uint32_t swirl_main_loop;
 	uint32_t swirl_loop_sub_4026D4;
+	uint32_t swirl_enter_40164E;
+	uint32_t swirl_enter_sub_401810;
+
+	uint32_t field_culling_model_639252;
+	uint32_t field_sub_63AC66;
+	void (*field_sub_63AC3F)(int, int, int, int);
+	uint32_t battle_draw_quad_5BD473;
+	uint32_t battle_sub_5895E0;
+	uint32_t battle_sub_589827;
+	uint32_t battle_sub_58AC59;
+	uint32_t battle_sub_58ACB9;
+	uint32_t ifrit_sub_595A05;
+	void (*engine_draw_sub_66A47E)(int);
+	int* battle_viewport_height;
+	uint32_t neo_bahamut_main_loop_48DA7A;
+	uint32_t neo_bahamut_effect_sub_490F2A;
+	uint32_t odin_gunge_effect_sub_4A4BE6;
+	uint32_t odin_gunge_effect_sub_4A3A2E;
+	uint32_t typhoon_effect_sub_4DB15F;
+	uint32_t typhoon_sub_4D6FF8;
+	uint32_t typhoon_effect_sub_4D7044;
+	uint32_t fat_chocobo_sub_5096F3;
+	uint32_t barret_limit_3_1_sub_4700F7;
+	uint32_t shadow_flare_draw_white_bg_57747E;
+	uint32_t credits_submit_draw_fade_quad_7AA89B;
+	uint32_t menu_submit_draw_fade_quad_6CD64E;
 };
 
 uint32_t ff7gl_load_group(uint32_t group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7/battle.cpp
+++ b/src/ff7/battle.cpp
@@ -22,6 +22,7 @@
 #include "../ff7.h"
 #include "../log.h"
 #include "../achievement.h"
+#include "widescreen.h"
 
 void magic_thread_start(void (*func)())
 {
@@ -56,4 +57,29 @@ void ff7_display_battle_action_text_sub_6D71FA(short command_id, short action_id
 	ff7_externals.battle_actor_data->action_index = action_id;
 
 	g_FF7SteamAchievements->unlockFirstLimitBreakAchievement(command_id, action_id);
+}
+
+void ifrit_first_wave_effect_widescreen_fix_sub_66A47E(int wave_data_pointer) {
+    if(aspect_ratio == AR_WIDESCREEN) {
+        int viewport_width_1_fix = ceil(255.f / game_width * wide_viewport_width) - 255;
+        *(short*)(wave_data_pointer + 8) += wide_viewport_x;
+        *(short*)(wave_data_pointer + 16) += wide_viewport_x + viewport_width_1_fix * 2;
+        *(short*)(wave_data_pointer + 24) += wide_viewport_x;
+        *(short*)(wave_data_pointer + 32) += wide_viewport_x + viewport_width_1_fix * 2;
+    }
+
+    ff7_externals.engine_draw_sub_66A47E(wave_data_pointer);
+}
+
+void ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E(int wave_data_pointer) {
+    if(aspect_ratio == AR_WIDESCREEN) {
+        int viewport_width_1_fix = ceil(255.f / game_width * wide_viewport_width) - 255;
+        int viewport_width_2_fix = ceil(65.f / game_width * wide_viewport_width) - 65;
+        *(short*)(wave_data_pointer + 8) += wide_viewport_x + viewport_width_1_fix * 2;
+        *(short*)(wave_data_pointer + 16) += wide_viewport_x + (viewport_width_1_fix + viewport_width_2_fix) * 2;
+        *(short*)(wave_data_pointer + 24) += wide_viewport_x + viewport_width_1_fix * 2;
+        *(short*)(wave_data_pointer + 32) += wide_viewport_x + (viewport_width_1_fix + viewport_width_2_fix) * 2;
+    }
+
+    ff7_externals.engine_draw_sub_66A47E(wave_data_pointer);
 }

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -26,6 +26,8 @@ void magic_thread_start(void (*func)());
 void ff7_load_battle_stage(int param_1, int battle_location_id, int **param_3);
 void ff7_battle_sub_5C7F94(int param_1, int param_2);
 void ff7_display_battle_action_text_sub_6D71FA(short command_id, short action_id);
+void ifrit_first_wave_effect_widescreen_fix_sub_66A47E(int wave_data_pointer);
+void ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E(int wave_data_pointer);
 
 // menu
 void ff7_menu_battle_end_sub_6C9543();
@@ -83,7 +85,10 @@ void field_layer4_pick_tiles(short x_offset, short y_offset);
 void ff7_field_clip_with_camera_range(vector2<short>* point);
 void ff7_field_layer3_clip_with_camera_range(field_trigger_header* trigger_header, vector2<short>* point);
 uint32_t field_open_flevel_siz();
+void field_init_scripted_bg_movement();
 void field_update_scripted_bg_movement();
+bool ff7_field_do_draw_3d_model(short x, short y);
+void ff7_field_set_fade_quad_size(int x, int y, int width, int height);
 
 // world
 void ff7_world_hook_init();

--- a/src/ff7/field.cpp
+++ b/src/ff7/field.cpp
@@ -32,6 +32,8 @@
 #include "../patch.h"
 #include "../sfx.h"
 #include "../movies.h"
+#include "../common.h"
+#include "widescreen.h"
 #include "defs.h"
 #include <set>
 #include <cmath>
@@ -118,6 +120,13 @@ int call_original_opcode_function(byte opcode)
 		ffnx_error("Initialization error: original opcode table empty in position %d\n", opcode);
 		return 0;
 	}
+}
+
+bool is_fieldmap_wide()
+{
+	field_trigger_header* field_triggers_header_ptr = *ff7_externals.field_triggers_header;
+	int cameraRange = field_triggers_header_ptr->camera_range.right - field_triggers_header_ptr->camera_range.left;
+	return aspect_ratio == AR_WIDESCREEN && cameraRange >= game_width / 2 + abs(wide_viewport_x);
 }
 
 // helper function initializes page dst, copies texture from src and applies
@@ -217,14 +226,10 @@ void field_layer1_pick_tiles(short bg_position_x, short bg_position_y)
 		uint32_t tile_index = (*ff7_externals.field_layer1_palette_sort)[i];
 		layer1_tiles[tile_index].field_1044 = 1;
 
-		if(layer1_tiles[tile_index].x < bg_position.x && layer1_tiles[tile_index].x > bg_position.x - 336
-			&& layer1_tiles[tile_index].y < bg_position.y && layer1_tiles[tile_index].y > bg_position.y - 256)
-		{
-			tile_position.x = initial_pos.x + field_bg_multiplier * layer1_tiles[tile_index].x;
-			tile_position.y = initial_pos.y + field_bg_multiplier * layer1_tiles[tile_index].y;
-			ff7_externals.add_page_tile(tile_position.x, tile_position.y, 0.9997, layer1_tiles[tile_index].u,
-										layer1_tiles[tile_index].v, layer1_tiles[tile_index].palette_index, layer1_tiles[tile_index].page);
-		}
+		tile_position.x = initial_pos.x + field_bg_multiplier * layer1_tiles[tile_index].x;
+		tile_position.y = initial_pos.y + field_bg_multiplier * layer1_tiles[tile_index].y;
+		ff7_externals.add_page_tile(tile_position.x, tile_position.y, 0.9997, layer1_tiles[tile_index].u,
+									layer1_tiles[tile_index].v, layer1_tiles[tile_index].palette_index, layer1_tiles[tile_index].page);
 	}
 }
 
@@ -274,66 +279,142 @@ void field_layer2_pick_tiles(short bg_position_x, short bg_position_y)
 	}
 }
 
+void field_layer3_shift_tile_position(vector2<float>* tile_position, vector2<float>* bg_position, int layer3_width, int layer3_height)
+{
+	const int left_offset = 352 + (is_fieldmap_wide() ? abs(wide_viewport_x) : 0);
+	const int right_offset = is_fieldmap_wide() ? abs(wide_viewport_x) : 0;
+	const int top_offset = 256 + (aspect_ratio == AR_WIDESCREEN ? 8 : 0);
+	const int bottom_offset = aspect_ratio == AR_WIDESCREEN ? 8 : 0;
+	const int half_width = is_fieldmap_wide() ? ceil(wide_viewport_width / 4) : 160;
+	const int half_height = aspect_ratio == AR_WIDESCREEN ? 120 : 112;
+
+	if(tile_position->x <= bg_position->x - left_offset || tile_position->x >= bg_position->x + right_offset)
+		tile_position->x += (tile_position->x >= bg_position->x - half_width) ? -layer3_width : layer3_width;
+
+	if(tile_position->y <= bg_position->y - top_offset || tile_position->y >= bg_position->y + bottom_offset)
+		tile_position->y += (tile_position->y >= bg_position->y - half_height) ? -layer3_height : layer3_height;
+}
+
 void field_layer3_pick_tiles(short bg_position_x, short bg_position_y)
 {
-	if(*ff7_externals.do_draw_layer3_CFFE3C)
+	if(!*ff7_externals.do_draw_layer3_CFFE3C)
+		return;
+
+	float z_value;
+	int field_bg_multiplier = *ff7_externals.field_bg_multiplier;
+	field_tile *layer3_tiles = *ff7_externals.field_layer3_tiles;
+	vector2<float> bg_position, initial_pos;
+
+	bg_position.x = bg_position_x;
+	bg_position.y = bg_position_y;
+	if(ff7_fps_limiter >= FF7_LIMITER_30FPS)
 	{
-		float z_value;
-		int field_bg_multiplier = *ff7_externals.field_bg_multiplier;
-		field_tile *layer3_tiles = *ff7_externals.field_layer3_tiles;
-		vector2<float> bg_position, initial_pos;
-
-		bg_position.x = bg_position_x;
-		bg_position.y = bg_position_y;
-		if(ff7_fps_limiter >= FF7_LIMITER_30FPS)
+		if(bg_layer3_pos.x != INVALID_VALUE && bg_layer3_pos.y != INVALID_VALUE)
 		{
-			if(bg_layer3_pos.x != INVALID_VALUE && bg_layer3_pos.y != INVALID_VALUE)
-			{
-				bg_position.x = bg_layer3_pos.x;
-				bg_position.y = bg_layer3_pos.y;
-			}
+			bg_position.x = bg_layer3_pos.x;
+			bg_position.y = bg_layer3_pos.y;
 		}
-
-		initial_pos.x = (320 - bg_position.x) * field_bg_multiplier;
-		initial_pos.y = ((ff7_center_fields ? 232 : 224) - bg_position.y) * field_bg_multiplier;
-		if(ff7_externals.modules_global_object->field_B0 < 0xFFF)
-			z_value = ff7_externals.field_layer_sub_623C0F(ff7_externals.field_camera_rotation_matrix_CFF3D8, ff7_externals.modules_global_object->field_B0, 0, 0);
-		else
-			z_value = 0.9998;
-
-		for(int i = 0; i < *ff7_externals.field_layer3_tiles_num; i++)
-		{
-			uint32_t tile_index = (*ff7_externals.field_layer3_palette_sort)[i];
-			vector2<float> tile_position;
-			tile_position.x = layer3_tiles[tile_index].x;
-			tile_position.y = layer3_tiles[tile_index].y;
-
-			if(tile_position.x <= bg_position.x - 352 || tile_position.x >= bg_position.x)
-			{
-				short width = (*ff7_externals.field_triggers_header)->bg3_width;
-				tile_position.x += (tile_position.x >= bg_position.x - 160) ? -width : width;
-			}
-			if(tile_position.y <= bg_position.y - 256 || tile_position.y >= bg_position.y)
-			{
-				short height = (*ff7_externals.field_triggers_header)->bg3_height;
-				tile_position.y += (tile_position.y >= bg_position.y - 112) ? -height : height;
-			}
-
-			char anim_group = layer3_tiles[tile_index].anim_group;
-			if(anim_group && !(ff7_externals.modules_global_object->background_sprite_layer[anim_group] & layer3_tiles[tile_index].anim_bitmask))
-				continue;
-
-			layer3_tiles[tile_index].field_1040 = 1;
-			tile_position.x = tile_position.x * field_bg_multiplier + initial_pos.x;
-			tile_position.y = tile_position.y * field_bg_multiplier + initial_pos.y;
-
-			uint32_t page = (layer3_tiles[tile_index].use_fx_page) ? layer3_tiles[tile_index].fx_page : layer3_tiles[tile_index].page;
-
-			ff7_externals.add_page_tile(tile_position.x, tile_position.y, z_value, layer3_tiles[tile_index].u,
-										layer3_tiles[tile_index].v, layer3_tiles[tile_index].palette_index, page);
-		}
-		*ff7_externals.field_layer3_flag_CFFE40 = 1;
 	}
+
+	initial_pos.x = (320 - bg_position.x) * field_bg_multiplier;
+	initial_pos.y = ((ff7_center_fields ? 232 : 224) - bg_position.y) * field_bg_multiplier;
+	if(ff7_externals.modules_global_object->field_B0 < 0xFFF)
+		z_value = ff7_externals.field_layer_sub_623C0F(ff7_externals.field_camera_rotation_matrix_CFF3D8, ff7_externals.modules_global_object->field_B0, 0, 0);
+	else
+		z_value = 0.9998;
+
+	const bool do_increase_height = aspect_ratio == AR_WIDESCREEN;
+	const bool do_increase_width = is_fieldmap_wide() && (*ff7_externals.field_triggers_header)->bg3_width < ceil(wide_viewport_width / 2);
+	const int layer3_width = (*ff7_externals.field_triggers_header)->bg3_width * (do_increase_width ? 2 : 1);
+	const int layer3_height = (*ff7_externals.field_triggers_header)->bg3_height * (do_increase_height ? 2 : 1);
+	const int left_offset = 352 + (is_fieldmap_wide() ? abs(wide_viewport_x) : 0);
+	const int right_offset = is_fieldmap_wide() ? abs(wide_viewport_x) : 0;
+	const int top_offset = 256 + (aspect_ratio == AR_WIDESCREEN ? 8 : 0);
+	const int bottom_offset = aspect_ratio == AR_WIDESCREEN ? 8 : 0;
+
+	for(int i = 0; i < *ff7_externals.field_layer3_tiles_num; i++)
+	{
+		uint32_t tile_index = (*ff7_externals.field_layer3_palette_sort)[i];
+		vector2<float> tile_position = {
+			static_cast<float>(layer3_tiles[tile_index].x),
+			static_cast<float>(layer3_tiles[tile_index].y)
+		};
+
+		field_layer3_shift_tile_position(&tile_position, &bg_position, layer3_width, layer3_height);
+
+		char anim_group = layer3_tiles[tile_index].anim_group;
+		if(tile_position.x <= bg_position.x - left_offset || tile_position.x >= bg_position.x + right_offset ||
+			tile_position.y <= bg_position.y - top_offset || tile_position.y >= bg_position.y + bottom_offset ||
+			(anim_group && !(ff7_externals.modules_global_object->background_sprite_layer[anim_group] & layer3_tiles[tile_index].anim_bitmask)))
+			continue;
+
+		layer3_tiles[tile_index].field_1040 = 1;
+		tile_position.x = tile_position.x * field_bg_multiplier + initial_pos.x;
+		tile_position.y = tile_position.y * field_bg_multiplier + initial_pos.y;
+
+		uint32_t page = (layer3_tiles[tile_index].use_fx_page) ? layer3_tiles[tile_index].fx_page : layer3_tiles[tile_index].page;
+
+		ff7_externals.add_page_tile(tile_position.x, tile_position.y, z_value, layer3_tiles[tile_index].u,
+									layer3_tiles[tile_index].v, layer3_tiles[tile_index].palette_index, page);
+	}
+
+	if(aspect_ratio == AR_WIDESCREEN)
+	{
+		// Apply repeat x-y for background layer 4 tiles
+		std::vector<vector2<int>> tile_offsets;
+		if(do_increase_height)
+			tile_offsets.push_back(vector2<int>{0, layer3_height /2});
+
+		if(do_increase_width){
+			tile_offsets.push_back(vector2<int>{layer3_width / 2, 0});
+			tile_offsets.push_back(vector2<int>{layer3_width / 2, layer3_height / 2});
+		}
+
+		for(vector2<int> tile_offset: tile_offsets)
+		{
+			for(int i = 0; i < *ff7_externals.field_layer3_tiles_num; i++)
+			{
+				uint32_t tile_index = (*ff7_externals.field_layer3_palette_sort)[i];
+				vector2<float> tile_position = {
+					static_cast<float>(layer3_tiles[tile_index].x + tile_offset.x),
+					static_cast<float>(layer3_tiles[tile_index].y + tile_offset.y)
+				};
+
+				field_layer3_shift_tile_position(&tile_position, &bg_position, layer3_width, layer3_height);
+
+				char anim_group = layer3_tiles[tile_index].anim_group;
+				if(tile_position.x <= bg_position.x - left_offset || tile_position.x >= bg_position.x + right_offset ||
+					tile_position.y <= bg_position.y - top_offset || tile_position.y >= bg_position.y + bottom_offset ||
+					(anim_group && !(ff7_externals.modules_global_object->background_sprite_layer[anim_group] & layer3_tiles[tile_index].anim_bitmask)))
+					continue;
+
+				layer3_tiles[tile_index].field_1040 = 1;
+				tile_position.x = tile_position.x * field_bg_multiplier + initial_pos.x;
+				tile_position.y = tile_position.y * field_bg_multiplier + initial_pos.y;
+
+				uint32_t page = (layer3_tiles[tile_index].use_fx_page) ? layer3_tiles[tile_index].fx_page : layer3_tiles[tile_index].page;
+
+				ff7_externals.add_page_tile(tile_position.x, tile_position.y, z_value, layer3_tiles[tile_index].u,
+											layer3_tiles[tile_index].v, layer3_tiles[tile_index].palette_index, page);
+			}
+		}
+	}
+	*ff7_externals.field_layer3_flag_CFFE40 = 1;
+}
+
+void field_layer4_shift_tile_position(vector2<float>* tile_position, vector2<float>* bg_position, int layer4_width, int layer4_height)
+{
+	const int left_offset = 352 + (is_fieldmap_wide() ? abs(wide_viewport_x) : 0);
+	const int right_offset = is_fieldmap_wide() ? abs(wide_viewport_x) : 0;
+	const int top_offset = 256 + (aspect_ratio == AR_WIDESCREEN ? 8 : 0);
+	const int bottom_offset = aspect_ratio == AR_WIDESCREEN ? 8 : 0;
+	const int half_width = is_fieldmap_wide() ? ceil(wide_viewport_width / 4) : 160;
+
+	if(tile_position->x <= bg_position->x - left_offset || tile_position->x >= bg_position->x + right_offset)
+		tile_position->x += (tile_position->x >= bg_position->x - half_width) ? -layer4_width : layer4_width;
+
+	if(tile_position->y <= bg_position->y - top_offset || tile_position->y >= bg_position->y + bottom_offset)
+		tile_position->y += (tile_position->y >= bg_position->y + bottom_offset) ? -layer4_height : layer4_height;
 }
 
 void field_layer4_pick_tiles(short bg_position_x, short bg_position_y)
@@ -359,26 +440,29 @@ void field_layer4_pick_tiles(short bg_position_x, short bg_position_y)
 		initial_pos.y = ((ff7_center_fields ? 232 : 224) - bg_position.y) * field_bg_multiplier;
 		float z_value = ff7_externals.field_layer_sub_623C0F(ff7_externals.field_camera_rotation_matrix_CFF3D8, ff7_externals.modules_global_object->field_AE, 0, 0);
 
+		const bool do_increase_height = aspect_ratio == AR_WIDESCREEN;
+		const bool do_increase_width = is_fieldmap_wide() && (*ff7_externals.field_triggers_header)->bg4_width < ceil(wide_viewport_width / 2);
+		const int layer4_width = (*ff7_externals.field_triggers_header)->bg4_width * (do_increase_width ? 2 : 1);
+		const int layer4_height = (*ff7_externals.field_triggers_header)->bg4_height * (do_increase_height ? 2 : 1);
+		const int left_offset = 352 + (is_fieldmap_wide() ? abs(wide_viewport_x) : 0);
+		const int right_offset = is_fieldmap_wide() ? abs(wide_viewport_x) : 0;
+		const int top_offset = 256 + (aspect_ratio == AR_WIDESCREEN ? 8 : 0);
+		const int bottom_offset = aspect_ratio == AR_WIDESCREEN ? 8 : 0;
+
 		for(int i = 0; i < *ff7_externals.field_layer4_tiles_num; i++)
 		{
 			uint32_t tile_index = (*ff7_externals.field_layer4_palette_sort)[i];
-			vector2<float> tile_position;
-			tile_position.x = layer4_tiles[tile_index].x;
-			tile_position.y = layer4_tiles[tile_index].y;
+			vector2<float> tile_position = {
+				static_cast<float>(layer4_tiles[tile_index].x),
+				static_cast<float>(layer4_tiles[tile_index].y)
+			};
 
-			if(tile_position.x <= bg_position.x - 352 || tile_position.x >= bg_position.x)
-			{
-				short width = (*ff7_externals.field_triggers_header)->bg4_width;
-				tile_position.x += (tile_position.x >= bg_position.x - 160) ? -width : width;
-			}
-			if(tile_position.y <= bg_position.y - 256 || tile_position.y >= bg_position.y)
-			{
-				short height = (*ff7_externals.field_triggers_header)->bg4_height;
-				tile_position.y += (tile_position.y >= bg_position.y) ? -height : height;
-			}
+			field_layer4_shift_tile_position(&tile_position, &bg_position, layer4_width, layer4_height);
 
 			char anim_group = layer4_tiles[tile_index].anim_group;
-			if(tile_position.x < bg_position.x - 352 || tile_position.x > bg_position.x || anim_group && !(ff7_externals.modules_global_object->background_sprite_layer[anim_group] & layer4_tiles[tile_index].anim_bitmask))
+			if(tile_position.x <= bg_position.x - left_offset || tile_position.x >= bg_position.x + right_offset ||
+				tile_position.y <= bg_position.y - top_offset || tile_position.y >= bg_position.y + bottom_offset ||
+				(anim_group && !(ff7_externals.modules_global_object->background_sprite_layer[anim_group] & layer4_tiles[tile_index].anim_bitmask)))
 				continue;
 
 			layer4_tiles[tile_index].field_1040 = 1;
@@ -392,6 +476,49 @@ void field_layer4_pick_tiles(short bg_position_x, short bg_position_y)
 											layer4_tiles[tile_index].v, layer4_tiles[tile_index].palette_index, page);
 			}
 		}
+
+		if(aspect_ratio == AR_WIDESCREEN)
+		{
+			// Apply repeat x-y for background layer 4 tiles
+			std::vector<vector2<int>> tile_offsets;
+			if(do_increase_height)
+				tile_offsets.push_back(vector2<int>{0, layer4_height /2});
+
+			if(do_increase_width){
+				tile_offsets.push_back(vector2<int>{layer4_width / 2, 0});
+				tile_offsets.push_back(vector2<int>{layer4_width / 2, layer4_height / 2});
+			}
+			for(vector2<int> tile_offset: tile_offsets){
+				for(int i = 0; i < *ff7_externals.field_layer4_tiles_num; i++)
+				{
+					uint32_t tile_index = (*ff7_externals.field_layer4_palette_sort)[i];
+					vector2<float> tile_position = {
+						static_cast<float>(layer4_tiles[tile_index].x + tile_offset.x),
+						static_cast<float>(layer4_tiles[tile_index].y + tile_offset.y)
+					};
+
+					field_layer4_shift_tile_position(&tile_position, &bg_position, layer4_width, layer4_height);
+
+					char anim_group = layer4_tiles[tile_index].anim_group;
+					if(tile_position.x <= bg_position.x - left_offset || tile_position.x >= bg_position.x + right_offset ||
+						tile_position.y <= bg_position.y - top_offset || tile_position.y >= bg_position.y + bottom_offset ||
+						(anim_group && !(ff7_externals.modules_global_object->background_sprite_layer[anim_group] & layer4_tiles[tile_index].anim_bitmask)))
+						continue;
+
+					layer4_tiles[tile_index].field_1040 = 1;
+					tile_position.x = tile_position.x * field_bg_multiplier + initial_pos.x;
+					tile_position.y = tile_position.y * field_bg_multiplier + initial_pos.y;
+
+					if(!*ff7_externals.field_layer_CFF1D8 || layer4_tiles[tile_index].palette_index != (*ff7_externals.field_palette_D00088) + 1)
+					{
+						uint32_t page = (layer4_tiles[tile_index].use_fx_page) ? layer4_tiles[tile_index].fx_page : layer4_tiles[tile_index].page;
+						ff7_externals.add_page_tile(tile_position.x, tile_position.y, z_value, layer4_tiles[tile_index].u,
+													layer4_tiles[tile_index].v, layer4_tiles[tile_index].palette_index, page);
+					}
+				}
+			}
+		}
+
 		*ff7_externals.field_layer4_flag_CFFEA8 = 1;
 	}
 }
@@ -433,38 +560,74 @@ void ff7_field_submit_draw_cursor(field_arrow_graphics_data* arrow_data)
 	ff7_externals.field_submit_draw_arrow_63A171(arrow_data);
 }
 
+bool ff7_field_do_draw_3d_model(short x, short y)
+{
+	if(*ff7_externals.field_bg_flag_CC15E4)
+		return 1;
+	int left_offset_x = 40 + (aspect_ratio == AR_WIDESCREEN ? abs(wide_viewport_x) - 50 : 0);
+	int right_offset_x = 400 + (aspect_ratio == AR_WIDESCREEN ? abs(wide_viewport_x) - 50 : 0);
+	return x > ff7_externals.field_viewport_xy_CFF204->x - left_offset_x && x < ff7_externals.field_viewport_xy_CFF204->x + right_offset_x &&
+		y > ff7_externals.field_viewport_xy_CFF204->y - 120 && y < ff7_externals.field_viewport_xy_CFF204->y + 460;
+}
+
+void ff7_field_set_fade_quad_size(int x, int y, int width, int height)
+{
+	if(aspect_ratio == AR_WIDESCREEN)
+	{
+		x -= abs(wide_viewport_x);
+		y -= ff7_center_fields ? 16 : 0;
+		width += (wide_viewport_width - game_width);
+		height += 32;
+	}
+	ff7_externals.field_sub_63AC3F(x, y, width, height);
+}
+
 void field_clip_with_camera_range_float(vector2<float>* point)
 {
 	field_trigger_header* field_triggers_header_ptr = *ff7_externals.field_triggers_header;
-	if (point->x > field_triggers_header_ptr->camera_range.right - 160)
-		point->x = field_triggers_header_ptr->camera_range.right - 160;
-	if (point->x < field_triggers_header_ptr->camera_range.left + 160)
-		point->x = field_triggers_header_ptr->camera_range.left + 160;
-	if (point->y > field_triggers_header_ptr->camera_range.top - 120)
-		point->y = field_triggers_header_ptr->camera_range.top - 120;
-	if (point->y < field_triggers_header_ptr->camera_range.bottom + 120)
-		point->y = field_triggers_header_ptr->camera_range.bottom + 120;
+	float half_width = 160;
+	if(is_fieldmap_wide())
+	{
+		int cameraRange = field_triggers_header_ptr->camera_range.right - field_triggers_header_ptr->camera_range.left;
+		half_width = ceil(wide_viewport_width / 4.f);
+	}
+
+	if (point->x > field_triggers_header_ptr->camera_range.right - half_width)
+		point->x = field_triggers_header_ptr->camera_range.right - half_width;
+	if (point->x < field_triggers_header_ptr->camera_range.left + half_width)
+		point->x = field_triggers_header_ptr->camera_range.left + half_width;
+	if (point->y > field_triggers_header_ptr->camera_range.bottom - 120)
+		point->y = field_triggers_header_ptr->camera_range.bottom - 120;
+	if (point->y < field_triggers_header_ptr->camera_range.top + 120)
+		point->y = field_triggers_header_ptr->camera_range.top + 120;
 }
 
 void float_sub_643628(field_trigger_header *trigger_header, vector2<float> *delta_position)
 {
+	float half_width = 160;
+	if(is_fieldmap_wide())
+	{
+		int cameraRange = trigger_header->camera_range.right - trigger_header->camera_range.left;
+		half_width = ceil(wide_viewport_width / 4.f);
+	}
+
 	if (trigger_header->field_14[0] == 1)
 	{
-		float diff_top_bottom = trigger_header->camera_range.top - 120 - (trigger_header->camera_range.bottom + 120);
-		float diff_right_left = trigger_header->camera_range.right - 160 - (trigger_header->camera_range.left + 160);
-		float temp_1 = -(diff_top_bottom * (trigger_header->camera_range.bottom + 120 - delta_position->y) + diff_right_left * (trigger_header->camera_range.left + 160 - delta_position->x));
+		float diff_top_bottom = trigger_header->camera_range.bottom - 120 - (trigger_header->camera_range.top + 120);
+		float diff_right_left = trigger_header->camera_range.right - half_width - (trigger_header->camera_range.left + half_width);
+		float temp_1 = -(diff_top_bottom * (trigger_header->camera_range.top + 120 - delta_position->y) + diff_right_left * (trigger_header->camera_range.left + half_width - delta_position->x));
 		float temp_square_value = (diff_top_bottom * diff_top_bottom + diff_right_left * diff_right_left) / 256.f;
-		delta_position->x = ((diff_right_left * temp_1 / temp_square_value) / 256.f) + trigger_header->camera_range.left + 160;
-		delta_position->y = ((diff_top_bottom * temp_1 / temp_square_value) / 256.f) + trigger_header->camera_range.bottom + 120;
+		delta_position->x = ((diff_right_left * temp_1 / temp_square_value) / 256.f) + trigger_header->camera_range.left + half_width;
+		delta_position->y = ((diff_top_bottom * temp_1 / temp_square_value) / 256.f) + trigger_header->camera_range.top + 120;
 	}
 	if (trigger_header->field_14[0] == 2)
 	{
-		float diff_bottom_top = trigger_header->camera_range.bottom + 120 - (trigger_header->camera_range.top - 120);
-		float diff_right_left = trigger_header->camera_range.right - 160 - (trigger_header->camera_range.left + 160);
-		float temp_1 = -((diff_bottom_top) * (trigger_header->camera_range.top - 120 - delta_position->y) + diff_right_left * (trigger_header->camera_range.left + 160 - delta_position->x));
+		float diff_bottom_top = trigger_header->camera_range.top + 120 - (trigger_header->camera_range.bottom - 120);
+		float diff_right_left = trigger_header->camera_range.right - half_width - (trigger_header->camera_range.left + half_width);
+		float temp_1 = -((diff_bottom_top) * (trigger_header->camera_range.bottom - 120 - delta_position->y) + diff_right_left * (trigger_header->camera_range.left + half_width - delta_position->x));
 		float temp_square_value = (diff_bottom_top * diff_bottom_top + diff_right_left * diff_right_left) / 256.f;
-		delta_position->x = ((diff_right_left * temp_1 / temp_square_value) / 256.f) + trigger_header->camera_range.left + 160;
-		delta_position->y = ((diff_bottom_top * temp_1 / temp_square_value) / 256.f) + trigger_header->camera_range.top - 120;
+		delta_position->x = ((diff_right_left * temp_1 / temp_square_value) / 256.f) + trigger_header->camera_range.left + half_width;
+		delta_position->y = ((diff_bottom_top * temp_1 / temp_square_value) / 256.f) + trigger_header->camera_range.bottom - 120;
 	}
 }
 
@@ -474,6 +637,26 @@ void ff7_field_clip_with_camera_range(vector2<short>* point)
 	field_clip_with_camera_range_float(&proxy_point);
 	point->x = round(proxy_point.x);
 	point->y = round(proxy_point.y);
+}
+
+void ff7_field_layer3_clip_with_camera_range(field_trigger_header* trigger_header, vector2<short>* point)
+{
+	vector2<float> proxy_point = {(float)point->x, (float)point->y};
+	float_sub_643628(*ff7_externals.field_triggers_header, &proxy_point);
+	point->x = round(proxy_point.x);
+	point->y = round(proxy_point.y);
+}
+
+void field_widescreen_width_clip_with_camera_range(vector2<short>* point)
+{
+	// This only clips backgrounds which width is enought to fill the whole screen in 16:9
+	field_trigger_header* field_triggers_header_ptr = *ff7_externals.field_triggers_header;
+	float half_width = ceil(wide_viewport_width / 4);
+
+	if (point->x > field_triggers_header_ptr->camera_range.right - half_width)
+		point->x = field_triggers_header_ptr->camera_range.right - half_width;
+	if (point->x < field_triggers_header_ptr->camera_range.left + half_width)
+		point->x = field_triggers_header_ptr->camera_range.left + half_width;
 }
 
 void engine_set_game_engine_world_coord_float_661B23(int field_world_x, int field_world_y)
@@ -579,6 +762,75 @@ float field_get_smooth_interpolated_value_float(float initial_value, float final
 {
 	float delta = final_value - initial_value;
 	return initial_value + delta * (0.5f + sin(-M_PI/2.f + M_PI * (step_idx / (float)n_steps)) / 2.f);
+}
+
+void field_init_scripted_bg_movement()
+{
+	vector2<short> world_pos;
+	if ( !ff7_externals.modules_global_object->world_move_status )
+	{
+		switch ( ff7_externals.modules_global_object->world_move_mode )
+		{
+		case 0:
+			*ff7_externals.field_bg_flag_CC15E4 = 0;
+			*ff7_externals.field_curr_delta_world_pos_x = 0;
+			*ff7_externals.field_curr_delta_world_pos_y = 0;
+			ff7_externals.modules_global_object->world_move_status = 2;
+			break;
+		case 1:
+			*ff7_externals.field_bg_flag_CC15E4 = 1;
+			ff7_externals.modules_global_object->world_move_status = 1;
+			break;
+		case 2:
+		case 3:
+			*ff7_externals.field_bg_flag_CC15E4 = 1;
+			*ff7_externals.scripted_world_move_n_steps = ff7_externals.modules_global_object->field_20;
+			*ff7_externals.scripted_world_move_step_index = 0;
+			world_pos = {*ff7_externals.field_curr_delta_world_pos_x, *ff7_externals.field_curr_delta_world_pos_y};
+
+			if(is_fieldmap_wide())
+				ff7_field_clip_with_camera_range(&world_pos);
+
+			*ff7_externals.scripted_world_initial_pos_x = world_pos.x;
+			*ff7_externals.scripted_world_initial_pos_y = world_pos.y;
+			ff7_externals.modules_global_object->world_move_status = 1;
+			break;
+		case 4:
+			*ff7_externals.field_bg_flag_CC15E4 = 1;
+
+			world_pos = {ff7_externals.modules_global_object->field_A, ff7_externals.modules_global_object->field_C};
+			if(is_fieldmap_wide())
+				field_widescreen_width_clip_with_camera_range(&world_pos);
+
+			*ff7_externals.field_curr_delta_world_pos_x = world_pos.x;
+			*ff7_externals.field_curr_delta_world_pos_y = world_pos.y;
+			ff7_externals.modules_global_object->world_move_status = 2;
+			break;
+		case 5:
+		case 6:
+			*ff7_externals.field_bg_flag_CC15E4 = 1;
+			*ff7_externals.scripted_world_move_n_steps = ff7_externals.modules_global_object->field_20;
+			*ff7_externals.scripted_world_move_step_index = 0;
+
+			world_pos = {*ff7_externals.field_curr_delta_world_pos_x, *ff7_externals.field_curr_delta_world_pos_y};
+			if(is_fieldmap_wide())
+				field_widescreen_width_clip_with_camera_range(&world_pos);
+
+			*ff7_externals.scripted_world_initial_pos_x = world_pos.x;
+			*ff7_externals.scripted_world_initial_pos_y = world_pos.y;
+
+			world_pos = {ff7_externals.modules_global_object->field_A, ff7_externals.modules_global_object->field_C};
+			if(is_fieldmap_wide())
+				field_widescreen_width_clip_with_camera_range(&world_pos);
+
+			*ff7_externals.scripted_world_final_pos_x = world_pos.x;
+			*ff7_externals.scripted_world_final_pos_y = world_pos.y;
+			ff7_externals.modules_global_object->world_move_status = 1;
+			break;
+		default:
+			return;
+		}
+	}
 }
 
 void field_update_scripted_bg_movement()
@@ -763,10 +1015,13 @@ void compute_pointer_hand_position(vector2<float> field_3d_world_coord, int mode
 	cursor_position.x = field_3d_world_coord.x + view_multiplier * cursor_delta_pos.x + ff7_externals.field_curr_half_viewport_width_height_CFF1FC->x;
 	cursor_position.y = field_3d_world_coord.y + view_multiplier * (cursor_delta_pos.y - 8) + ff7_externals.field_curr_half_viewport_width_height_CFF1FC->y;
 
-	if(cursor_position.x > ff7_externals.field_viewport_xy_CFF204->x + 320 * view_multiplier)
-		cursor_position.x = ff7_externals.field_viewport_xy_CFF204->x + 320 * view_multiplier;
-	if(cursor_position.x < ff7_externals.field_viewport_xy_CFF204->x)
-		cursor_position.x = ff7_externals.field_viewport_xy_CFF204->x;
+
+	int viewport_x = is_fieldmap_wide() ? wide_viewport_x : ff7_externals.field_viewport_xy_CFF204->x;
+	int viewport_width = is_fieldmap_wide() ? wide_viewport_width / 2 : 320;
+	if(cursor_position.x > viewport_x + viewport_width * view_multiplier)
+		cursor_position.x = viewport_x + viewport_width * view_multiplier;
+	if(cursor_position.x < viewport_x)
+		cursor_position.x = viewport_x;
 	if(cursor_position.y > ff7_externals.field_viewport_xy_CFF204->y + 224 * view_multiplier)
 		cursor_position.y = ff7_externals.field_viewport_xy_CFF204->y + 224 * view_multiplier;
 	if(cursor_position.y < ff7_externals.field_viewport_xy_CFF204->y - 32)

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -1,0 +1,176 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 myst6re                                            //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//    Copyright (C) 2020 John Pritchard                                     //
+//    Copyright (C) 2022 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2022 Tang-Tang Zhou                                     //
+//    Copyright (C) 2022 Cosmos                                             //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#include "widescreen.h"
+#include "../patch.h"
+#include "../ff7.h"
+#include "cmath"
+
+int viewport_width_plus_x_widescreen_fix = 750;
+int swirl_framebuffer_offset_x_widescreen_fix = 106;
+int swirl_framebuffer_offset_y_widescreen_fix = 64;
+
+void ff7_widescreen_hook_init() {
+    // Field fix
+    replace_function((uint32_t)ff7_externals.field_clip_with_camera_range_6438F6, ff7_field_clip_with_camera_range);
+    replace_function(ff7_externals.field_layer3_clip_with_camera_range_643628, ff7_field_layer3_clip_with_camera_range);
+    replace_function(ff7_externals.field_culling_model_639252, ff7_field_do_draw_3d_model);
+    replace_call_function(ff7_externals.field_sub_63AC66 + 0xD5, ff7_field_set_fade_quad_size);
+    patch_code_dword(ff7_externals.field_submit_draw_pointer_hand_60D572 + 0x6A, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.field_submit_draw_pointer_hand_60D572 + 0x80, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.field_submit_draw_pointer_hand_60D572 + 0x94, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.field_submit_draw_pointer_hand_60D572 + 0x9C, (uint32_t)&wide_viewport_x);
+    patch_code_int(ff7_externals.field_submit_draw_pointer_hand_60D572 + 0x64, wide_viewport_width / 2);
+    patch_code_int(ff7_externals.field_submit_draw_pointer_hand_60D572 + 0x7A, wide_viewport_width / 2);
+    memset_code(ff7_externals.field_submit_draw_pointer_hand_60D572 + 0x39, 0x90, 12); // Remove useless culling cursor
+    patch_code_int(ff7_externals.field_init_viewport_values + 0xBE, wide_viewport_width + wide_viewport_x - 60);
+    patch_code_int(ff7_externals.field_init_viewport_values + 0xC8, 18);
+
+    // Swirl fix
+    patch_code_dword(ff7_externals.swirl_loop_sub_4026D4 + 0x335, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.swirl_enter_sub_401810 + 0x21, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.swirl_enter_40164E + 0xEE, (uint32_t)&swirl_framebuffer_offset_x_widescreen_fix);
+    patch_code_dword(ff7_externals.swirl_enter_40164E + 0x112, (uint32_t)&swirl_framebuffer_offset_x_widescreen_fix);
+    patch_code_dword(ff7_externals.swirl_enter_40164E + 0xFB, (uint32_t)&swirl_framebuffer_offset_y_widescreen_fix);
+    patch_code_dword(ff7_externals.swirl_enter_40164E + 0x11F, (uint32_t)&swirl_framebuffer_offset_y_widescreen_fix);
+    patch_code_int(ff7_externals.swirl_enter_40164E + 0xE8, 85);
+
+    // Battle fix
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x4B, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x68, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x8B, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0xB4, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x105, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x122, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x141, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x16A, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x19F, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x1BB, (uint32_t)&wide_viewport_x);
+    patch_code_int(ff7_externals.battle_enter + 0x1E8, 0);
+    patch_code_int(ff7_externals.battle_enter + 0x21A, wide_viewport_height);
+    patch_code_dword(ff7_externals.battle_enter + 0x229, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.battle_enter + 0x22F, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_draw_quad_5BD473 + 0xDA, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_draw_quad_5BD473 + 0x112, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_58ACB9 + 0x55, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.battle_sub_58ACB9 + 0x65, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x23F, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x24C, (uint32_t)&wide_viewport_x);
+    patch_code_int(ff7_externals.shadow_flare_draw_white_bg_57747E + 0x18, wide_viewport_x);
+    patch_code_int(ff7_externals.shadow_flare_draw_white_bg_57747E + 0x1F, wide_viewport_width / 2);
+    // Battle summon fix
+    replace_call_function(ff7_externals.ifrit_sub_595A05 + 0x930, ifrit_first_wave_effect_widescreen_fix_sub_66A47E);
+    replace_call_function(ff7_externals.ifrit_sub_595A05 + 0xAEC, ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E);
+    replace_call_function(ff7_externals.ifrit_sub_595A05 + 0xCC0, ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E);
+    patch_code_int(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x58, wide_viewport_width / 4);
+    patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x5D, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x6A, (uint32_t)&wide_viewport_x);
+    patch_code_int(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x88, wide_viewport_width / 4);
+    patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x1A2, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.neo_bahamut_effect_sub_490F2A + 0x1AF, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x140, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x15B, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x19B, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x1D1, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x20E, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x243, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x28A, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x2C0, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x2FC, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.run_bahamut_neo_main_48C2A1 + 0x332, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A3A2E + 0x38, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A3A2E + 0x53, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A4BE6 + 0x36, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.odin_gunge_effect_sub_4A4BE6 + 0x51, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.typhoon_effect_sub_4D7044 + 0x1B, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.typhoon_effect_sub_4D7044 + 0x36, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.typhoon_effect_sub_4DB15F + 0x22, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.typhoon_effect_sub_4DB15F + 0x3D, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.barret_limit_3_1_sub_4700F7 + 0x1B, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.barret_limit_3_1_sub_4700F7 + 0x36, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.fat_chocobo_sub_5096F3 + 0x4A, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.fat_chocobo_sub_5096F3 + 0x5F, (uint32_t)&wide_viewport_width);
+    // Battle fading animation fix
+    patch_code_short(ff7_externals.battle_sub_5BCF9D + 0x3A, 30);
+    patch_code_byte(ff7_externals.battle_sub_5BCF9D + 0x69, 120);
+    patch_code_byte(ff7_externals.battle_sub_5BD050 + 0x46, 72);
+    patch_code_byte(ff7_externals.battle_sub_5BD050 + 0xA5, 72);
+    patch_code_byte(ff7_externals.battle_sub_5BD050 + 0x87, 48);
+    patch_code_byte(ff7_externals.battle_sub_5BD050 + 0xDC, 48);
+    patch_code_byte(ff7_externals.battle_sub_5BD050 + 0x100, 48);
+    patch_code_byte(ff7_externals.battle_sub_5BD050 + 0x15C, 48);
+    patch_code_byte(ff7_externals.battle_sub_5BD050 + 0x186, 48);
+
+    // Worldmap fix
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x12, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x1A3, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x2BE, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x331, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x4E8, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_draw_fade_quad_75551A + 0x54A, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_culling_bg_meshes_75F263 + 0xE, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.world_culling_bg_meshes_75F263 + 0x20, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_culling_bg_meshes_75F263 + 0x26, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.world_submit_draw_bg_meshes_75F68C + 0xAE, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.world_submit_draw_bg_meshes_75F68C + 0xB6, (uint32_t)&wide_viewport_x);
+    memset_code(ff7_externals.world_sub_751EFC + 0xC89, 0x90, 6);
+
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x174, -wide_viewport_width / 4 - 20);
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x1D1, wide_viewport_width / 4 + 20);
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x22E, -wide_viewport_width / 4 - 20);
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x282, wide_viewport_width / 4 + 20);
+    patch_code_byte(ff7_externals.world_compute_skybox_data_754100 + 0x180, 44);
+    patch_code_byte(ff7_externals.world_compute_skybox_data_754100 + 0x1DD, 44);
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x237, 20);
+    patch_code_short(ff7_externals.world_compute_skybox_data_754100 + 0x28B, 20);
+    patch_code_short(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x132, -256);
+    patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x144, 256);
+    patch_code_byte(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x15C, 0);
+    patch_code_short(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x16D, 256);
+    patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x2DC, 0);
+    patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x40F, 0);
+    patch_code_dword(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x5A5, (uint32_t)&wide_viewport_x); // Meteor avoid culling
+    patch_code_int(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 + 0x5B5, wide_viewport_width / 2); // Meteor avoid culling
+
+    // Gameover fix
+    patch_code_int(ff7_externals.enter_gameover + 0xA4, wide_viewport_x);
+    patch_code_int(ff7_externals.enter_gameover + 0xB8, wide_viewport_width);
+
+    // CDCheck fix
+    patch_code_int(ff7_externals.cdcheck_enter_sub + 0xB9, wide_viewport_x);
+    patch_code_int(ff7_externals.cdcheck_enter_sub + 0xCD, wide_viewport_width);
+
+    // Credits fix
+    patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0x99, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0xE6, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0x133, (uint32_t)&viewport_width_plus_x_widescreen_fix);
+    patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0x180, (uint32_t)&viewport_width_plus_x_widescreen_fix);
+
+    // Menu, endbattle menu, ... fixes
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x50, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0xA8, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x105, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x163, (uint32_t)&wide_viewport_x);
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x111, (uint32_t)&wide_viewport_width);
+    patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x16F, (uint32_t)&wide_viewport_width);
+}

--- a/src/ff7/widescreen.h
+++ b/src/ff7/widescreen.h
@@ -6,6 +6,8 @@
 //    Copyright (C) 2020 Chris Rizzitello                                   //
 //    Copyright (C) 2020 John Pritchard                                     //
 //    Copyright (C) 2022 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2022 Tang-Tang Zhou                                     //
+//    Copyright (C) 2022 Cosmos                                             //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //
@@ -21,52 +23,8 @@
 
 #pragma once
 
-#include "log.h"
+int wide_viewport_x = -106;
+int wide_viewport_width = 854;
+int wide_viewport_height = 480;
 
-uint32_t replace_function(uint32_t offset, void *func);
-// Can also unreplace a call_function
-void unreplace_function(uint32_t func);
-// Replace again a function unreplaced before
-void rereplace_function(uint32_t func);
-void unreplace_functions();
-
-void replace_call(uint32_t offset, void *func);
-uint32_t replace_call_function(uint32_t offset, void* func);
-
-uint32_t get_relative_call(uint32_t base, uint32_t offset);
-uint32_t get_absolute_value(uint32_t base, uint32_t offset);
-void patch_code_byte(uint32_t offset, unsigned char r);
-void patch_code_word(uint32_t offset, WORD r);
-void patch_code_short(uint32_t offset, short r);
-void patch_code_dword(uint32_t offset, DWORD r);
-void patch_code_int(uint32_t offset, int r);
-void patch_code_uint(uint32_t offset, uint32_t r);
-void patch_code_float(uint32_t offset, float r);
-void patch_code_double(uint32_t offset, double r);
-
-template<typename T>
-void patch_multiply_code(uint32_t offset, int multiplier)
-{
-	DWORD dummy;
-
-	VirtualProtect((void *)offset, sizeof(T), PAGE_EXECUTE_READWRITE, &dummy);
-
-	*(T *)offset = (*(T *)offset) * (T)multiplier;
-
-    // TODO Add assertion
-}
-
-template<typename T>
-void patch_divide_code(uint32_t offset, int multiplier)
-{
-	DWORD dummy;
-
-	VirtualProtect((void *)offset, sizeof(T), PAGE_EXECUTE_READWRITE, &dummy);
-
-	*(T *)offset = (*(T *)offset) / (T)multiplier;
-
-    // TODO Add assertion
-}
-
-void memcpy_code(uint32_t offset, void *data, uint32_t size);
-void memset_code(uint32_t offset, uint32_t val, uint32_t size);
+void ff7_widescreen_hook_init();

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -253,6 +253,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.menu_sub_6CBD43 = get_relative_call(ff7_externals.menu_sub_6CDA83, 0xAF);
 	ff7_externals.menu_sub_701EE4 = get_relative_call(ff7_externals.menu_sub_6CBD43, 0x7);
 	ff7_externals.phs_menu_sub = get_relative_call(ff7_externals.menu_sub_701EE4, 0xE3);
+	ff7_externals.menu_battle_end_sub_6C9543 = get_relative_call(ff7_externals.menu_sub_6CDA83, 0x20);
 
 	switch(version)
 	{
@@ -524,6 +525,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.on_gameover_exit = ff7_externals.exit_gameover + 0x21;
 
 	ff7_externals.enter_field = get_absolute_value(main_loop, 0x90D);
+	ff7_externals.field_init_viewport_values = get_relative_call(main_init_loop, 0x375);
 	ff7_externals.field_loop_sub_63C17F = get_relative_call(field_main_loop, 0x59);
 	ff7_externals.field_update_models_positions = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x5DD);
 	ff7_externals.field_update_single_model_position = (int (*)(int16_t))get_relative_call(ff7_externals.field_update_models_positions, 0x8BC);
@@ -541,6 +543,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.sub_40B27B = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0xEE);
 	ff7_externals.word_CC0DD4 = (WORD*)get_absolute_value(ff7_externals.enter_field, 0x124);
 	ff7_externals.word_CC1638 = (WORD*)get_absolute_value(ff7_externals.sub_40B27B, 0x25);
+	ff7_externals.field_init_scripted_bg_movement = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x182);
 	ff7_externals.field_update_scripted_bg_movement = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x187);
 	ff7_externals.field_update_background_positions = (void (*)())get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x1A6);
 	ff7_externals.compute_and_submit_draw_gateways_arrows_64DA3B = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x62C);
@@ -955,8 +958,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.run_phoenix_main_loop_516297 = get_absolute_value(run_summon_phoenix_sub_515127, 0xB2);
 	ff7_externals.run_phoenix_movement_518AFF = get_absolute_value(ff7_externals.run_phoenix_main_loop_516297, 0x310);
 	ff7_externals.run_phoenix_camera_515238 = get_absolute_value(run_summon_phoenix_camera_handler_5151F8, 0x5);
-	uint32_t run_bahamut_neo_main_48C2A1 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x377);
-	uint32_t run_bahamut_neo_sub_48C60B = get_relative_call(run_bahamut_neo_main_48C2A1, 0x35D);
+	ff7_externals.run_bahamut_neo_main_48C2A1 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x377);
+	uint32_t run_bahamut_neo_sub_48C60B = get_relative_call(ff7_externals.run_bahamut_neo_main_48C2A1, 0x35D);
 	uint32_t run_bahamut_neo_camera_handler_48C71D = get_relative_call(run_bahamut_neo_sub_48C60B, 0xD2);
 	ff7_externals.run_bahamut_neo_movement_48D7BC = get_absolute_value(run_bahamut_neo_sub_48C60B, 0xAA);
 	ff7_externals.run_bahamut_neo_camera_48C75D = get_absolute_value(run_bahamut_neo_camera_handler_48C71D, 0x5);
@@ -1128,10 +1131,19 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.is_wait_frames_zero_E39BC0 = (int*)get_absolute_value(ff7_externals.run_world_event_scripts_system_operations, 0xD46);
 	ff7_externals.world_sub_75A1C6 = get_relative_call(ff7_externals.world_init_variables_74E1E9, 0x3A);
 	ff7_externals.world_sub_75A5D5 = get_relative_call(ff7_externals.world_sub_75A1C6, 0x61);
+	ff7_externals.world_draw_fade_quad_75551A = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x554);
+	ff7_externals.world_sub_75079D = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x421);
+	ff7_externals.world_sub_751EFC = get_relative_call(ff7_externals.world_sub_75079D, 0x1FB);
+	ff7_externals.world_culling_bg_meshes_75F263 = get_relative_call(ff7_externals.world_sub_751EFC, 0x7C6);
+	ff7_externals.world_submit_draw_bg_meshes_75F68C = get_relative_call(ff7_externals.world_sub_751EFC, 0x7FD);
+	ff7_externals.world_compute_skybox_data_754100 = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x537);
+	ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x547);
 
 	// Swirl externals
 	ff7_externals.swirl_main_loop = swirl_main_loop;
 	ff7_externals.swirl_loop_sub_4026D4 = get_relative_call(swirl_main_loop, 0xC9);
+	ff7_externals.swirl_enter_40164E = get_absolute_value(main_loop, 0x254);
+	ff7_externals.swirl_enter_sub_401810 = get_relative_call(ff7_externals.swirl_enter_40164E, 0x160);
 
 	// --------------------------------
 
@@ -1158,12 +1170,46 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.g_active_actor_id = (byte*)get_absolute_value(ff7_externals.display_battle_action_text_42782A, 0x52);
 	// --------------------------------
 
+	// Widescreen
+	ff7_externals.field_culling_model_639252 = get_relative_call(ff7_externals.field_animate_3d_models_6392BB, 0x203);
+	ff7_externals.field_sub_63AC66 = get_relative_call(ff7_externals.sub_60DF96, 0xB0);
+	ff7_externals.field_sub_63AC3F = (void(*)(int, int, int, int))get_relative_call(ff7_externals.field_sub_63AC66, 0xD5);
+
+	ff7_externals.battle_draw_quad_5BD473 = get_relative_call(ff7_externals.battle_boss_death_call_5BD436, 0x16);
+	ff7_externals.battle_sub_5895E0 = ff7_externals.enemy_atk_effects_fn_table[119];
+	ff7_externals.battle_sub_589827 = get_relative_call(ff7_externals.battle_sub_5895E0, 0x10D);
+	ff7_externals.battle_sub_58AC59 = get_absolute_value(ff7_externals.battle_sub_589827, 0x64);
+	ff7_externals.battle_sub_58ACB9 = get_relative_call(ff7_externals.battle_sub_58AC59, 0x22);
+	ff7_externals.ifrit_sub_595A05 = get_absolute_value(run_ifrit_main_loop_593A95, 0x51B);
+	ff7_externals.engine_draw_sub_66A47E = (void(*)(int))get_relative_call(ff7_externals.ifrit_sub_595A05, 0x930);
+	ff7_externals.battle_viewport_height = (int*)get_absolute_value(battle_main_loop, 0x151);
+	ff7_externals.neo_bahamut_main_loop_48DA7A = get_absolute_value(run_bahamut_neo_sub_48C60B, 0xF3);
+	ff7_externals.neo_bahamut_effect_sub_490F2A = get_absolute_value(ff7_externals.neo_bahamut_main_loop_48DA7A, 0x2CD);
+	ff7_externals.odin_gunge_effect_sub_4A4BE6 = get_absolute_value(run_summon_odin_gunge_main_loop_4A0B6D, 0xA7);
+	ff7_externals.odin_gunge_effect_sub_4A3A2E = get_absolute_value(run_summon_odin_gunge_main_loop_4A0B6D, 0x2D8);
+	ff7_externals.typhoon_sub_4D6FF8 = get_relative_call(run_typhoon_main_loop_4D69A6, 0x4B7);
+	ff7_externals.typhoon_effect_sub_4D7044 = get_absolute_value(ff7_externals.typhoon_sub_4D6FF8, 0xF);
+	ff7_externals.typhoon_effect_sub_4DB15F = get_absolute_value(run_typhoon_main_loop_4D69A6, 0x416);
+	ff7_externals.fat_chocobo_sub_5096F3 = get_absolute_value(run_fat_chocobo_main_loop_508BED, 0x110);
+	uint32_t barret_limit_3_1_main_46FF90 = ff7_externals.limit_break_effects_fn_table[11];
+	uint32_t barret_limit_3_1_sub_46FFAC = get_relative_call(barret_limit_3_1_main_46FF90, 0x10);
+	uint32_t barret_limit_3_1_sub_470031 = get_absolute_value(barret_limit_3_1_sub_46FFAC, 0x44);
+	ff7_externals.barret_limit_3_1_sub_4700F7 = get_absolute_value(barret_limit_3_1_sub_470031, 0x36);
+	uint32_t shadow_flare_enemy_skill_entry_576FD0 = ff7_externals.enemy_skill_effects_fn_table[22];
+	uint32_t shadow_flare_enemy_skill_sub_576FEA = get_relative_call(shadow_flare_enemy_skill_entry_576FD0, 0x10);
+	uint32_t shadow_flare_enemy_skill_main_loop_57708E = get_absolute_value(shadow_flare_enemy_skill_sub_576FEA, 0x70);
+	ff7_externals.shadow_flare_draw_white_bg_57747E = get_relative_call(shadow_flare_enemy_skill_main_loop_57708E, 0x6C);
+
+	ff7_externals.cdcheck_enter_sub = get_absolute_value(main_loop, 0x390);
+	ff7_externals.credits_submit_draw_fade_quad_7AA89B = get_relative_call(credits_main_loop, 0xD9);
+	ff7_externals.menu_submit_draw_fade_quad_6CD64E = get_relative_call(ff7_externals.menu_battle_end_sub_6C9543, 0x104);
+	// --------------------------------
+
 	// Steam achievement
 	uint32_t sub_434347 = get_relative_call(ff7_externals.battle_loop, 0x484);
 	uint32_t* pointer_functions_7C2980 = (uint32_t*)get_absolute_value(sub_434347, 0x19C);
 	ff7_externals.battle_enemy_killed_sub_433BD2 = pointer_functions_7C2980[0];
 	ff7_externals.battle_sub_5C7F94 = get_relative_call(ff7_externals.battle_enemy_killed_sub_433BD2, 0x2AF);
-	ff7_externals.menu_battle_end_sub_6C9543 = get_relative_call(ff7_externals.menu_sub_6CDA83, 0x20);
 	ff7_externals.menu_battle_end_mode = (uint16_t*)get_absolute_value(ff7_externals.menu_battle_end_sub_6C9543, 0x2C);
 	uint32_t menu_sub_6CBD54 = get_relative_call(ff7_externals.menu_sub_6CDA83, 0xC1);
 	ff7_externals.menu_sub_71FF95 = get_relative_call(menu_sub_6CBD54, 0x7);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -29,6 +29,7 @@
 #include "music.h"
 #include "ff7/defs.h"
 #include "ff7_data.h"
+#include "ff7/widescreen.h"
 
 unsigned char midi_fix[] = {0x8B, 0x4D, 0x14};
 WORD snowboard_fix[] = {0x0F, 0x10, 0x0F};
@@ -95,6 +96,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	patch_code_byte(ff7_externals.field_draw_everything + 0xE2, 0x1D);
 	patch_code_byte(ff7_externals.field_draw_everything + 0x353, 0x1D);
 	replace_function(ff7_externals.open_flevel_siz, field_open_flevel_siz);
+	replace_function(ff7_externals.field_init_scripted_bg_movement, field_init_scripted_bg_movement);
 	replace_function(ff7_externals.field_update_scripted_bg_movement, field_update_scripted_bg_movement);
 
 	replace_function(ff7_externals.get_equipment_stats, get_equipment_stats);
@@ -148,7 +150,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 
 	// phoenix camera animation glitch
 	memset_code(ff7_externals.run_phoenix_main_loop_516297 + 0x3A5, 0x90, 49);
-  memset_code(ff7_externals.run_phoenix_main_loop_516297 + 0x3F7, 0x90, 49);
+	memset_code(ff7_externals.run_phoenix_main_loop_516297 + 0x3F7, 0x90, 49);
 
 	// ##################################
 	// bugfixes to enhance game stability
@@ -169,6 +171,12 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	patch_code_byte(ff7_externals.coaster_sub_5EE150 + 0x14A, 5);
 	patch_code_byte(ff7_externals.coaster_sub_5EE150 + 0x16D, 5);
 	patch_code_byte(ff7_externals.coaster_sub_5EE150 + 0x190, 5);
+
+	// #####################
+	// widescreen
+	// #####################
+	if(aspect_ratio == AR_WIDESCREEN)
+		ff7_widescreen_hook_init();
 
 	// #####################
 	// new timer calibration

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -209,6 +209,15 @@ void patch_code_word(uint32_t offset, WORD r)
 	*(WORD *)offset = r;
 }
 
+void patch_code_short(uint32_t offset, short r)
+{
+	DWORD dummy;
+
+	VirtualProtect((void *)offset, sizeof(r), PAGE_EXECUTE_READWRITE, &dummy);
+
+	*(short *)offset = r;
+}
+
 void patch_code_dword(uint32_t offset, DWORD r)
 {
 	DWORD dummy;

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -315,6 +315,7 @@ private:
     bool doesItFitInMemory(size_t size);
 
     void recalcInternals();
+    void calcBackendProjMatrix();
     void prepareFramebuffer();
 
     void bindTextures();


### PR DESCRIPTION
Added new 16:9 widescreen mode without stretching by modifying the projection matrix. This works for all parts of the game other than fields that do not have enough horizontal scrolling range to make it 16:9, the menus, movies and condor mode.

Below are the contributions by vertex (Thank you!!!)
- Decrease culling width range for 3D field models
- Fix fade quad size for FIELD mode
- Swirl framebuffer fix
- fixes: fading during start of battle, flashes done with quad, others
- Fix ifrit wave effect (only width)
- Fix Bahamut Neo backgrounds widths
- Fix 3D model unculling method
- Fix typhoon flashes effect widths
- Fix odin gunge lance flashes effect widths
- Fix effects for barret satellite beam and fat chocobo
- Add support for worldmap
- Fix shadow flare white background effect
- Fix FIELD mode scripted movement and scissor during movies
- Fix other modes fading (cdcheck, gameover, credits, menu, ...)
- Refactor widescreen patches, Add WM mesh cull fix, and remove dynamic change of aspect ratio to widescreen
- Fix crash when transitioning from FIELD mode to WM mode
- Disable shift left and shift right shortcuts for widescreen mode
- clip only x coordinate in scripted scrolling background
- remove all FIELD layers culling
- Fix precision in clipping FIELD maps
- Extend FIELD cursor position to widescreen
- Revert partially modification to culling on FIELD layer3 and layer4
- Increase cursor max height limit in FIELD mode
- Add repeat X and Y for moving background layer 3 and layer 4
- Increase height viewport for BATTLE mod
- Partially implement fullscreen hext and fix battle enter fading animation