### PR TITLE
FF7: Fixed time cycle filter not applying in battle mode

### DIFF
--- a/src/ff7/battle/menu.cpp
+++ b/src/ff7/battle/menu.cpp
@@ -33,6 +33,8 @@ namespace ff7::battle
     {
         *ff7_externals.g_do_render_menu = 0;
         battle_depth_clear();
+
+        if (enable_time_cycle) newRenderer.setTimeFilterEnabled(false);
     }
 
     void battle_depth_clear()

--- a/src/ff7/time.cpp
+++ b/src/ff7/time.cpp
@@ -217,12 +217,7 @@ namespace ff7
         else color = nightColor;
 
         newRenderer.setTimeEnabled(true);
-
-        if(mode->driver_mode == MODE_FIELD || mode->driver_mode == MODE_WORLDMAP)
-            newRenderer.setTimeFilterEnabled(true);
-        else
-            newRenderer.setTimeFilterEnabled(false);
-
+        newRenderer.setTimeFilterEnabled(true);
         newRenderer.setTimeColor(color);
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes the time cycle filter not applying in battle mode.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
