### PR TITLE
60FPS: Fix Climhazzard random crash on poisoned enemy

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 - 60FPS: Fix fading speed in FIELD mode screen transitions ( https://github.com/julianxhokaxhiu/FFNx/pull/503 )
 - 60FPS: Fix fading out speed in BATTLE mode exit screen transition
+- 60FPS: Fix Climhazzard random crash on enemies with status effects ( https://github.com/julianxhokaxhiu/FFNx/pull/516 )
 - Core: Fix Barret's eyebrow not loading ( https://github.com/julianxhokaxhiu/FFNx/issues/107 )
 - Modding: Added day-night time cycle system that can be controled from field scripts ( https://github.com/julianxhokaxhiu/FFNx/pull/511 )
 - Renderer: Fixed graphical glitch happening in battle when 3d models rendered in front of UI ( https://github.com/julianxhokaxhiu/FFNx/issues/131 )

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2814,6 +2814,7 @@ struct ff7_externals
 	uint32_t tifa_limit_1_2_sub_4E3D51;
 	uint32_t tifa_limit_2_1_sub_4E48D4;
 	uint32_t aerith_limit_2_1_sub_45B0CF;
+	uint32_t cloud_limit_2_2_sub_467256;
 	uint32_t vincent_limit_satan_slam_camera_45CF2A;
 	uint32_t barret_limit_4_1_camera_4688A2;
 	uint32_t barret_limit_4_1_model_movement_4698EF;

--- a/src/ff7/battle/animations.cpp
+++ b/src/ff7/battle/animations.cpp
@@ -1355,6 +1355,7 @@ namespace ff7::battle
         fixed_effect100_addresses.insert(ff7_externals.goblin_punch_flash_573291);
         fixed_effect100_addresses.insert(ff7_externals.run_ifrit_movement_596702);
         fixed_effect100_addresses.insert(ff7_externals.vincent_limit_fade_effect_sub_5D4240);
+        fixed_effect100_addresses.insert(ff7_externals.cloud_limit_2_2_sub_467256);
         one_call_effect100_addresses.insert(ff7_externals.run_bahamut_zero_main_loop_484A16);
         one_call_effect100_addresses.insert(ff7_externals.death_sentence_main_loop_5661A0);
         one_call_effect100_addresses.insert(ff7_externals.roulette_skill_main_loop_566287);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -887,6 +887,11 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	uint32_t aerith_limit_2_1_sub_45AEE8 = get_absolute_value(aerith_limit_2_1_sub_45AEA6, 0xE);
 	uint32_t aerith_limit_2_1_sub_45AF39 = get_absolute_value(aerith_limit_2_1_sub_45AEE8, 0x5);
 	ff7_externals.aerith_limit_2_1_sub_45B0CF = get_absolute_value(aerith_limit_2_1_sub_45AF39, 0x4A);
+	uint32_t cloud_limit_2_2_main_466A31 = ff7_externals.limit_break_effects_fn_table[3];
+	uint32_t cloud_limit_2_2_sub_466A57 = get_relative_call(cloud_limit_2_2_main_466A31, 0x1A);
+	uint32_t cloud_limit_2_2_sub_466A7A = get_absolute_value(cloud_limit_2_2_sub_466A57, 0x15);
+	uint32_t cloud_limit_2_2_sub_466CD2 = get_absolute_value(cloud_limit_2_2_sub_466A7A, 0x185);
+	ff7_externals.cloud_limit_2_2_sub_467256 = get_absolute_value(cloud_limit_2_2_sub_466CD2, 0x38C);
 	uint32_t aerith_limit_4_1_sub_473A70 = ff7_externals.limit_break_effects_fn_table[20];
 	uint32_t aerith_limit_4_1_sub_473B84 = get_relative_call(aerith_limit_4_1_sub_473A70, 0xAA);
 	uint32_t aerith_limit_4_1_sub_473C82 = get_relative_call(aerith_limit_4_1_sub_473B84, 0xB7);


### PR DESCRIPTION
## Summary

With 60 FPS mod, when using Climhazzard against enemy with status (e.g. poison), can cause a crash. This crash does not happen always, but somehow "randomly". I do not know the real cause, but I just disabled any decorator wrapper on the battle effect function that cause the crash. After testing it more than 10 times, I didn't get any crash.

### Motivation

A user reported it.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
