### PR TITLE
FF7: Improve texture loading speed and caching

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1326,7 +1326,7 @@ void common_unload_texture(struct texture_set *texture_set)
 	// Destroy animated textures
 	if (gl_set->is_animated)
 	{
-		for(std::map<std::string,uint32_t>::iterator it = gl_set->animated_textures.begin(); it != gl_set->animated_textures.end(); ++it) {
+		for(std::map<uint64_t,uint32_t>::iterator it = gl_set->animated_textures.begin(); it != gl_set->animated_textures.end(); ++it) {
 			newRenderer.deleteTexture(it->second);
 		}
 		gl_set->animated_textures.clear();

--- a/src/gl.h
+++ b/src/gl.h
@@ -95,7 +95,7 @@ struct gl_texture_set
 	uint32_t disable_lighting;
 	// ANIMATED TEXTURES
 	uint32_t is_animated;
-	std::map<std::string, uint32_t> animated_textures;
+	std::map<uint64_t, uint32_t> animated_textures;
 	// ADDITIONAL TEXTURES
 	std::map<uint16_t, uint32_t> additional_textures;
 };

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1380,7 +1380,7 @@ bimg::ImageContainer* Renderer::createImageContainer(const char* filename, bimg:
 
 bgfx::TextureHandle Renderer::createTextureHandle(char* filename, uint32_t* width, uint32_t* height, uint32_t* mipCount, bool isSrgb)
 {
-    bgfx::TextureHandle ret = BGFX_INVALID_HANDLE;
+    bgfx::TextureHandle ret = FFNX_RENDERER_INVALID_HANDLE;
     bimg::ImageContainer* img = createImageContainer(filename);
 
     if (img != nullptr)


### PR DESCRIPTION
 - Fix default handle index for DDS texture create (use FFNx one which returns 0 if not found)
 - Remove as much as possible the number of reads on the texture file (Primarily the `stat` function check)
 - Overhaul the texture loading by dividing clearly the animated texture loading and the normal texture loading.

## Summary

Performance improvement for loading textures. The goal is to decrease the number of reads to the file. Instead of verifying the file existence, immediately try to load it. This reduce the number of reads on the file and it will return 0 if the texture file hasn't been loaded.

Also moved up the check for caching for animated texture. Also once an animated texture has been resolved (even with missing texture), this is saved on the hash table cache.

### Motivation

Due to performance issue in 7th with missing textures (e.g. basketball minigame) and cold start on some field map.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [x] I test it on 7th new overhaul and also with 7th caching disabled (the one on Wrap.cs)
- [ ] I only tested it with 60 fps mod + SYW texture mod. We still need to test it with other mods. Also if someone else could try to check the performance improvement, it would be helpful
- [ ] I did test my code on FF8
