### PR TITLE
60FPS: Fix fading speed in FIELD mode screen transitions

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2602,6 +2602,7 @@ struct ff7_externals
 	uint32_t field_sub_661B68;
 	void (*engine_set_game_engine_world_coord_661B23)(int, int);
 	void (*engine_sub_67CCDE)(float, float, float, float, float, float, float, ff7_game_obj*);
+	uint32_t field_handle_screen_fading;
 	uint32_t field_opcode_message_update_loop_630D50;
 	uint32_t field_text_box_window_create_631586;
 	uint32_t field_text_box_window_opening_6317A9;

--- a/src/ff7/field/field.cpp
+++ b/src/ff7/field/field.cpp
@@ -221,6 +221,11 @@ namespace ff7::field
 
                 // Model blinking: wait time and blink time
                 replace_call_function(ff7_externals.field_animate_3d_models_6392BB + 0x8A7, ff7_field_blink_3d_model);
+
+                // Fade in and fade out screen transitions
+                patch_divide_code<short>(ff7_externals.field_initialize_variables + 0x123, common_frame_multiplier);
+                patch_code_byte(ff7_externals.field_handle_screen_fading + 0x210, 25 * common_frame_multiplier);
+                patch_code_int(ff7_externals.field_handle_screen_fading + 0x240, 25 * common_frame_multiplier - 1);
             }
 
             // Smooth background movement for both 30 fps mode and 60 fps mode
@@ -237,7 +242,7 @@ namespace ff7::field
         replace_call_function(ff7_externals.field_update_models_positions + 0xA2B, ff7_field_update_model_animation_frame);
         replace_call_function(ff7_externals.field_update_models_positions + 0xE8C, ff7_field_update_model_animation_frame);
 
-            // Background scroll fps fix
+        // Background scroll fps fix
         replace_call_function(common_externals.execute_opcode_table[BGSCR] + 0x34, ff7_opcode_divide_get_bank_value);
         replace_call_function(common_externals.execute_opcode_table[BGSCR] + 0x4D, ff7_opcode_divide_get_bank_value);
         replace_call_function(common_externals.execute_opcode_table[BGSCR] + 0x68, ff7_opcode_divide_get_bank_value);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -595,6 +595,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.field_prev_world_pos_y = (short*)get_absolute_value((uint32_t)ff7_externals.field_sub_640EB7, 0x18);
 	ff7_externals.engine_set_game_engine_world_coord_661B23 = (void (*)(int, int))get_relative_call(ff7_externals.field_sub_661B68, 0x1A);
 	ff7_externals.engine_sub_67CCDE = (void (*)(float, float, float, float, float, float, float, ff7_game_obj*))get_relative_call(ff7_externals.field_sub_661B68, 0x72);
+	ff7_externals.field_handle_screen_fading = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x634);
 
 	ff7_externals.sfx_stop_channel_6 = get_relative_call(common_externals.sfx_cleanup, 0x16);
 	ff7_externals.sfx_stop_channel_timer_handle = (UINT *)get_absolute_value(ff7_externals.sfx_stop_channel_6, 0x5);


### PR DESCRIPTION
## Summary

Fix fading speed in FIELD screen transitions by decreasing a the fading speed for fade in and fade out.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
