### PR TITLE
FF7Achievement: Fix crash during load save file for spanish version

### DIFF
--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -329,10 +329,15 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		replace_call_function(ff7_externals.opcode_biton + 0x3A, ff7_character_regularly_field_entity_60FA7D);
 
 		// INITIALIZATION AT LOAD SAVE FILE
-		if (version == VERSION_FF7_102_US) {
-			replace_call_function(ff7_externals.menu_sub_7212FB + 0xE9D, ff7_load_save_file);
-		} else {
-			replace_call_function(ff7_externals.menu_sub_7212FB + 0xEC5, ff7_load_save_file);
+		switch(version) {
+			case VERSION_FF7_102_US:
+			case VERSION_FF7_102_SP:
+				replace_call_function(ff7_externals.menu_sub_7212FB + 0xE9D, ff7_load_save_file);
+				break;
+			case VERSION_FF7_102_DE:
+			case VERSION_FF7_102_FR:
+				replace_call_function(ff7_externals.menu_sub_7212FB + 0xEC5, ff7_load_save_file);
+				break;
 		}
 	}
 }


### PR DESCRIPTION
Someone reported crash during loading save file for spanish version. I saw this clear bug since in `ff7_data.h` the spanish version uses the offset with `0xE9D`