### PR TITLE
Reworked gamepad shortcuts to prevent conflicts with game inputs

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -33,7 +33,7 @@ This cheat will allow you to skip movies in-game.
 Shortcuts:
 
 - Keyboard Shortcut: `CTRL + S`
-- Gamepad Shortcut: `SELECT + START`
+- Gamepad Shortcut: `L3` THEN `SQUARE` (XInput: `LSB` THEN `X`)
 
 ### Battle mode toggle
 
@@ -42,7 +42,7 @@ This cheat will allow you to disable battle encounters while in the worldmap or 
 Shortcuts:
 
 - Keyboard Shortcut: `CTRL + B`
-- Gamepad Shortcut: `L3 + R3`
+- Gamepad Shortcut: `L3` THEN `CIRCLE` (XInput: `LSB` THEN `B`)
 
 ### Speedhack
 
@@ -51,12 +51,12 @@ This cheat will allow you to boost the gameplay timing up to 8x ( by default, [y
 Shortcuts:
 
 - Keyboard Shortcut: `CTRL + Arrow Up/Down`
-- Gamepad Shortcut: `L2 + R2 + Up/Down` ( DPad works too if using an XInput controller )
+- Gamepad Shortcut: `L3` THEN `L1/R1` (XInput: `LSB` THEN `LB/RB`)
 
 You can toggle the speedhack (enable/disable) when you want by using these Shortcuts:
 
 - Keyboard Shortcut: `CTRL + Arrow Left/Right`
-- Gamepad Shortcut: `L2 + R2 + Left/Right` ( DPad works too if using an XInput controller )
+- Gamepad Shortcut: `L3` THEN `L2/R2` (XInput: `LSB` THEN `LT/RT`)
 
 ### Soft Reset
 
@@ -65,7 +65,7 @@ This cheat will allow you to reset the game like on PSX, by triggering the game 
 Shortcuts:
 
 - Keyboard Shortcut: `CTRL + R`
-- Gamepad Shortcut: `L1 + L2 + R1 + R2 + START + SELECT`
+- Gamepad Shortcut: `L3` THEN `START + SELECT` (XInput: `LSB` THEN `BACK + START`)
 
 ### Auto-Attack ( FF7 only! )
 
@@ -74,7 +74,7 @@ This cheat will allow you to auto-attack the enemies in battle, instead of press
 Shortcuts:
 
 - Keyboard Shortcut: `CTRL + A`
-- Gamepad Shortcut: `L2 + R3`
+- Gamepad Shortcut: `L3` THEN `TRIANGLE` (XInput: `LSB` THEN `Y`)
 
 ### Toggle Music on Battle pause ( FF7 only! )
 

--- a/src/gamehacks.h
+++ b/src/gamehacks.h
@@ -27,6 +27,8 @@ class GameHacks
 {
 private:
 	uint16_t hold_input_for_frames = 0;
+	bool enable_hold_input = true;
+
 	bool speedhack_enabled;
 	double speedhack_current_speed;
 	bool battle_wanted = true;
@@ -69,6 +71,10 @@ public:
 
 	// INPUT VALIDATION
 	bool canInputBeProcessed();
+
+private:
+	bool isKeyboardShortcutMode = false;
+	bool isGamepadShortcutMode = false;
 };
 
 extern GameHacks gamehacks;

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -123,3 +123,25 @@ bool Gamepad::IsPressed(WORD button) const
 {
     return (state.Gamepad.wButtons & button) != 0;
 }
+
+bool Gamepad::IsIdle()
+{
+  return  !(gamepad.leftStickY > 0.5f || gamepad.IsPressed(XINPUT_GAMEPAD_DPAD_UP)) &&
+          !(gamepad.leftStickY < -0.5f || gamepad.IsPressed(XINPUT_GAMEPAD_DPAD_DOWN)) &&
+          !(gamepad.leftStickX < -0.5f || gamepad.IsPressed(XINPUT_GAMEPAD_DPAD_LEFT)) &&
+          !(gamepad.leftStickX > 0.5f || gamepad.IsPressed(XINPUT_GAMEPAD_DPAD_RIGHT)) &&
+          !gamepad.IsPressed(XINPUT_GAMEPAD_X) &&
+          !gamepad.IsPressed(XINPUT_GAMEPAD_A) &&
+          !gamepad.IsPressed(XINPUT_GAMEPAD_B) &&
+          !gamepad.IsPressed(XINPUT_GAMEPAD_Y) &&
+          !gamepad.IsPressed(XINPUT_GAMEPAD_LEFT_SHOULDER)&&
+          !gamepad.IsPressed(XINPUT_GAMEPAD_RIGHT_SHOULDER) &&
+          !(gamepad.leftTrigger > 0.85f) &&
+          !(gamepad.rightTrigger > 0.85f) &&
+          !gamepad.IsPressed(XINPUT_GAMEPAD_BACK) &&
+          !gamepad.IsPressed(XINPUT_GAMEPAD_START) &&
+          !gamepad.IsPressed(XINPUT_GAMEPAD_START) &&
+          !gamepad.IsPressed(XINPUT_GAMEPAD_LEFT_THUMB) &&
+          !gamepad.IsPressed(XINPUT_GAMEPAD_RIGHT_THUMB) &&
+          !gamepad.IsPressed(0x400);
+}

--- a/src/gamepad.h
+++ b/src/gamepad.h
@@ -55,6 +55,7 @@ public:
     bool Refresh();
     bool Vibrate(WORD wLeftMotorSpeed, WORD wRightMotorSpeed);
     bool IsPressed(WORD) const;
+    bool IsIdle();
 };
 
 extern Gamepad gamepad;

--- a/src/joystick.cpp
+++ b/src/joystick.cpp
@@ -283,6 +283,27 @@ void Joystick::Vibrate(WORD leftMotorSpeed, WORD rightMotorSpeed)
   }
 }
 
