### PR TITLE
FF7 Widescreen: Add support for highway, snowboard, chocobo, and credits mode

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2616,8 +2616,8 @@ struct ff7_externals
 	uint32_t fps_limiter_submarine;
 	uint32_t fps_limiter_credits;
 	uint32_t sub_5F5042;
-	uint32_t sub_650F36;
-	uint32_t sub_72381C;
+	uint32_t highway_loop_sub_650F36;
+	uint32_t snowboard_loop_sub_72381C;
 	uint32_t sub_779E14;
 	uint32_t battle_fps_menu_multiplier;
 	DWORD *submarine_minigame_status;
@@ -3021,6 +3021,16 @@ struct ff7_externals
 	uint32_t shadow_flare_draw_white_bg_57747E;
 	uint32_t credits_submit_draw_fade_quad_7AA89B;
 	uint32_t menu_submit_draw_fade_quad_6CD64E;
+	uint32_t highway_submit_fade_quad_659532;
+	uint32_t chocobo_init_viewport_values_76D320;
+	byte* chocobo_quads_graphics_data_97A498;
+	uint32_t chocobo_submit_draw_fade_quad_77B1CE;
+	uint32_t snowboard_draw_sky_and_mountains_72DAF0;
+	uint32_t snowboard_submit_draw_sky_quad_graphics_object_72E31F;
+	float* snowboard_sky_quad_pos_x_7B7DB8;
+	uint32_t snowboard_submit_draw_black_quad_graphics_object_72DD94;
+	uint32_t snowboard_submit_draw_white_fade_quad_graphics_object_72DD53;
+	uint32_t snowboard_submit_draw_opaque_quad_graphics_object_72DDD5;
 };
 
 uint32_t ff7gl_load_group(uint32_t group_num, struct matrix_set *matrix_set, struct p_hundred *hundred_data, struct p_group *group_data, struct polygon_data *polygon_data, struct ff7_polygon_set *polygon_set, struct ff7_game_obj *game_object);

--- a/src/ff7/battle.cpp
+++ b/src/ff7/battle.cpp
@@ -60,26 +60,22 @@ void ff7_display_battle_action_text_sub_6D71FA(short command_id, short action_id
 }
 
 void ifrit_first_wave_effect_widescreen_fix_sub_66A47E(int wave_data_pointer) {
-    if(aspect_ratio == AR_WIDESCREEN) {
-        int viewport_width_1_fix = ceil(255.f / game_width * wide_viewport_width) - 255;
-        *(short*)(wave_data_pointer + 8) += wide_viewport_x;
-        *(short*)(wave_data_pointer + 16) += wide_viewport_x + viewport_width_1_fix * 2;
-        *(short*)(wave_data_pointer + 24) += wide_viewport_x;
-        *(short*)(wave_data_pointer + 32) += wide_viewport_x + viewport_width_1_fix * 2;
-    }
+	int viewport_width_1_fix = ceil(255.f / game_width * wide_viewport_width) - 255;
+	*(short*)(wave_data_pointer + 8) += wide_viewport_x;
+	*(short*)(wave_data_pointer + 16) += wide_viewport_x + viewport_width_1_fix * 2;
+	*(short*)(wave_data_pointer + 24) += wide_viewport_x;
+	*(short*)(wave_data_pointer + 32) += wide_viewport_x + viewport_width_1_fix * 2;
 
     ff7_externals.engine_draw_sub_66A47E(wave_data_pointer);
 }
 
 void ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E(int wave_data_pointer) {
-    if(aspect_ratio == AR_WIDESCREEN) {
-        int viewport_width_1_fix = ceil(255.f / game_width * wide_viewport_width) - 255;
-        int viewport_width_2_fix = ceil(65.f / game_width * wide_viewport_width) - 65;
-        *(short*)(wave_data_pointer + 8) += wide_viewport_x + viewport_width_1_fix * 2;
-        *(short*)(wave_data_pointer + 16) += wide_viewport_x + (viewport_width_1_fix + viewport_width_2_fix) * 2;
-        *(short*)(wave_data_pointer + 24) += wide_viewport_x + viewport_width_1_fix * 2;
-        *(short*)(wave_data_pointer + 32) += wide_viewport_x + (viewport_width_1_fix + viewport_width_2_fix) * 2;
-    }
+	int viewport_width_1_fix = ceil(255.f / game_width * wide_viewport_width) - 255;
+	int viewport_width_2_fix = ceil(65.f / game_width * wide_viewport_width) - 65;
+	*(short*)(wave_data_pointer + 8) += wide_viewport_x + viewport_width_1_fix * 2;
+	*(short*)(wave_data_pointer + 16) += wide_viewport_x + (viewport_width_1_fix + viewport_width_2_fix) * 2;
+	*(short*)(wave_data_pointer + 24) += wide_viewport_x + viewport_width_1_fix * 2;
+	*(short*)(wave_data_pointer + 32) += wide_viewport_x + (viewport_width_1_fix + viewport_width_2_fix) * 2;
 
     ff7_externals.engine_draw_sub_66A47E(wave_data_pointer);
 }

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -66,7 +66,7 @@ void ff7_widescreen_hook_init() {
     patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x16A, (uint32_t)&wide_viewport_x);
     patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x19F, (uint32_t)&wide_viewport_width);
     patch_code_dword(ff7_externals.battle_sub_5BD050 + 0x1BB, (uint32_t)&wide_viewport_x);
