### PR TITLE
Lighting: fixed visual glitch when enabling both lighting and anti-aliasing

### DIFF
--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -750,8 +750,6 @@ void Lighting::draw(struct game_obj* game_object)
 
 void drawFieldShadow()
 {
-	newRenderer.backupDepthBuffer();
-
     lighting.createFieldWalkmesh(lighting.getWalkmeshExtrudeSize());
 
 	auto walkMeshVertices = lighting.getWalkmeshVertices();
@@ -766,7 +764,7 @@ void drawFieldShadow()
     newRenderer.setBlendMode(RendererBlendMode::BLEND_AVG);
     newRenderer.isFBTexture(false);
     newRenderer.doDepthTest(true);
-    newRenderer.doDepthWrite(true);
+    newRenderer.doDepthWrite(false);
 
     // Create a world matrix
     struct matrix worldMatrix;
@@ -785,8 +783,6 @@ void drawFieldShadow()
     newRenderer.setWorldViewMatrix(&worldViewMatrix);
 
     newRenderer.drawFieldShadow();
-
-	newRenderer.recoverDepthBuffer();
 }
 
 const LightingState& Lighting::getLightingState()

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -332,8 +332,6 @@ void Renderer::destroyAll()
 
     bgfx::destroy(shadowMapFrameBuffer);
 
-    bgfx::destroy(backupDepthTexture);
-
     for (auto& handle : backendProgramHandles)
     {
         if (bgfx::isValid(handle))
@@ -606,22 +604,13 @@ void Renderer::prepareFramebuffer()
         false,
         1,
         bgfx::TextureFormat::D32F,
-        fbFlags | BGFX_TEXTURE_BLIT_DST
+        fbFlags
     );
 
     backendFrameBuffer = bgfx::createFrameBuffer(
         backendFrameBufferRT.size(),
         backendFrameBufferRT.data(),
         true
-    );
-
-    backupDepthTexture = bgfx::createTexture2D(
-        framebufferWidth,
-        framebufferHeight,
-        false,
-        1,
-        bgfx::TextureFormat::D32F,
-        fbFlags | BGFX_TEXTURE_BLIT_DST
     );
 }
 
@@ -947,28 +936,6 @@ void Renderer::drawWithLighting(bool isCastShadow)
 
     // Draw with lighting
     draw(isCastShadow);
-}
-
-void Renderer::backupDepthBuffer()
-{
-    backendViewId++;
-    bgfx::setViewClear(backendViewId, BGFX_CLEAR_NONE, internalState.clearColorValue, 1.0f);
-    bgfx::touch(backendViewId);
-    bgfx::blit(backendViewId, backupDepthTexture, 0, 0, bgfx::getTexture(backendFrameBuffer, 1), 0, 0, framebufferWidth, framebufferHeight);
-    backendViewId++;
-    bgfx::setViewClear(backendViewId, BGFX_CLEAR_NONE, internalState.clearColorValue, 1.0f);
-    bgfx::touch(backendViewId);
-}
-
-void Renderer::recoverDepthBuffer()
-{
-    backendViewId++;
-    bgfx::setViewClear(backendViewId, BGFX_CLEAR_NONE, internalState.clearColorValue, 1.0f);
-    bgfx::touch(backendViewId);
-    bgfx::blit(backendViewId, bgfx::getTexture(backendFrameBuffer, 1), 0, 0, backupDepthTexture, 0, 0, framebufferWidth, framebufferHeight);
-    backendViewId++;
-    bgfx::setViewClear(backendViewId, BGFX_CLEAR_NONE, internalState.clearColorValue, 1.0f);
-    bgfx::touch(backendViewId);
 }
 
 void Renderer::drawFieldShadow()

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -256,8 +256,6 @@ private:
     std::vector<bgfx::TextureHandle> backendFrameBufferRT = { BGFX_INVALID_HANDLE, BGFX_INVALID_HANDLE };
     bgfx::FrameBufferHandle backendFrameBuffer = BGFX_INVALID_HANDLE;
 
-    bgfx::TextureHandle backupDepthTexture = BGFX_INVALID_HANDLE;
-
     bgfx::TextureHandle shadowMapTexture = BGFX_INVALID_HANDLE;
     bgfx::FrameBufferHandle shadowMapFrameBuffer = BGFX_INVALID_HANDLE;
 
@@ -345,9 +343,7 @@ public:
     void clearShadowMap();
     void drawToShadowMap();
     void drawWithLighting(bool isCastShadow);
-    void backupDepthBuffer();
     void drawFieldShadow();
-    void recoverDepthBuffer();
     void draw(bool uniformsAlreadyAttached = false);
     void drawOverlay();
     void show();


### PR DESCRIPTION
This PR fixes visual glitch when enabling both lighting and anti-aliasing.
By disabling the z-write for the field shadow draw call it works just fine so no need to backup/recover the depth buffer anymore.