### PR TITLE
60FPS: Fix BATTLE mode outro fading speed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 - Core: Fix Barret's eyebrow not loading ( https://github.com/julianxhokaxhiu/FFNx/issues/107 )
 - 60FPS: Fix fading speed in FIELD mode screen transitions ( https://github.com/julianxhokaxhiu/FFNx/pull/503 )
+- 60FPS: Fix fading out speed in BATTLE mode exit screen transition
 - Renderer: Fixed graphical glitch happening in battle when 3d models rendered in front of UI ( https://github.com/julianxhokaxhiu/FFNx/issues/131 )
 - Voice: Add play voice for enemy actions during BATTLE mode ( https://github.com/julianxhokaxhiu/FFNx/pull/502 )
 - Widescreen: Allow the buster sword image on new game screen to support 16:9 ratio ( https://github.com/julianxhokaxhiu/FFNx/pull/506 )

--- a/src/ff7/battle/camera.cpp
+++ b/src/ff7/battle/camera.cpp
@@ -286,9 +286,12 @@ namespace ff7::battle
         replace_call_function(ff7_externals.handle_camera_functions + 0x4B, run_camera_position_script);
 
         // Battle outro camera frame fix: patch DAT_009AE138 (frames to wait before closing battle mode)
-        patch_multiply_code<byte>(ff7_externals.battle_sub_430DD0 + 0x3DE, battle_frame_multiplier);
-        patch_multiply_code<byte>(ff7_externals.battle_sub_430DD0 + 0x361, battle_frame_multiplier);
-        patch_multiply_code<byte>(ff7_externals.battle_sub_430DD0 + 0x326, battle_frame_multiplier);
+        patch_multiply_code<DWORD>(ff7_externals.battle_sub_430DD0 + 0x3DE, battle_frame_multiplier);
+        patch_multiply_code<DWORD>(ff7_externals.battle_sub_430DD0 + 0x361, battle_frame_multiplier);
+        patch_multiply_code<DWORD>(ff7_externals.battle_sub_430DD0 + 0x326, battle_frame_multiplier);
+
+        // Battle outro fading speed fix
+        patch_multiply_code<byte>(ff7_externals.battle_sub_430DD0 + 0x60E, battle_frame_multiplier);
 
         // Battle intro camera frame fix: patch DAT_00BFD0F4 (frames to wait before atb starts)
         patch_multiply_code<byte>(ff7_externals.battle_sub_429AC0 + 0x152, battle_frame_multiplier);


### PR DESCRIPTION
## Summary

Fix fading out speed in BATTLE mode when exiting from battle mode. Also change generic type in few patches (just a refactor. Shouldn't change anything).

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
