### PR TITLE
FF7: Fix 3D model drawn over UI on BATTLE mode if lighting enabled

### DIFF
--- a/src/ff7/battle/menu.cpp
+++ b/src/ff7/battle/menu.cpp
@@ -32,8 +32,14 @@ namespace ff7::battle
     void battle_menu_enter()
     {
         *ff7_externals.g_do_render_menu = 0;
-        if(!enable_lighting)
-            newRenderer.clearDepthBuffer();
+        battle_depth_clear();
+    }
+
+    void battle_depth_clear()
+    {
+        if(gl_defer_battle_depth_clear()) return;
+
+        newRenderer.clearDepthBuffer();
     }
 
     void update_battle_menu()

--- a/src/ff7/battle/menu.h
+++ b/src/ff7/battle/menu.h
@@ -30,4 +30,5 @@ namespace ff7::battle
     void display_cait_sith_slots_handler();
     void display_battle_arena_menu_handler();
     void delay_battle_target_pointer_animation_type();
+    void battle_depth_clear();
 }

--- a/src/gl.h
+++ b/src/gl.h
@@ -34,6 +34,7 @@ enum DrawCallType
 	DCT_BLIT,
 	DCT_DRAW,
 	DCT_DRAW_MOVIE,
+	DCT_BATTLE_DEPTH_CLEAR,
 	DCT_ZOOM
 };
 
@@ -118,6 +119,7 @@ uint32_t gl_defer_sorted_draw(uint32_t primitivetype, uint32_t vertextype, struc
 uint32_t gl_defer_blit_framebuffer(struct texture_set *texture_set, struct tex_header *tex_header);
 uint32_t gl_defer_clear_buffer(uint32_t clear_color, uint32_t clear_depth, struct game_obj *game_object);
 uint32_t gl_defer_yuv_frame(uint32_t buffer_index);
+uint32_t gl_defer_battle_depth_clear();
 uint32_t gl_defer_zoom();
 void gl_draw_deferred(draw_field_shadow_callback shadow_callback);
 struct boundingbox calculateSceneAabb();


### PR DESCRIPTION
Fixes #131

## Summary

The same fix as below but for lighting enabled:
https://github.com/julianxhokaxhiu/FFNx/pull/501

### Motivation

The motivation is to make Kuraudo happy. The expected outcome is Kuraudo being happy.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file -> changelog was already changed by vertex
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
