### PR TITLE
Widescreen: Added config logic and zoom implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ target_compile_features(${RELEASE_NAME}
 target_link_options(${RELEASE_NAME} PRIVATE /PDBALTPATH:${RELEASE_NAME}.pdb PRIVATE /DEF:${CMAKE_SOURCE_DIR}/misc/${RELEASE_NAME}.def)
 
 # SHADER COMPILATION
-set(FFNX_SHADERS "FFNx" "FFNx.lighting" "FFNx.shadowmap" "FFNx.field.shadow" "FFNx.overlay" "FFNx.post")
+set(FFNX_SHADERS "FFNx" "FFNx.lighting" "FFNx.shadowmap" "FFNx.field.shadow" "FFNx.overlay" "FFNx.post" "FFNx.blit")
 foreach(FFNX_SHADER IN LISTS FFNX_SHADERS)
   foreach(BGFX_VARYING flat smooth)
     add_custom_command(

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 - Lighting: Fixed visual glitches happening while using Antialiasing ( https://github.com/julianxhokaxhiu/FFNx/pull/476 )
 - Lighting: Fixed various missing graphical elements through the overall game ( Titan missing floor, etc. ) ( https://github.com/julianxhokaxhiu/FFNx/pull/478 )
 - 60FPS: Fix FIELD and WORLD mode text box animation speed (opening, closing, next paging)
+- Widescreen: Added config logic and zoom implementation
 
 ## FF8
 

--- a/misc/FFNx.blit.frag
+++ b/misc/FFNx.blit.frag
@@ -1,0 +1,26 @@
+/****************************************************************************/
+//    Copyright (C) 2022 Cosmos                                             //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+$input v_texcoord0
+
+#include <bgfx/bgfx_shader.sh>
+#include "FFNx.common.sh"
+
+SAMPLER2D(tex_0, 0);
+
+void main()
+{
+	gl_FragColor = texture2D(tex_0, v_texcoord0.xy);
+}

--- a/misc/FFNx.blit.vert
+++ b/misc/FFNx.blit.vert
@@ -1,0 +1,32 @@
+/****************************************************************************/
+//    Copyright (C) 2022 Cosmos                                             //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+$input a_position, a_texcoord0
+$output v_texcoord0
+
+#include <bgfx/bgfx_shader.sh>
+
+void main()
+{
+    vec4 pos = a_position;
+
+    pos.w = 1.0 / pos.w;
+    pos.xyz *= pos.w;
+    pos = mul(u_proj, pos);
+
+    gl_Position = pos;
+    v_texcoord0 = a_texcoord0;
+}
+

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -45,6 +45,7 @@ std::vector<std::string> external_voice_ext;
 std::string external_ambient_path;
 std::vector<std::string> external_ambient_ext;
 std::string external_lighting_path;
+std::string external_widescreen_path;
 bool enable_voice_music_fade;
 long external_voice_music_fade_volume;
 bool enable_voice_auto_text;
@@ -186,6 +187,7 @@ void read_cfg()
 	external_ambient_path = config["external_ambient_path"].value_or("");
 	external_ambient_ext = get_string_or_array_of_strings(config["external_ambient_ext"]);
 	external_lighting_path = config["external_lighting_path"].value_or("");
+	external_widescreen_path = config["external_widescreen_path"].value_or("");
 	save_textures = config["save_textures"].value_or(false);
 	trace_all = config["trace_all"].value_or(false);
 	trace_renderer = config["trace_renderer"].value_or(false);
@@ -405,6 +407,10 @@ void read_cfg()
 	// EXTERNAL LIGHTING PATH
 	if (external_lighting_path.empty())
 		external_lighting_path = "lighting";
+
+	// EXTERNAL WIDESCREEN PATH
+	if (external_widescreen_path.empty())
+		external_widescreen_path = "widescreen";
 
 	// MOD PATH
 	if (mod_path.empty())

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -58,6 +58,7 @@ extern std::vector<std::string> external_voice_ext;
 extern std::string external_ambient_path;
 extern std::vector<std::string> external_ambient_ext;
 extern std::string external_lighting_path;
+extern std::string external_widescreen_path;
 extern bool enable_voice_music_fade;
 extern long external_voice_music_fade_volume;
 extern bool enable_voice_auto_text;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -55,6 +55,8 @@
 #include "achievement.h"
 #include "game_cfg.h"
 
+#include "ff7/widescreen.h"
+
 #include "ff8/vram.h"
 #include "ff8/vibration.h"
 
@@ -835,6 +837,8 @@ int common_create_window(HINSTANCE hInstance, struct game_obj* game_object)
 					vram_init();
 					vibration_init();
 				}
+
+				if(aspect_ratio == AR_WIDESCREEN) widescreen.init();
 
 				// enable verbose logging for FFMpeg
 				av_log_set_level(AV_LOG_VERBOSE);

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2415,6 +2415,7 @@ struct ff7_externals
 	uint32_t *field_bg_multiplier;
 	void (*add_page_tile)(float, float, float, float, float, uint32_t, uint32_t);
 	double (*field_layer_sub_623C0F)(rotation_matrix*, int, int, int);
+	void (*field_draw_gray_quads_644E90)();
 	field_trigger_header** field_triggers_header;
 	rotation_matrix* field_camera_rotation_matrix_CFF3D8;
 	uint32_t field_load_textures;

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -24,11 +24,25 @@
 #include "widescreen.h"
 #include "../patch.h"
 #include "../ff7.h"
+#include "../cfg.h"
+#include "../renderer.h"
 #include "cmath"
 
 int viewport_width_plus_x_widescreen_fix = 750;
 int swirl_framebuffer_offset_x_widescreen_fix = 106;
 int swirl_framebuffer_offset_y_widescreen_fix = 64;
+
+Widescreen widescreen;
+
+// This function should be called at each frame after drawing backgrounds and 3d models
+void ff7_field_draw_gray_quads_sub_644E90() {
+    ff7_externals.field_draw_gray_quads_644E90();
+
+    if(gl_defer_zoom()) return;
+
+    if(aspect_ratio == AR_WIDESCREEN && widescreen.getMode() == WM_ZOOM)
+        newRenderer.zoomBackendFrameBuffer();
+}
 
 void ifrit_first_wave_effect_widescreen_fix_sub_66A47E(int wave_data_pointer) {
 	int viewport_width_1_fix = ceil(255.f / game_width * wide_viewport_width) - 255;
@@ -77,6 +91,8 @@ void ff7_widescreen_hook_init() {
     memset_code(ff7_externals.field_submit_draw_pointer_hand_60D572 + 0x39, 0x90, 12); // Remove useless culling cursor
     patch_code_int(ff7_externals.field_init_viewport_values + 0xBE, wide_viewport_width + wide_viewport_x - 60);
     patch_code_int(ff7_externals.field_init_viewport_values + 0xC8, 18);
+    // For zoom field maps
+    replace_call_function(ff7_externals.field_draw_everything + 0x360, ff7_field_draw_gray_quads_sub_644E90);
 
     // Swirl fix
     patch_code_dword(ff7_externals.swirl_loop_sub_4026D4 + 0x335, (uint32_t)&wide_viewport_x);
@@ -230,4 +246,59 @@ void ff7_widescreen_hook_init() {
     patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x163, (uint32_t)&wide_viewport_x);
     patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x111, (uint32_t)&wide_viewport_width);
     patch_code_dword(ff7_externals.menu_submit_draw_fade_quad_6CD64E + 0x16F, (uint32_t)&wide_viewport_width);
+}
+
+void Widescreen::loadConfig()
+{
+    char _fullpath[MAX_PATH];
+    sprintf(_fullpath, "%s/%s/config.toml", basedir, external_widescreen_path.c_str());
+
+    try
+    {
+        config = toml::parse_file(_fullpath);
+    }
+    catch (const toml::parse_error &err)
+    {
+        config = toml::parse("");
+    }
+}
+
+void Widescreen::init()
+{
+    loadConfig();
+}
+
+void Widescreen::initParamsFromConfig()
+{
+    field_trigger_header* field_triggers_header_ptr = *ff7_externals.field_triggers_header;
+    camera_range.left = field_triggers_header_ptr->camera_range.left;
+    camera_range.right = field_triggers_header_ptr->camera_range.right;
+    camera_range.bottom = field_triggers_header_ptr->camera_range.bottom;
+    camera_range.top = field_triggers_header_ptr->camera_range.top;
+    if(camera_range.right - camera_range.left >= 426)
+        widescreen_mode = WM_EXTEND_ONLY;
+    else
+        widescreen_mode = WM_DISABLED;
+
+    auto pName = get_current_field_name();
+    if(pName == 0) return;
+
+    std::string _name(pName);
+    auto node = config[_name];
+    if(node)
+    {
+        if(auto leftNode = node["left"]) camera_range.left = leftNode.value_or(0);
+        if(auto rightNode = node["right"]) camera_range.right = rightNode.value_or(0);
+        if(auto bottomNode = node["bottom"])camera_range.bottom = bottomNode.value_or(0);
+        if(auto topNode = node["top"]) camera_range.top = topNode.value_or(0);
+
+        if(auto modeNode = node["mode"]) widescreen_mode = static_cast<WIDESCREEN_MODE>(modeNode.value_or(0));
+
+        if(widescreen_mode == WM_ZOOM)
+        {
+            int verticalRangeOffset = 9 * (camera_range.right - camera_range.left) / 16 - 240;
+            camera_range.bottom -= verticalRangeOffset / 2;
+            camera_range.top += verticalRangeOffset / 2;
+        }
+    }
 }

--- a/src/ff7/widescreen.h
+++ b/src/ff7/widescreen.h
@@ -23,6 +23,9 @@
 
 #pragma once
 
+#include "common.h"
+#include "globals.h"
+
 int wide_viewport_x = -106;
 int wide_viewport_y = 0;
 int wide_viewport_width = 854;
@@ -34,3 +37,48 @@ int wide_game_width = 960;
 int wide_game_height = 480;
 
 void ff7_widescreen_hook_init();
+void ff7_field_draw_gray_quads_sub_644E90();
+
+enum WIDESCREEN_MODE
+{
+    WM_DISABLED,
+    WM_EXTEND_ONLY,
+    WM_ZOOM,
+};
+
+class Widescreen
+{
+public:
+    void init();
+    void initParamsFromConfig();
+    void exportConfig();
+    void reloadConfig();
+
+    const field_camera_range& getCameraRange();
+    WIDESCREEN_MODE getMode();
+
+private:
+    void loadConfig();
+
+private:
+    // Config
+    toml::parse_result config;
+
+    field_camera_range camera_range;
+    WIDESCREEN_MODE widescreen_mode = WM_DISABLED;
+};
+
+inline const field_camera_range& Widescreen::getCameraRange()
+{
+    return camera_range;
+}
+
+inline WIDESCREEN_MODE Widescreen::getMode()
+{
+    struct game_mode* mode = getmode_cached();
+    if (mode->driver_mode != MODE_FIELD) return WM_DISABLED;
+
+    return widescreen_mode;
+}
+
+extern Widescreen widescreen;

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -338,6 +338,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.add_page_tile = (void (*)(float, float, float, float, float, uint32_t, uint32_t))get_relative_call(ff7_externals.field_layer2_pick_tiles, 0x327);
 	ff7_externals.field_triggers_header = (field_trigger_header**)get_absolute_value(ff7_externals.field_layer3_pick_tiles, 0x134);
 	ff7_externals.field_camera_rotation_matrix_CFF3D8 = (rotation_matrix*)get_absolute_value(ff7_externals.field_layer3_pick_tiles, 0x7A);
+	ff7_externals.field_draw_gray_quads_644E90 = (void(*)())get_relative_call(ff7_externals.field_draw_everything, 0x360);
 
 	ff7_externals.field_load_textures = get_relative_call(ff7_externals.field_sub_60DCED, 0x107);
 	ff7_externals.field_convert_type2_layers = (void (*)())get_relative_call(ff7_externals.field_load_textures, 0xD);

--- a/src/gl.h
+++ b/src/gl.h
@@ -33,7 +33,8 @@ enum DrawCallType
 	DCT_CLEAR = 0,
 	DCT_BLIT,
 	DCT_DRAW,
-	DCT_DRAW_MOVIE
+	DCT_DRAW_MOVIE,
+	DCT_ZOOM
 };
 
 struct driver_state
@@ -117,6 +118,7 @@ uint32_t gl_defer_sorted_draw(uint32_t primitivetype, uint32_t vertextype, struc
 uint32_t gl_defer_blit_framebuffer(struct texture_set *texture_set, struct tex_header *tex_header);
 uint32_t gl_defer_clear_buffer(uint32_t clear_color, uint32_t clear_depth, struct game_obj *game_object);
 uint32_t gl_defer_yuv_frame(uint32_t buffer_index);
+uint32_t gl_defer_zoom();
 void gl_draw_deferred(draw_field_shadow_callback shadow_callback);
 struct boundingbox calculateSceneAabb();
 void gl_draw_sorted_deferred();

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -233,6 +233,8 @@ void Renderer::updateRendererShaderPaths()
     fragmentShadowMapPath += ".smooth" + shaderSuffix + ".frag";
     vertexFieldShadowPath += ".smooth" + shaderSuffix + ".vert";
     fragmentFieldShadowPath += ".smooth" + shaderSuffix + ".frag";
+    vertexBlitPath += ".flat" + shaderSuffix + ".vert";
+    fragmentBlitPath += ".flat" + shaderSuffix + ".frag";
 }
 
 // Via https://dev.to/pperon/hello-bgfx-4dka
@@ -755,6 +757,12 @@ void Renderer::init()
         true
     );
 
+    backendProgramHandles[RendererProgram::BLIT] = bgfx::createProgram(
+        getShader(vertexBlitPath.c_str()),
+        getShader(fragmentBlitPath.c_str()),
+        true
+    );
+
     vertexLayout
         .begin()
         .add(bgfx::Attrib::Position, 4, bgfx::AttribType::Float)
@@ -1170,37 +1178,66 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
     scissorWidth = getInternalCoordX(width);
     scissorHeight = getInternalCoordY(height);
 
-    if(aspect_ratio == AR_WIDESCREEN)
+    if(aspect_ratio != AR_WIDESCREEN) return;
+
+    struct game_mode* mode = getmode_cached();
+    switch(mode->driver_mode)
     {
-        // Keep the default scissor for FIELD mode movies and credits mode
-        struct game_mode* mode = getmode_cached();
-        bool is_movie_playing = *ff7_externals.word_CC1638 && !ff7_externals.modules_global_object->BGMOVIE_flag;
-        if(is_movie_playing || mode->driver_mode == MODE_CREDITS) {
-            scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
-            return;
-        }
-
-        // This removes the black bars on the top and bottom of the screen
-        if(y = 16 && height == 448)
-        {
-            scissorOffsetY = getInternalCoordY(0.0);
-            scissorHeight = getInternalCoordY(480);
-        }
-
-        // This sets a scissor offset for field with width not enough to fill the screen in 16:9
-        field_trigger_header* field_triggers_header_ptr = *ff7_externals.field_triggers_header;
-        if(mode->driver_mode == MODE_FIELD && *ff7_externals.field_level_data_pointer != 0)
-        {
-            int cameraRange = (field_triggers_header_ptr->camera_range.right - field_triggers_header_ptr->camera_range.left);
-            if(cameraRange < game_width / 2 + abs(wide_viewport_x))
+        case MODE_CREDITS:
             {
+                // Keep the default scissor for credits mode
                 scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
-                return;
             }
-        }
+            break;
+        case MODE_FIELD:
+            {
+                // Keep the default scissor for movies and widescreen disabled fields
+                bool is_movie_playing = *ff7_externals.word_CC1638 && !ff7_externals.modules_global_object->BGMOVIE_flag;
+                if(is_movie_playing || widescreen.getMode() == WM_DISABLED)
+                {
+                    scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
+                    return;
+                }
 
-        // This intercepts the scissor width and makes it bigger to fit widescreen
-        scissorWidth = getInternalCoordX(width + (wide_viewport_width - game_width));
+                // This removes the black bars on the top and bottom of the screen
+                if(y == 16 && height == 448)
+                {
+                    scissorOffsetY = getInternalCoordY(0.0);
+                    scissorHeight = getInternalCoordY(480);
+                }
+
+                // This changes the scissor width and makes it bigger to fit widescreen
+                if(x == 0 && width == game_width)
+                    scissorWidth = getInternalCoordX(wide_viewport_width);
+                else
+                    scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
+            }
+            break;
+            case MODE_SWIRL:
+            {
+                // This removes the black bars on the top and bottom of the screen
+                if(y == 16 && height == 448)
+                {
+                    scissorOffsetY = getInternalCoordY(0.0);
+                    scissorHeight = getInternalCoordY(480);
+                }
+
+                // This changes the scissor width and makes it bigger to fit widescreen
+                if(x == 0 && width == game_width)
+                    scissorWidth = getInternalCoordX(wide_viewport_width);
+                else if (x != 0)
+                    scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
+            }
+            break;
+        default:
+            {
+                // This changes the scissor width and makes it bigger to fit widescreen
+                if(x == 0 && width == game_width)
+                    scissorWidth = getInternalCoordX(wide_viewport_width);
+                else if (x != 0)
+                    scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
+            }
+            break;
     }
 }
 
