### PR TITLE
Add clear depth on BATTLE mode before drawing UI (Related #131)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.14.0...master
 
+## FF7
+
+- Renderer: Fixed graphical glitch happening in battle when 3d models rendered in front of UI (https://github.com/julianxhokaxhiu/FFNx/issues/131)
+
 # 1.14.0
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.13.0...1.14.0

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2929,6 +2929,7 @@ struct ff7_externals
 	void (*display_cait_sith_slots_handler_6E2170)();
 	void (*display_tifa_slots_handler_6E3135)();
 	void (*display_battle_arena_menu_handler_6E384F)();
+	uint32_t battle_set_do_render_menu_call;
 	uint32_t battle_set_do_render_menu;
 	int *g_do_render_menu;
 	uint32_t battle_menu_update_call;

--- a/src/ff7/battle/defs.h
+++ b/src/ff7/battle/defs.h
@@ -38,4 +38,7 @@ namespace ff7::battle
     void load_battle_stage(int param_1, int battle_location_id, int **param_3);
     void battle_sub_5C7F94(int param_1, int param_2);
     void display_battle_action_text_sub_6D71FA(short command_id, short action_id);
+
+    // Menu
+    void battle_menu_enter();
 }

--- a/src/ff7/battle/menu.cpp
+++ b/src/ff7/battle/menu.cpp
@@ -22,11 +22,20 @@
 /****************************************************************************/
 
 #include "../../globals.h"
+#include "../../renderer.h"
 
 #include "menu.h"
+#include "defs.h"
 
 namespace ff7::battle
 {
+    void battle_menu_enter()
+    {
+        *ff7_externals.g_do_render_menu = 0;
+        if(!enable_lighting)
+            newRenderer.clearDepthBuffer();
+    }
+
     void update_battle_menu()
     {
         ((void(*)())ff7_externals.battle_menu_update_6CE8B3)();

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1098,6 +1098,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.display_cait_sith_slots_handler_6E2170 = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1BB);
 	ff7_externals.display_tifa_slots_handler_6E3135 = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1C2);
 	ff7_externals.display_battle_arena_menu_handler_6E384F = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1C9);
+	ff7_externals.battle_set_do_render_menu_call = battle_main_loop + 0x32A;
 	ff7_externals.battle_set_do_render_menu = get_relative_call(battle_main_loop, 0x32A);
 	ff7_externals.g_do_render_menu = (int*)get_absolute_value(ff7_externals.battle_set_do_render_menu, 0x7);
 	ff7_externals.battle_menu_animation_idx = (int*)get_absolute_value(ff7_externals.battle_menu_update_6CE8B3, 0x144);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -174,6 +174,11 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	patch_code_byte(ff7_externals.coaster_sub_5EE150 + 0x16D, 5);
 	patch_code_byte(ff7_externals.coaster_sub_5EE150 + 0x190, 5);
 
+	// ##################################
+	// menu UI glitch fix
+	// ##################################
+	replace_call_function(ff7_externals.battle_set_do_render_menu_call, ff7::battle::battle_menu_enter);
+
 	// #####################
 	// widescreen
 	// #####################

--- a/src/gl/special_case.cpp
+++ b/src/gl/special_case.cpp
@@ -111,10 +111,11 @@ uint32_t gl_special_case(uint32_t primitivetype, uint32_t vertextype, struct nve
 		if(SAFE_GFXOBJ_CHECK(graphics_object, ff7_externals.menu_objects->menu_fade)) defer = true;
 		if(SAFE_GFXOBJ_CHECK(graphics_object, ff7_externals.menu_objects->blend_window_bg)) defer = true;
 
-		if(mode == MODE_BATTLE && vertextype == TLVERTEX)
+		if(mode == MODE_BATTLE)
 		{
-			// z-sort all obvious GUI elements in battle
-			if(!(current_state.viewport[2] == 640 && (current_state.viewport[3] == 332 || current_state.viewport[3] == 480)) || vertexcount == 4) defer = true;
+			// z-sort some GUI elements in battle
+			if(SAFE_GFXOBJ_CHECK(graphics_object, ff7_externals.menu_objects->unknown2)) defer = true; // Limit and barrier bar (necessary for ESUI)
+			if(SAFE_GFXOBJ_CHECK(graphics_object, ff7_externals.menu_objects->unknown3)) defer = true; // Limit and barrier bar (necessary for ESUI)
 		}
 	}
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1092,6 +1092,9 @@ void Renderer::show()
 
     bgfx::dbgTextClear();
 
+    for(int i = 1; i <= backendViewId; i++)
+        bgfx::resetView(i);
+
     backendViewId = 1;
 
     vertexBufferData.clear();
@@ -1788,6 +1791,18 @@ void Renderer::zoomBackendFrameBuffer(int x, int y, int width, int height)
     draw();
 
     if (bgfx::isValid(textureHandle)) bgfx::destroy(textureHandle);
+}
+
+void Renderer::clearDepthBuffer()
+{
+    backendViewId++;
+    bgfx::setViewMode(backendViewId, bgfx::ViewMode::Sequential);
+    bgfx::setViewRect(backendViewId, 0, 0, framebufferWidth, framebufferHeight);
+    bgfx::setViewFrameBuffer(backendViewId, backendFrameBuffer);
+    bgfx::setViewClear(backendViewId, BGFX_CLEAR_DEPTH);
+    bgfx::touch(backendViewId);
+
+    if (trace_all || trace_renderer) ffnx_trace("Renderer::%s: Clearing depth\n", __func__, backendViewId);
 }
 
 void Renderer::isMovie(bool flag)

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -379,6 +379,7 @@ public:
     uint32_t createBlitTexture(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
     void blitTexture(uint16_t dest, uint32_t x, uint32_t y, uint32_t width, uint32_t height);
     void zoomBackendFrameBuffer(int x, int y, int width, int height);
+    void clearDepthBuffer();
 
     void isMovie(bool flag = false);
     void isTLVertex(bool flag = false);


### PR DESCRIPTION
## Summary

 - Clear the frame buffer depth
 - Add `bgfx::resetView` on all used viewId at each frame to avoid view collision at the next frame to allow to have dynamic number of views at each frame.
 - Change logic to select battle UI elements to defer. Use a more clear condition.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