-    patch_code_int(ff7_externals.battle_enter + 0x1E8, 0);
+    patch_code_int(ff7_externals.battle_enter + 0x1E8, wide_viewport_y);
     patch_code_int(ff7_externals.battle_enter + 0x21A, wide_viewport_height);
     patch_code_dword(ff7_externals.battle_enter + 0x229, (uint32_t)&wide_viewport_width);
     patch_code_dword(ff7_externals.battle_enter + 0x22F, (uint32_t)&wide_viewport_x);
@@ -165,6 +165,30 @@ void ff7_widescreen_hook_init() {
     patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0xE6, (uint32_t)&wide_viewport_x);
     patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0x133, (uint32_t)&viewport_width_plus_x_widescreen_fix);
     patch_code_dword(ff7_externals.credits_submit_draw_fade_quad_7AA89B + 0x180, (uint32_t)&viewport_width_plus_x_widescreen_fix);
+
+    // Highway fix
+    patch_code_int(ff7_externals.highway_submit_fade_quad_659532 + 0x5F, wide_viewport_width);
+    patch_code_char(ff7_externals.highway_submit_fade_quad_659532 + 0x66, wide_viewport_x);
+
+    // Chocobo fix
+    patch_code_int(ff7_externals.chocobo_init_viewport_values_76D320 + 0x1F, wide_viewport_height);
+    patch_code_char(ff7_externals.chocobo_init_viewport_values_76D320 + 0x29, wide_viewport_y);
+    patch_code_int(ff7_externals.chocobo_init_viewport_values_76D320 + 0x62, wide_viewport_y);
+    patch_code_dword((uint32_t)ff7_externals.chocobo_submit_draw_fade_quad_77B1CE + 0x99, (uint32_t)&wide_viewport_x);
+    patch_code_int((uint32_t)ff7_externals.chocobo_quads_graphics_data_97A498 + 0x28, wide_viewport_width / 2);
+
+    // Snowboard fix
+    patch_code_int(ff7_externals.snowboard_draw_sky_and_mountains_72DAF0 + 0xCC, ceil(wide_viewport_width / 4));
+    patch_code_int(ff7_externals.snowboard_draw_sky_and_mountains_72DAF0 + 0x140, ceil(wide_viewport_width / 4));
+    patch_code_float((uint32_t)ff7_externals.snowboard_sky_quad_pos_x_7B7DB8, wide_viewport_x);
+    patch_code_int(ff7_externals.snowboard_submit_draw_sky_quad_graphics_object_72E31F + 0x173, wide_viewport_width + wide_viewport_x);
+    patch_code_int(ff7_externals.snowboard_submit_draw_sky_quad_graphics_object_72E31F + 0x225, wide_viewport_width + wide_viewport_x);
+    patch_code_int(ff7_externals.snowboard_submit_draw_black_quad_graphics_object_72DD94 + 0x27, wide_viewport_width);
+    patch_code_char(ff7_externals.snowboard_submit_draw_black_quad_graphics_object_72DD94 + 0x2E, wide_viewport_x);
+    patch_code_int(ff7_externals.snowboard_submit_draw_white_fade_quad_graphics_object_72DD53 + 0x27, wide_viewport_width);
+    patch_code_char(ff7_externals.snowboard_submit_draw_white_fade_quad_graphics_object_72DD53 + 0x2E, wide_viewport_x);
+    patch_code_int(ff7_externals.snowboard_submit_draw_opaque_quad_graphics_object_72DDD5 + 0x1F, wide_viewport_width);
+    patch_code_char(ff7_externals.snowboard_submit_draw_opaque_quad_graphics_object_72DDD5 + 0x26, wide_viewport_x);
 
     // Menu, endbattle menu, ... fixes
     patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x50, (uint32_t)&wide_viewport_x);

