### PR TITLE
Widescreen: Added logic for vertical offset in movies and other minor fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 - Widescreen: Added logic to offset camera scrolling and minor other fixes
 - Modding: Added support for chunked field files
 - Modding: Added support for `direct/*.lgp` direct paths
+- Widescreen: Added logic for vertical offset in movies and other minor fixes
 
 ## FF8
 

--- a/src/ff7/field.cpp
+++ b/src/ff7/field.cpp
@@ -676,10 +676,16 @@ void field_widescreen_width_clip_with_camera_range(vector2<short>* point)
 	if(widescreen.isResetVerticalPos()) point->y = 0;
 	point->y += widescreen.getVerticalOffset();
 
+	if (widescreen.getMode() == WM_EXTEND_ONLY) return;
+
 	if (point->x > camera_range.right - half_width)
 		point->x = camera_range.right - half_width;
 	if (point->x < camera_range.left + half_width)
 		point->x = camera_range.left + half_width;
+	if (point->y > camera_range.bottom - 120)
+		point->y = camera_range.bottom - 120;
+	if (point->y < camera_range.top + 120)
+		point->y = camera_range.top + 120;
 }
 
 void engine_set_game_engine_world_coord_float_661B23(int field_world_x, int field_world_y)

--- a/src/ff7/widescreen.h
+++ b/src/ff7/widescreen.h
@@ -26,14 +26,16 @@
 #include "common.h"
 #include "globals.h"
 
-int wide_viewport_x = -106;
+#include <vector>
+
+int wide_viewport_x = -107;
 int wide_viewport_y = 0;
 int wide_viewport_width = 854;
 int wide_viewport_height = 480;
 
 int wide_game_x = 0;
 int wide_game_y = 0;
-int wide_game_width = 960;
+int wide_game_width = 854;
 int wide_game_height = 480;
 
 void ff7_widescreen_hook_init();
@@ -44,6 +46,19 @@ enum WIDESCREEN_MODE
     WM_DISABLED,
     WM_EXTEND_ONLY,
     WM_ZOOM,
+    WM_EXTEND_WIDE
+};
+
+struct Keyframe
+{
+    int frame = 0;
+    int v_offset = 0;
+};
+
+struct KeyPair
+{
+    Keyframe first;
+    Keyframe second;
 };
 
 class Widescreen
@@ -51,8 +66,7 @@ class Widescreen
 public:
     void init();
     void initParamsFromConfig();
-    void exportConfig();
-    void reloadConfig();
+    void initMovieParamsFromConfig(char *name);
 
     const field_camera_range& getCameraRange();
     int getHorizontalOffset();
@@ -60,18 +74,26 @@ public:
     bool isResetVerticalPos();
     WIDESCREEN_MODE getMode();
 
+    KeyPair getMovieKeyPair(int frame);
+    WIDESCREEN_MODE getMovieMode();
+
 private:
     void loadConfig();
+    void loadMovieConfig();
 
 private:
     // Config
     toml::parse_result config;
+    toml::parse_result movie_config;
 
     field_camera_range camera_range;
     int h_offset = 0;
     int v_offset = 0;
     bool is_reset_vertical_pos = false;
     WIDESCREEN_MODE widescreen_mode = WM_DISABLED;
+
+    std::vector<Keyframe> movie_v_offset;
+    WIDESCREEN_MODE widescreen_movie_mode = WM_DISABLED;
 };
 
 inline const field_camera_range& Widescreen::getCameraRange()
@@ -100,6 +122,11 @@ inline WIDESCREEN_MODE Widescreen::getMode()
     if (mode->driver_mode != MODE_FIELD) return WM_DISABLED;
 
     return widescreen_mode;
+}
+
+inline WIDESCREEN_MODE Widescreen::getMovieMode()
+{
+    return widescreen_movie_mode;
 }
 
 extern Widescreen widescreen;

--- a/src/movies.cpp
+++ b/src/movies.cpp
@@ -27,6 +27,7 @@
 #include "patch.h"
 #include "field.h"
 #include "ff7/defs.h"
+#include "ff7/widescreen.h"
 #include "video/movies.h"
 #include "redirect.h"
 #include "achievement.h"
@@ -84,6 +85,9 @@ uint32_t ff7_prepare_movie(char *name, uint32_t loop, struct dddevice **dddevice
 		}
 	}
 	// ---------------------------
+
+	if(aspect_ratio == AR_WIDESCREEN)
+		widescreen.initMovieParamsFromConfig(filename);
 
 	if(steam_edition || enable_steam_achievements)
 		g_FF7SteamAchievements->initMovieStats(std::string(filename));

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -378,7 +378,7 @@ public:
     void useTexture(uint16_t texId, uint32_t slot = 0);
     uint32_t createBlitTexture(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
     void blitTexture(uint16_t dest, uint32_t x, uint32_t y, uint32_t width, uint32_t height);
-    void zoomBackendFrameBuffer();
+    void zoomBackendFrameBuffer(int x, int y, int width, int height);
 
     void isMovie(bool flag = false);
     void isTLVertex(bool flag = false);


### PR DESCRIPTION
## Summary

Added logic for vertical offset in movies and other minor widescreen fixes. The changes of this PR only take effect when widescreen mode is enabled.

### Motivation

This feature will allow to make movies 16:9 by zooming in a context dependent way so that the camera focuses on the important parts of the image

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