@@ -1666,6 +1703,92 @@ void Renderer::blitTexture(uint16_t dest, uint32_t x, uint32_t y, uint32_t width
 
     backendViewId++;
     setClearFlags(false, false);
+}
+
+void Renderer::zoomBackendFrameBuffer()
+{
+    if(!internalState.bHasDrawBeenDone) return;
+
+    auto camera_range = widescreen.getCameraRange();
+    int hCameraRangeSize = camera_range.right - camera_range.left;
+    int zoomed_x = wide_viewport_width / 2 - hCameraRangeSize - 1;
+    float vOffset = 240 - 9 * (camera_range.right - camera_range.left) / 16;
+
+    uint16_t newX = getInternalCoordX(zoomed_x);
+    uint16_t newY = getInternalCoordY(vOffset);
+    uint16_t newWidth = newRenderer.getInternalCoordX(2 * hCameraRangeSize);
+    uint16_t newHeight = newRenderer.getInternalCoordY(game_height - vOffset);
+
+    uint16_t texture = newRenderer.createBlitTexture(0, vOffset, game_width, game_height- 2 * vOffset);
+
+    bgfx::TextureHandle textureHandle = { texture };
+
+    backendViewId++;
+    bgfx::setViewClear(backendViewId, BGFX_CLEAR_NONE, internalState.clearColorValue, 1.0f);
+    bgfx::touch(backendViewId);
+    bgfx::blit(backendViewId, textureHandle, 0, 0, bgfx::getTexture(backendFrameBuffer, 0), newX, newY, newWidth, newHeight);
+    backendViewId++;
+    bgfx::setViewClear(backendViewId, BGFX_CLEAR_NONE, internalState.clearColorValue, 1.0f);
+    bgfx::touch(backendViewId);
+
+    /*  y0    y2
+     x0 +-----+ x2
+        |    /|
+        |   / |
+        |  /  |
+        | /   |
+        |/    |
+     x1 +-----+ x3
+        y1    y3
+    */
+
+    // 0
+    float x0 = wide_viewport_x;
+    float y0 = wide_viewport_y;
+    float u0 = 0.0f;
+    float v0 = getCaps()->originBottomLeft ? 1.0f : 0.0f;
+    // 1
+    float x1 = x0;
+    float y1 = wide_viewport_height;
+    float u1 = u0;
+    float v1 = getCaps()->originBottomLeft ? 0.0f : 1.0f;
+    // 2
+    float x2 = x0 + wide_viewport_width;
+    float y2 = y0;
+    float u2 = 1.0f;
+    float v2 = v0;
+    // 3
+    float x3 = x2;
+    float y3 = y1;
+    float u3 = u2;
+    float v3 = v1;
+
+    struct nvertex vertices[] = {
+        {x0, y0, 1.0f, 1.0f, 0xff000000, 0, u0, v0},
+        {x1, y1, 1.0f, 1.0f, 0xff000000, 0, u1, v1},
+        {x2, y2, 1.0f, 1.0f, 0xff000000, 0, u2, v2},
+        {x3, y3, 1.0f, 1.0f, 0xff000000, 0, u3, v3},
+    };
+    WORD indices[] = {
+        0, 1, 2,
+        1, 3, 2
+    };
+
+    backendProgram = RendererProgram::BLIT;
+
+    useTexture(texture);
+
+    bindVertexBuffer(vertices, 0, 4);
+    bindIndexBuffer(indices, 6);
+
+    doDepthTest(false);
+    setCullMode(DISABLED);
+    setBlendMode(RendererBlendMode::BLEND_DISABLED);
+    setPrimitiveType();
+
+    draw();
+
+    if (bgfx::isValid(textureHandle)) bgfx::destroy(textureHandle);
 }
 
 void Renderer::isMovie(bool flag)

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -162,6 +162,7 @@ private:
         FIELD_SHADOW,
         POSTPROCESSING,
         OVERLAY,