--- a/src/ff7/widescreen.h
+++ b/src/ff7/widescreen.h
@@ -24,6 +24,7 @@
 #pragma once
 
 int wide_viewport_x = -106;
+int wide_viewport_y = 0;
 int wide_viewport_width = 854;
 int wide_viewport_height = 480;
 

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -591,8 +591,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.word_CC0DC6 = (WORD *)get_absolute_value(main_init_loop, 0x4BD);
 
 	ff7_externals.sub_5F5042 = get_relative_call(condor_main_loop, 0x69);
-	ff7_externals.sub_650F36 = get_relative_call(highway_main_loop, 0x53);
-	ff7_externals.sub_72381C = get_relative_call(snowboard_main_loop, 0x7D);
+	ff7_externals.highway_loop_sub_650F36 = get_relative_call(highway_main_loop, 0x53);
+	ff7_externals.snowboard_loop_sub_72381C = get_relative_call(snowboard_main_loop, 0x7D);
 	ff7_externals.sub_779E14 = get_relative_call(chocobo_main_loop, 0x70);
 
 	ff7_externals.fps_limiter_swirl = get_relative_call(swirl_main_loop, 0xDE);
@@ -600,8 +600,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.fps_limiter_coaster = get_relative_call(coaster_main_loop, 0x51);
 	ff7_externals.fps_limiter_condor = get_relative_call(ff7_externals.sub_5F5042, 0x5F);
 	ff7_externals.fps_limiter_field = get_relative_call(ff7_externals.field_sub_6388EE, 0x58);
-	ff7_externals.fps_limiter_highway = get_relative_call(ff7_externals.sub_650F36, 0xC3);
-	ff7_externals.fps_limiter_snowboard = get_relative_call(ff7_externals.sub_72381C, 0x14);
+	ff7_externals.fps_limiter_highway = get_relative_call(ff7_externals.highway_loop_sub_650F36, 0xC3);
+	ff7_externals.fps_limiter_snowboard = get_relative_call(ff7_externals.snowboard_loop_sub_72381C, 0x14);
 	ff7_externals.fps_limiter_worldmap = get_relative_call(worldmap_main_loop, 0x1D);
 	ff7_externals.fps_limiter_chocobo = get_relative_call(ff7_externals.sub_779E14, 0x4D);
 	ff7_externals.fps_limiter_submarine = get_relative_call(submarine_main_loop, 0x98);
@@ -1203,6 +1203,24 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.cdcheck_enter_sub = get_absolute_value(main_loop, 0x390);
 	ff7_externals.credits_submit_draw_fade_quad_7AA89B = get_relative_call(credits_main_loop, 0xD9);
 	ff7_externals.menu_submit_draw_fade_quad_6CD64E = get_relative_call(ff7_externals.menu_battle_end_sub_6C9543, 0x104);