+bool Joystick::IsIdle()
+{
+  return  !(joystick.GetState()->lY < joystick.GetDeadZone(-0.5f) || joystick.GetState()->rgdwPOV[0] == 0) &&
+          !(joystick.GetState()->lY > joystick.GetDeadZone(0.5f) || joystick.GetState()->rgdwPOV[0] == 18000) &&
+          !(joystick.GetState()->lX < joystick.GetDeadZone(-0.5f) || joystick.GetState()->rgdwPOV[0] == 27000) &&
+          !(joystick.GetState()->lX > joystick.GetDeadZone(0.5f) || joystick.GetState()->rgdwPOV[0] == 9000) &&
+          !(joystick.GetState()->rgbButtons[0] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[1] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[2] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[3] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[4] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[5] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[6] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[7] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[8] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[9] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[10] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[11] & 0x80) &&
+          !(joystick.GetState()->rgbButtons[12] & 0x80);
+}
+
 //-----------------------------------------------------------------------------
 // Enum each PNP device using WMI and check each device ID to see if it contains
 // "IG_" (ex. "VID_045E&PID_028E&IG_00").  If it does, then it's an XInput device

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -56,6 +56,7 @@ public:
   bool HasForceFeedback();
   void Clean();
   void Vibrate(WORD leftMotorSpeed, WORD rightMotorSpeed);
+  bool IsIdle();
 
   LONG GetDeadZone(float percent);
   DWORD GetMaxVibration();

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -119,6 +119,16 @@ void show_popup_msg(uint8_t text_color, const char* fmt, ...)
 	popup_color = text_colors[text_color];
 }
 
+void clear_popup_msg()
+{
+	popup_ttl = 0;
+}
+
+uint32_t get_popup_time()
+{
+	return popup_ttl;
+}
+
 void external_debug_print(const char *str)
 {
 	std::string msg(str);

--- a/src/log.h
+++ b/src/log.h
@@ -47,6 +47,8 @@ void external_debug_print(const char *str);
 void external_debug_print2(const char *fmt, ...);
 
 void show_popup_msg(uint8_t text_color, const char* fmt, ...);
+void clear_popup_msg();
+uint32_t get_popup_time();
 
 void debug_printf(const char *, uint32_t, const char *, ...);
 


### PR DESCRIPTION
Reworked gamepad shortcuts to prevent conflicts with game inputs.

I reworked the gamepad shortcuts to prevent conflicts with the game inputs. The new system works as follows;
- Press `L3` to enter shortcut input mode
- Press the newly simplified shortcut buttons:
  - FMV Skip: `SQUARE`
  - Battle mode toggle: `CIRCLE`
  - Speedhack speed: `L1/R1`
  - Speedhack toggle: `L2/R2`
  - Soft Reset: `START + SELECT`
  - Auto-Attack : `TRIANGLE`

You can also cancel the shortcut input mode at any time by pressing `L3` again.

Other than that I improved it so that you have to only wait 1 sec for the first input then it speeds up like with the keyboard.
Also it detects all button presses unlike before where inputs were ignored if you pressed the buttons too fast.