+        BLIT,
         COUNT
     };
 
@@ -247,6 +248,8 @@ private:
     std::string fragmentShadowMapPath = "shaders/FFNx.shadowmap";
     std::string vertexFieldShadowPath = "shaders/FFNx.field.shadow";
     std::string fragmentFieldShadowPath = "shaders/FFNx.field.shadow";
+    std::string vertexBlitPath = "shaders/FFNx.blit";
+    std::string fragmentBlitPath = "shaders/FFNx.blit";
 
     bgfx::ViewId backendViewId = 1;
     RendererProgram backendProgram = RendererProgram::SMOOTH;
@@ -373,6 +376,7 @@ public:
     void useTexture(uint16_t texId, uint32_t slot = 0);
     uint32_t createBlitTexture(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
     void blitTexture(uint16_t dest, uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+    void zoomBackendFrameBuffer();
 
     void isMovie(bool flag = false);
     void isTLVertex(bool flag = false);


### PR DESCRIPTION
## Summary

This PR adds the logic to load and use a widescreen config file and implements a zoom logic to fill the 16:9 screen for fields that are not wide enough to extend all the way to 16:9. The changes of this PR are behind checks so that it only affects FF7.

Below is the work contributed by vertex:
- Widescreen: Add hook function just before draws related to text and text boxes

### Motivation

This will allow to increment the number of fields that can be displayed in widescreen mode and therefore improve consistency.
This is optional so when no config file is provided it will work as before.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8