### PR TITLE
Lighting: Fixed draw call order for framebuffer effects

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -6,6 +6,7 @@
 //    Copyright (C) 2020 Chris Rizzitello                                   //
 //    Copyright (C) 2020 John Pritchard                                     //
 //    Copyright (C) 2022 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2022 Cosmos                                             //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //
@@ -320,6 +321,8 @@ struct game_mode *getmode();
 struct game_mode *getmode_cached();
 struct tex_header *make_framebuffer_tex(uint32_t tex_w, uint32_t tex_h, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint32_t color_key);
 void internal_set_renderstate(uint32_t state, uint32_t option, struct game_obj *game_object);
+uint32_t create_framebuffer_texture(struct texture_set *texture_set, struct tex_header *tex_header);
+void blit_framebuffer_texture(struct texture_set *texture_set, struct tex_header *tex_header);
 
 void get_data_lang_path(PCHAR buffer);
 void get_userdata_path(PCHAR buffer, size_t bufSize, bool isSavegameFile);

--- a/src/gl.h
+++ b/src/gl.h
@@ -28,6 +28,14 @@
 #define LVERTEX 2
 #define TLVERTEX 3
 
+enum DrawCallType
+{
+	DCT_CLEAR = 0,
+	DCT_BLIT,
+	DCT_DRAW,
+	DCT_DRAW_MOVIE
+};
+
 struct driver_state
 {
 	struct texture_set *texture_set;
@@ -62,6 +70,13 @@ struct deferred_draw
 	uint32_t clip;
 	uint32_t mipmap;
 	struct driver_state state;
+	DrawCallType draw_call_type;
+	struct texture_set *fb_texture_set;
+	struct tex_header *fb_tex_header;
+	uint32_t clear_color;
+	uint32_t clear_depth;
+	struct game_obj *game_object;
+	uint32_t movie_buffer_index;
 };
 
 struct deferred_sorted_draw
@@ -99,8 +114,10 @@ void gl_save_state(struct driver_state *dest);
 void gl_load_state(struct driver_state *src);
 uint32_t gl_defer_draw(uint32_t primitivetype, uint32_t vertextype, struct nvertex* vertices, vector3<float>* normals, uint32_t vertexcount, WORD* indices, uint32_t count, struct boundingbox* boundingbox, uint32_t clip, uint32_t mipmap);
 uint32_t gl_defer_sorted_draw(uint32_t primitivetype, uint32_t vertextype, struct nvertex *vertices, uint32_t vertexcount, WORD *indices, uint32_t count, uint32_t clip, uint32_t mipmap);
+uint32_t gl_defer_blit_framebuffer(struct texture_set *texture_set, struct tex_header *tex_header);
+uint32_t gl_defer_clear_buffer(uint32_t clear_color, uint32_t clear_depth, struct game_obj *game_object);
+uint32_t gl_defer_yuv_frame(uint32_t buffer_index);
 void gl_draw_deferred(draw_field_shadow_callback shadow_callback);
-void gl_set_projection_viewport_matrices();
 struct boundingbox calculateSceneAabb();
 void gl_draw_sorted_deferred();
 void gl_check_deferred(struct texture_set *texture_set);

--- a/src/movies.h
+++ b/src/movies.h
@@ -6,6 +6,7 @@
 //    Copyright (C) 2020 Chris Rizzitello                                   //
 //    Copyright (C) 2020 John Pritchard                                     //
 //    Copyright (C) 2022 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2022 Cosmos                                             //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -371,7 +371,8 @@ public:
     bool saveTexture(const char* filename, uint32_t width, uint32_t height, const void* data);
     void deleteTexture(uint16_t texId);
     void useTexture(uint16_t texId, uint32_t slot = 0);
-    uint32_t blitTexture(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+    uint32_t createBlitTexture(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+    void blitTexture(uint16_t dest, uint32_t x, uint32_t y, uint32_t width, uint32_t height);
 
     void isMovie(bool flag = false);
     void isTLVertex(bool flag = false);

--- a/src/video/movies.cpp
+++ b/src/video/movies.cpp
@@ -327,6 +327,8 @@ void buffer_yuv_frame(uint8_t **planes, int *strides)
 
 void draw_yuv_frame(uint32_t buffer_index)
 {
+	if(gl_defer_yuv_frame(buffer_index)) return;
+
 	for (uint32_t idx = 0; idx < 3; idx++)
 		newRenderer.useTexture(video_buffer[buffer_index].yuv_textures[idx], idx);
 

--- a/src/video/movies.h
+++ b/src/video/movies.h
@@ -40,3 +40,5 @@ void ffmpeg_loop();
 uint32_t ffmpeg_get_movie_frame();
 
 short ffmpeg_get_fps_ratio();
+
+void draw_yuv_frame(uint32_t buffer_index);


### PR DESCRIPTION
This PR fixes the framebuffer effects when lighting is enabled. 
The problem until now was that the blit draw call for the framebuffer effect was being executed at the wrong timing (before anything was drawn to the screen and therefore it was all black). By deferring the blit draw call in the same way as the other draw calls, we can reproduce the original intended order of execution. The same applies for the clear and movie rendering draw calls.

In other words, with this fix Titan finally found his floor :)