+	ff7_externals.highway_submit_fade_quad_659532 = get_relative_call(ff7_externals.highway_loop_sub_650F36, 0x126);
+	ff7_externals.chocobo_init_viewport_values_76D320 = get_relative_call(main_init_loop, 0x38B);
+	uint32_t chocobo_sub_77C462 = get_relative_call(chocobo_main_loop, 0x5E);
+	uint32_t chocobo_sub_77946A = get_relative_call(chocobo_sub_77C462, 0x649);
+	ff7_externals.chocobo_quads_graphics_data_97A498 = (byte*)get_absolute_value(chocobo_sub_77946A, 0x2F);
+	ff7_externals.chocobo_submit_draw_fade_quad_77B1CE = get_relative_call(chocobo_sub_77946A, 0x33);
+	ff7_externals.snowboard_draw_sky_and_mountains_72DAF0 = get_relative_call(ff7_externals.snowboard_loop_sub_72381C, 0x27);
+	ff7_externals.snowboard_submit_draw_sky_quad_graphics_object_72E31F = get_relative_call(ff7_externals.snowboard_draw_sky_and_mountains_72DAF0, 0x24D);
+	ff7_externals.snowboard_sky_quad_pos_x_7B7DB8 = (float*)get_absolute_value(ff7_externals.snowboard_submit_draw_sky_quad_graphics_object_72E31F, 0x2E);
+	uint32_t snowboard_callable_submit_draw_sub_723F60 = get_absolute_value(ff7_externals.snowboard_loop_sub_72381C, 0x10E);
+	uint32_t snowboard_callable_draw_black_quad_7241E5 = get_absolute_value(snowboard_callable_submit_draw_sub_723F60, 0x15C);
+	uint32_t snowboard_submit_draw_fade_black_quad_729926 = get_relative_call(snowboard_callable_draw_black_quad_7241E5, 0x31);
+	ff7_externals.snowboard_submit_draw_black_quad_graphics_object_72DD94 = get_relative_call(snowboard_submit_draw_fade_black_quad_729926, 0xD);
+	uint32_t snowboard_callable_draw_white_quad_7240D6 = get_absolute_value(snowboard_callable_submit_draw_sub_723F60, 0x165);
+	uint32_t snowboard_submit_draw_white_fade_quad_729912 = get_relative_call(snowboard_callable_draw_white_quad_7240D6, 0x38);
+	ff7_externals.snowboard_submit_draw_white_fade_quad_graphics_object_72DD53 = get_relative_call(snowboard_submit_draw_white_fade_quad_729912, 0xD);
+	uint32_t snowboard_submit_draw_opaque_quad_72993A = get_relative_call(snowboard_callable_draw_white_quad_7240D6, 0xCC);
+	ff7_externals.snowboard_submit_draw_opaque_quad_graphics_object_72DDD5 = get_relative_call(snowboard_submit_draw_opaque_quad_72993A, 0xD);
 	// --------------------------------
 
 	// Steam achievement

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -200,6 +200,15 @@ void patch_code_byte(uint32_t offset, unsigned char r)
 	*(unsigned char *)offset = r;
 }
 
+void patch_code_char(uint32_t offset, char r)
+{
+	DWORD dummy;
+
+	VirtualProtect((void *)offset, sizeof(r), PAGE_EXECUTE_READWRITE, &dummy);
+
+	*(char *)offset = r;
+}
+
 void patch_code_word(uint32_t offset, WORD r)
 {
 	DWORD dummy;

--- a/src/patch.h
+++ b/src/patch.h
@@ -35,6 +35,7 @@ uint32_t replace_call_function(uint32_t offset, void* func);
 
 uint32_t get_relative_call(uint32_t base, uint32_t offset);
 uint32_t get_absolute_value(uint32_t base, uint32_t offset);
+void patch_code_char(uint32_t offset, char r);
 void patch_code_byte(uint32_t offset, unsigned char r);
 void patch_code_word(uint32_t offset, WORD r);
 void patch_code_short(uint32_t offset, short r);

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1170,9 +1170,10 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
 
     if(aspect_ratio == AR_WIDESCREEN)
     {
-        // Keep the default scissor for movies
+        // Keep the default scissor for FIELD mode movies and credits mode
+        struct game_mode* mode = getmode_cached();
         bool is_movie_playing = *ff7_externals.word_CC1638 && !ff7_externals.modules_global_object->BGMOVIE_flag;
-        if(is_movie_playing) {
+        if(is_movie_playing || mode->driver_mode == MODE_CREDITS) {
             scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
             return;
         }
@@ -1185,7 +1186,6 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
         }
 
         // This sets a scissor offset for field with width not enough to fill the screen in 16:9
-        struct game_mode* mode = getmode_cached();
         field_trigger_header* field_triggers_header_ptr = *ff7_externals.field_triggers_header;
         if(mode->driver_mode == MODE_FIELD && *ff7_externals.field_level_data_pointer != 0)
         {


### PR DESCRIPTION
This PR is meant to be merged after the main widescreen PR (#461).