### PR TITLE
Widescreen: Added logic to offset camera scrolling and minor other fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 - Lighting: Fixed various missing graphical elements through the overall game ( Titan missing floor, etc. ) ( https://github.com/julianxhokaxhiu/FFNx/pull/478 )
 - 60FPS: Fix FIELD and WORLD mode text box animation speed (opening, closing, next paging)
 - Widescreen: Added config logic and zoom implementation
+- Widescreen: Added logic to offset camera scrolling and minor other fixes
 
 ## FF8
 

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -275,10 +275,13 @@ void Widescreen::initParamsFromConfig()
     camera_range.right = field_triggers_header_ptr->camera_range.right;
     camera_range.bottom = field_triggers_header_ptr->camera_range.bottom;
     camera_range.top = field_triggers_header_ptr->camera_range.top;
-    if(camera_range.right - camera_range.left >= 426)
+    if(camera_range.right - camera_range.left >= game_width / 2 + abs(wide_viewport_x))
         widescreen_mode = WM_EXTEND_ONLY;
     else
         widescreen_mode = WM_DISABLED;
+    h_offset = 0;
+    v_offset = 0;
+    is_reset_vertical_pos = false;
 
     auto pName = get_current_field_name();
     if(pName == 0) return;
@@ -291,6 +294,9 @@ void Widescreen::initParamsFromConfig()
         if(auto rightNode = node["right"]) camera_range.right = rightNode.value_or(0);
         if(auto bottomNode = node["bottom"])camera_range.bottom = bottomNode.value_or(0);
         if(auto topNode = node["top"]) camera_range.top = topNode.value_or(0);
+        if(auto hOffsetNode = node["h_offset"]) h_offset = hOffsetNode.value_or(0);
+        if(auto vOffsetNode = node["v_offset"]) v_offset = vOffsetNode.value_or(0);
+        if(auto vResetVerticalPosNode = node["reset_vertical_pos"]) is_reset_vertical_pos = vResetVerticalPosNode.value_or(false);
 
         if(auto modeNode = node["mode"]) widescreen_mode = static_cast<WIDESCREEN_MODE>(modeNode.value_or(0));
 

--- a/src/ff7/widescreen.h
+++ b/src/ff7/widescreen.h
@@ -55,6 +55,9 @@ public:
     void reloadConfig();
 
     const field_camera_range& getCameraRange();
+    int getHorizontalOffset();
+    int getVerticalOffset();
+    bool isResetVerticalPos();
     WIDESCREEN_MODE getMode();
 
 private:
@@ -65,12 +68,30 @@ private:
     toml::parse_result config;
 
     field_camera_range camera_range;
+    int h_offset = 0;
+    int v_offset = 0;
+    bool is_reset_vertical_pos = false;
     WIDESCREEN_MODE widescreen_mode = WM_DISABLED;
 };
 
 inline const field_camera_range& Widescreen::getCameraRange()
 {
     return camera_range;
+}
+
+inline int Widescreen::getHorizontalOffset()
+{
+    return h_offset;
+}
+
+inline int Widescreen::getVerticalOffset()
+{
+    return v_offset;
+}
+
+inline bool Widescreen::isResetVerticalPos()
+{
+    return is_reset_vertical_pos;
 }
 
 inline WIDESCREEN_MODE Widescreen::getMode()

--- a/src/gl/deferred.cpp
+++ b/src/gl/deferred.cpp
@@ -676,6 +676,8 @@ void gl_check_deferred(struct texture_set *texture_set)
 void gl_cleanup_deferred()
 {
 	driver_free(deferred_draws);
+	deferred_draws = nullptr;
 	driver_free(deferred_sorted_draws);
+	deferred_sorted_draws = nullptr;
 }
 

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -510,6 +510,8 @@ void Lighting::createWalkmeshBorder(std::vector<struct walkmeshEdge>& edges, flo
 		vector3<float> pos0 = walkMeshVertices[e.v0]._;
 		vector3<float> pos1 = walkMeshVertices[e.v1]._;
 
+		if(e.prevEdge == -1 || e.nextEdge == -1) continue;
+
 		auto& prevEdge = edges[e.prevEdge];
 		auto& nextEdge = edges[e.nextEdge];
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1225,7 +1225,15 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
                 // This changes the scissor width and makes it bigger to fit widescreen
                 if(x == 0 && width == game_width)
                     scissorWidth = getInternalCoordX(wide_viewport_width);
-                else if (x != 0)
+                else
+                    scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
+            }
+            break;
+            case MODE_BATTLE:
+            {
+                if(x == 0 && width == game_width)
+                    scissorWidth = getInternalCoordX(wide_viewport_width);
+                else if(internalState.bIsTLVertex)
                     scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
             }
             break;
@@ -1234,7 +1242,7 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
                 // This changes the scissor width and makes it bigger to fit widescreen
                 if(x == 0 && width == game_width)
                     scissorWidth = getInternalCoordX(wide_viewport_width);
-                else if (x != 0)
+                else
                     scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
             }
             break;
@@ -1719,7 +1727,7 @@ void Renderer::zoomBackendFrameBuffer()
     uint16_t newWidth = newRenderer.getInternalCoordX(2 * hCameraRangeSize);
     uint16_t newHeight = newRenderer.getInternalCoordY(game_height - vOffset);
 
-    uint16_t texture = newRenderer.createBlitTexture(0, vOffset, game_width, game_height- 2 * vOffset);
+    uint16_t texture = newRenderer.createBlitTexture(0, vOffset, 2 * hCameraRangeSize, game_height- 2 * vOffset);
 
     bgfx::TextureHandle textureHandle = { texture };
 


### PR DESCRIPTION
## Summary

This PR adds the logic to offset the camera scrolling so that the camera movement can be adapted to better fit fields that use the zoom functionality.

### Motivation

These changes are done to improve the quality of camera movement in zoomed fields and only affects the widescreen mode when zooming is enabled through the config file.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
