### PR TITLE
60FPS: Fix FIELD and WORLD mode text box animation speed (opening, closing, next paging)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 - Lighting: Fixed minor graphical glitches happening in fields ( https://github.com/julianxhokaxhiu/FFNx/pull/475 )
 - Lighting: Fixed visual glitches happening while using Antialiasing ( https://github.com/julianxhokaxhiu/FFNx/pull/476 )
 - Lighting: Fixed various missing graphical elements through the overall game ( Titan missing floor, etc. ) ( https://github.com/julianxhokaxhiu/FFNx/pull/478 )
+- 60FPS: Fix FIELD and WORLD mode text box animation speed (opening, closing, next paging)
 
 ## FF8
 

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2596,14 +2596,17 @@ struct ff7_externals
 	uint32_t field_sub_661B68;
 	void (*engine_set_game_engine_world_coord_661B23)(int, int);
 	void (*engine_sub_67CCDE)(float, float, float, float, float, float, float, ff7_game_obj*);
-	uint32_t sub_630D50;
-	uint32_t sub_631586;
-	uint32_t sub_631945;
+	uint32_t field_opcode_message_update_loop_630D50;
+	uint32_t field_text_box_window_create_631586;
+	uint32_t field_text_box_window_opening_6317A9;
+	uint32_t field_text_box_window_paging_631945;
+	uint32_t field_text_box_window_reverse_paging_632CAA;
+	uint32_t field_text_box_window_closing_632EB8;
 	char* field_entity_id_list; // 0xCC0960
 	DWORD* current_dialog_string_pointer; //0xCBF578
 	WORD* current_dialog_message_speed; // 0xCC0418
 	WORD* opcode_message_loop_code;
-	int (*sub_6310A1)(uint8_t, uint8_t, uint8_t, uint8_t, WORD*);
+	int (*field_opcode_ask_update_loop_6310A1)(uint8_t, uint8_t, uint8_t, uint8_t, WORD*);
 	WORD* opcode_ask_question_code;
 	void (*play_midi)(uint32_t);
 	WORD *current_movie_frame;
@@ -2976,7 +2979,10 @@ struct ff7_externals
 	uint32_t world_opcode_ask_sub_75EEBB;
 	uint32_t world_opcode_message;
 	uint32_t world_opcode_ask;
-	uint32_t world_opcode_message_update_text_769C02;
+	uint32_t world_text_box_window_opening_769A66;
+	uint32_t world_text_box_window_paging_769C02;
+	uint32_t world_text_box_reverse_paging_76ABE9;
+	uint32_t world_text_box_window_closing_76ADF7;
 	int (*get_world_encounter_rate)();
 	int (*pop_world_script_stack)();
 	uint32_t world_update_player_74EA48;

--- a/src/ff7/field.cpp
+++ b/src/ff7/field.cpp
@@ -1611,11 +1611,20 @@ void ff7_field_hook_init()
 			// Encounter rate fix
 			replace_call_function(ff7_externals.field_update_models_positions + 0x90F, ff7_field_evaluate_encounter_rate);
 
-			// Message speed fix
-			patch_code_byte(ff7_externals.sub_631945 + 0xFD, 0x5 + common_frame_multiplier / 2);
-			patch_divide_code<byte>(ff7_externals.sub_631945 + 0x100, common_frame_multiplier);
-			patch_divide_code<WORD>(ff7_externals.sub_631945 + 0x111, common_frame_multiplier);
-			patch_code_byte(ff7_externals.sub_631945 + 0x141, 0x4 + common_frame_multiplier / 2);
+			// Text box message fix
+			patch_code_byte(ff7_externals.field_text_box_window_paging_631945 + 0xFD, 0x5 + common_frame_multiplier / 2);
+			patch_divide_code<byte>(ff7_externals.field_text_box_window_paging_631945 + 0x100, common_frame_multiplier);
+			patch_divide_code<WORD>(ff7_externals.field_text_box_window_paging_631945 + 0x111, common_frame_multiplier);
+			patch_code_byte(ff7_externals.field_text_box_window_paging_631945 + 0x141, 0x4 + common_frame_multiplier / 2);
+			patch_code_byte(ff7_externals.field_text_box_window_opening_6317A9 + 0x3D, 0x2 + common_frame_multiplier / 2);
+			patch_code_byte(ff7_externals.field_text_box_window_opening_6317A9 + 0xD2, 0x2 + common_frame_multiplier / 2);
+			patch_code_byte(ff7_externals.field_text_box_window_closing_632EB8 + 0x64, 0x2 + common_frame_multiplier / 2);
+			patch_code_byte(ff7_externals.field_text_box_window_closing_632EB8 + 0xBF, 0x2 + common_frame_multiplier / 2);
+			patch_divide_code<short>(ff7_externals.field_text_box_window_reverse_paging_632CAA + 0x42, common_frame_multiplier);
+			patch_divide_code<short>(ff7_externals.field_opcode_message_update_loop_630D50 + 0x1AC, common_frame_multiplier);
+			patch_divide_code<short>(ff7_externals.field_opcode_message_update_loop_630D50 + 0x2CF, common_frame_multiplier);
+			patch_divide_code<short>((uint32_t)ff7_externals.field_opcode_ask_update_loop_6310A1 + 0x1AC, common_frame_multiplier);
+			patch_divide_code<byte>((uint32_t)ff7_externals.field_opcode_ask_update_loop_6310A1 + 0x3CC, common_frame_multiplier);
 
 			// Model blinking: wait time and blink time
 			replace_call_function(ff7_externals.field_animate_3d_models_6392BB + 0x8A7, ff7_field_blink_3d_model);

--- a/src/ff7/world.cpp
+++ b/src/ff7/world.cpp
@@ -154,11 +154,20 @@ void ff7_world_hook_init()
     // World Encounter rate fix
     replace_call_function(ff7_externals.world_sub_767641 + 0x110, ff7_get_world_encounter_rate);
 
-    // Message speed fix
-    patch_code_byte(ff7_externals.world_opcode_message_update_text_769C02 + 0xF6, 0x5 + common_frame_multiplier / 2);
-    patch_divide_code<byte>(ff7_externals.world_opcode_message_update_text_769C02 + 0xF9, common_frame_multiplier);
-    patch_divide_code<WORD>(ff7_externals.world_opcode_message_update_text_769C02 + 0x10A, common_frame_multiplier);
-    patch_code_byte(ff7_externals.world_opcode_message_update_text_769C02 + 0x13A, 0x4 + common_frame_multiplier / 2);
+    // Text box message fix
+    patch_code_byte(ff7_externals.world_text_box_window_paging_769C02 + 0xF6, 0x5 + common_frame_multiplier / 2);
+    patch_divide_code<byte>(ff7_externals.world_text_box_window_paging_769C02 + 0xF9, common_frame_multiplier);
+    patch_divide_code<WORD>(ff7_externals.world_text_box_window_paging_769C02 + 0x10A, common_frame_multiplier);
+    patch_code_byte(ff7_externals.world_text_box_window_paging_769C02 + 0x13A, 0x4 + common_frame_multiplier / 2);
+    patch_code_byte(ff7_externals.world_text_box_window_opening_769A66 + 0x3D, 0x2 + common_frame_multiplier / 2);
+    patch_code_byte(ff7_externals.world_text_box_window_opening_769A66 + 0xD2, 0x2 + common_frame_multiplier / 2);
+    patch_code_byte(ff7_externals.world_text_box_window_closing_76ADF7 + 0x67, 0x2 + common_frame_multiplier / 2);
+    patch_code_byte(ff7_externals.world_text_box_window_closing_76ADF7 + 0xC2, 0x2 + common_frame_multiplier / 2);
+    patch_divide_code<short>(ff7_externals.world_text_box_reverse_paging_76ABE9 + 0x42, common_frame_multiplier);
+    patch_divide_code<short>(ff7_externals.world_opcode_message + 0x1AC, common_frame_multiplier);
+    patch_divide_code<short>(ff7_externals.world_opcode_message + 0x2CF, common_frame_multiplier);
+    patch_divide_code<short>(ff7_externals.world_opcode_ask + 0x1AC, common_frame_multiplier);
+    patch_divide_code<byte>(ff7_externals.world_opcode_ask + 0x3CC, common_frame_multiplier);
 
     // Wait frames decrease delayed
     replace_call_function(ff7_externals.run_world_event_scripts + 0xC7, ff7_run_world_script_system_operations);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -496,16 +496,19 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.animation_type_array = (char*)get_absolute_value(ff7_externals.opcode_canm1_canm2, 0x5D);
 	ff7_externals.word_DB958A = (WORD *)get_absolute_value(common_externals.execute_opcode_table[0x23], 0x5);
 
-	ff7_externals.sub_630D50 = get_relative_call(ff7_externals.opcode_message, 0x3B);
-	ff7_externals.sub_631586 = get_relative_call(ff7_externals.sub_630D50, 0x39);
-	ff7_externals.sub_631945 = get_relative_call(ff7_externals.sub_630D50, 0x6D);
-	ff7_externals.opcode_message_loop_code = (WORD*)get_absolute_value(ff7_externals.sub_630D50, 0x12);
-	ff7_externals.current_dialog_string_pointer = (DWORD*)get_absolute_value(ff7_externals.sub_631586, 0x154);
-	ff7_externals.current_dialog_message_speed = (WORD*)get_absolute_value(ff7_externals.sub_631586, 0x1C1);
-	ff7_externals.field_entity_id_list = (char*)get_absolute_value(ff7_externals.sub_631586, 0x1F);
+	ff7_externals.field_opcode_message_update_loop_630D50 = get_relative_call(ff7_externals.opcode_message, 0x3B);
+	ff7_externals.field_text_box_window_create_631586 = get_relative_call(ff7_externals.field_opcode_message_update_loop_630D50, 0x39);
+	ff7_externals.field_text_box_window_opening_6317A9 = get_relative_call(ff7_externals.field_opcode_message_update_loop_630D50, 0x5A);
+	ff7_externals.field_text_box_window_paging_631945 = get_relative_call(ff7_externals.field_opcode_message_update_loop_630D50, 0x6D);
+	ff7_externals.field_text_box_window_reverse_paging_632CAA = get_relative_call(ff7_externals.field_opcode_message_update_loop_630D50, 0x80);
+	ff7_externals.field_text_box_window_closing_632EB8 = get_relative_call(ff7_externals.field_opcode_message_update_loop_630D50, 0x235);
+	ff7_externals.opcode_message_loop_code = (WORD*)get_absolute_value(ff7_externals.field_opcode_message_update_loop_630D50, 0x12);
+	ff7_externals.current_dialog_string_pointer = (DWORD*)get_absolute_value(ff7_externals.field_text_box_window_create_631586, 0x154);
+	ff7_externals.current_dialog_message_speed = (WORD*)get_absolute_value(ff7_externals.field_text_box_window_create_631586, 0x1C1);
+	ff7_externals.field_entity_id_list = (char*)get_absolute_value(ff7_externals.field_text_box_window_create_631586, 0x1F);
 
-	ff7_externals.sub_6310A1 = (int (*)(uint8_t, uint8_t, uint8_t, uint8_t, WORD*))get_relative_call(ff7_externals.opcode_ask, 0x8E);
-	ff7_externals.opcode_ask_question_code = (WORD*)get_absolute_value((uint32_t)ff7_externals.sub_6310A1, 0x2FE);
+	ff7_externals.field_opcode_ask_update_loop_6310A1 = (int (*)(uint8_t, uint8_t, uint8_t, uint8_t, WORD*))get_relative_call(ff7_externals.opcode_ask, 0x8E);
+	ff7_externals.opcode_ask_question_code = (WORD*)get_absolute_value((uint32_t)ff7_externals.field_opcode_ask_update_loop_6310A1, 0x2FE);
 
 	ff7_externals.field_music_helper = get_relative_call(ff7_externals.opcode_cmusc, 0x5E);
 	ff7_externals.field_music_id_to_midi_id = (uint32_t (*)(int16_t))get_relative_call(ff7_externals.field_music_helper, 0x3B);
@@ -1125,7 +1128,10 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.world_opcode_ask_sub_75EEBB = get_relative_call(ff7_externals.run_world_event_scripts_system_operations, 0xBA1);
 	ff7_externals.world_opcode_message = get_relative_call(ff7_externals.world_sub_75EF46, 0x8C);
 	ff7_externals.world_opcode_ask = get_relative_call(ff7_externals.world_sub_75EF46, 0xAF);
-	ff7_externals.world_opcode_message_update_text_769C02 = get_relative_call(ff7_externals.world_opcode_message, 0x6D);
+	ff7_externals.world_text_box_window_opening_769A66 = get_relative_call(ff7_externals.world_opcode_message, 0x5A);
+	ff7_externals.world_text_box_window_paging_769C02 = get_relative_call(ff7_externals.world_opcode_message, 0x6D);
+	ff7_externals.world_text_box_reverse_paging_76ABE9 = get_relative_call(ff7_externals.world_opcode_message, 0x80);
+	ff7_externals.world_text_box_window_closing_76ADF7 = get_relative_call(ff7_externals.world_opcode_message, 0x235);
 	ff7_externals.world_update_player_74EA48 = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x2D7);
 	ff7_externals.world_get_player_model_id = (int(*)())get_relative_call(ff7_externals.world_update_player_74EA48, 0x1B);
 	ff7_externals.world_get_current_key_input_status = (int(*)())get_relative_call(ff7_externals.world_update_player_74EA48, 0x4A);

--- a/src/voice.cpp
+++ b/src/voice.cpp
@@ -365,7 +365,7 @@ int opcode_voice_parse_options(uint8_t window_id, uint8_t dialog_id, uint8_t fir
 {
 	opcode_ask_current_option = *current_question_id;
 
-	return ff7_externals.sub_6310A1(window_id, dialog_id, first_question_id, last_question_id, current_question_id);
+	return ff7_externals.field_opcode_ask_update_loop_6310A1(window_id, dialog_id, first_question_id, last_question_id, current_question_id);
 }
 
 int opcode_voice_ask(int unk)


### PR DESCRIPTION
## Summary

Fix FIELD and WORLD mode text box animation speed in 60 FPS. Also refactored a few of function names related to window text boxes.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
