### PR TITLE
FF7: Fixed time cycle filter applying over the action text box in battle mode

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2932,6 +2932,9 @@ struct ff7_externals
 	void (*display_cait_sith_slots_handler_6E2170)();
 	void (*display_tifa_slots_handler_6E3135)();
 	void (*display_battle_arena_menu_handler_6E384F)();
+	uint32_t battle_draw_text_ui_graphics_objects_call;
+	uint32_t battle_draw_box_ui_graphics_objects_call;
+	void (*battle_draw_call_42908C)(int, int);
 	uint32_t battle_set_do_render_menu_call;
 	uint32_t battle_set_do_render_menu;
 	int *g_do_render_menu;

--- a/src/ff7/battle/defs.h
+++ b/src/ff7/battle/defs.h
@@ -41,4 +41,5 @@ namespace ff7::battle
 
     // Menu
     void battle_menu_enter();
+    void draw_ui_graphics_objects_wrapper(int flag, int type);
 }

--- a/src/ff7/battle/menu.cpp
+++ b/src/ff7/battle/menu.cpp
@@ -76,4 +76,13 @@ namespace ff7::battle
             (*ff7_externals.targeting_actor_id_DC3C98)++;
         }
     }
+
+    void draw_ui_graphics_objects_wrapper(int flag, int type)
+    {
+        if (enable_time_cycle) newRenderer.setTimeFilterEnabled(false);
+
+        ff7_externals.battle_draw_call_42908C(flag, type);
+
+        if (enable_time_cycle) newRenderer.setTimeFilterEnabled(true);
+    }
 }

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1105,6 +1105,9 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.display_cait_sith_slots_handler_6E2170 = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1BB);
 	ff7_externals.display_tifa_slots_handler_6E3135 = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1C2);
 	ff7_externals.display_battle_arena_menu_handler_6E384F = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1C9);
+	ff7_externals.battle_draw_text_ui_graphics_objects_call = battle_main_loop + 0x289;
+	ff7_externals.battle_draw_box_ui_graphics_objects_call = battle_main_loop + 0x2CF;
+	ff7_externals.battle_draw_call_42908C = (void(*)(int, int))get_relative_call(battle_main_loop, 0x2CF);
 	ff7_externals.battle_set_do_render_menu_call = battle_main_loop + 0x32A;
 	ff7_externals.battle_set_do_render_menu = get_relative_call(battle_main_loop, 0x32A);
 	ff7_externals.g_do_render_menu = (int*)get_absolute_value(ff7_externals.battle_set_do_render_menu, 0x7);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -318,9 +318,12 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	//######################
 	if (enable_time_cycle)
 	{
+		replace_call_function(ff7_externals.battle_draw_text_ui_graphics_objects_call, ff7::battle::draw_ui_graphics_objects_wrapper);
+		replace_call_function(ff7_externals.battle_draw_box_ui_graphics_objects_call, ff7::battle::draw_ui_graphics_objects_wrapper);
+
 		replace_call_function(ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x175, ff7::world::wm0_draw_minimap_quad_graphics_object);
-        replace_call_function(ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x1BE, ff7::world::wm0_draw_world_effects_1_graphics_object);
-        replace_call_function(ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x208, ff7::world::wm0_draw_minimap_points_graphics_object);
+		replace_call_function(ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x1BE, ff7::world::wm0_draw_world_effects_1_graphics_object);
+		replace_call_function(ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x208, ff7::world::wm0_draw_minimap_points_graphics_object);
 	}
 
 	//#############################


### PR DESCRIPTION
Co-authored-by: Tangtang Zhou <5919707+tangtang95@users.noreply.github.com>

## Summary

This PR fixes the time cycle filter applying over the action text box in battle mode.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
