### PR TITLE
FF7: Added logic to update a month string variable for the time cycle system

### DIFF
--- a/misc/FFNx.time.toml
+++ b/misc/FFNx.time.toml
@@ -28,6 +28,14 @@
 # hours_address : address for pointer to unused game data to store the hours
 # days_address : address for pointer to unused game data to store the days
 # months_address : address for pointer to unused game data to store the months
+
+# month_char_0_address : address to the first character of the month string
+# month_char_1_address : address to the second character of the month string
+# month_char_2_address : address to the third character of the month string
+
+# month_x_char_0 : value of first character of month x (replace x by month index between 0 and 11)
+# month_x_char_1 : value of first character of month x (replace x by month index between 0 and 11)
+# month_x_char_2 : value of first character of month x (replace x by month index between 0 and 11)
 ###############################################################################
 
 #sunrise_time = 6.0
@@ -48,3 +56,55 @@
 #hours_address = "DC08EB"
 #days_address = "DC08EA"
 #months_address = "DC08E9"
+
+#month_char_0_address = "DC0BFC"
+#month_char_1_address = "DC0BFD"
+#month_char_2_address = "DC0BFE"
+
+#month_0_char_0 = 42
+#month_0_char_1 = 65
+#month_0_char_2 = 78
+
+#month_1_char_0 = 38
+#month_1_char_1 = 69
+#month_1_char_2 = 66
+
+#month_2_char_0 = 45
+#month_2_char_1 = 65
+#month_2_char_2 = 82
+
+#month_3_char_0 = 33
+#month_3_char_1 = 65
+#month_3_char_2 = 89
+
+#month_4_char_0 = 45
+#month_4_char_1 = 65
+#month_4_char_2 = 89
+
+#month_5_char_0 = 42
+#month_5_char_1 = 85
+#month_5_char_2 = 78
+
+#month_6_char_0 = 42
+#month_6_char_1 = 85
+#month_6_char_2 = 76
+
+#month_7_char_0 = 33
+#month_7_char_1 = 85
+#month_7_char_2 = 71
+
+#month_8_char_0 = 51
+#month_8_char_1 = 69
+#month_8_char_2 = 80
+
+#month_9_char_0 = 47
+#month_9_char_1 = 67
+#month_9_char_2 = 84
+
+#month_10_char_0 = 46
+#month_10_char_1 = 79
+#month_10_char_2 = 86
+
+#month_11_char_0 = 36
+#month_11_char_1 = 69
+#month_11_char_2 = 67

--- a/src/ff7/time.cpp
+++ b/src/ff7/time.cpp
@@ -120,6 +120,34 @@ namespace ff7
             auto str = monthsAddressStr.value();
             pMonths = (byte*)(std::strtol(str.data(), nullptr, 16));
         }
+
+        auto monthChar0AddressStr = config["month_char_0_address"].value<std::string>();
+        if(monthChar0AddressStr.has_value())
+        {
+            auto str = monthChar0AddressStr.value();
+            pMonthChar0 = (byte*)(std::strtol(str.data(), nullptr, 16));
+        }
+
+        auto monthChar1AddressStr = config["month_char_1_address"].value<std::string>();
+        if(monthChar1AddressStr.has_value())
+        {
+            auto str = monthChar1AddressStr.value();
+            pMonthChar1 = (byte*)(std::strtol(str.data(), nullptr, 16));
+        }
+
+        auto monthChar2AddressStr = config["month_char_2_address"].value<std::string>();
+        if(monthChar2AddressStr.has_value())
+        {
+            auto str = monthChar2AddressStr.value();
+            pMonthChar2 = (byte*)(std::strtol(str.data(), nullptr, 16));
+        }
+
+        for (int i = 0; i < 12; ++i)
+        {
+            monthChar0[i] = config["month_" + std::to_string(i) + "_char_0"].value_or(0);
+            monthChar1[i] = config["month_" + std::to_string(i) + "_char_1"].value_or(0);
+            monthChar2[i] = config["month_" + std::to_string(i) + "_char_2"].value_or(0);
+        }
     }
 
     void time_hook_init()
@@ -191,6 +219,13 @@ namespace ff7
         if((*pMonths) >= 12)
         {
             (*pMonths) = 0;
+        }
+
+        if(pMonthChar0 != nullptr && pMonthChar1 != nullptr && pMonthChar2 != nullptr)
+        {
+            *pMonthChar0 = monthChar0[*pMonths];
+            *pMonthChar1 = monthChar1[*pMonths];
+            *pMonthChar2 = monthChar2[*pMonths];
         }
 
         if(mode->driver_mode == MODE_FIELD ||

--- a/src/ff7/time.h
+++ b/src/ff7/time.h
@@ -57,6 +57,14 @@ namespace ff7
             byte* pHours = nullptr;
             byte* pDays = nullptr;
             byte* pMonths = nullptr;
+
+            byte* pMonthChar0 = nullptr;
+            byte* pMonthChar1 = nullptr;
+            byte* pMonthChar2 = nullptr;
+
+            byte monthChar0[12];
+            byte monthChar1[12];
+            byte monthChar2[12];
     };
 
     extern Time time;


### PR DESCRIPTION
## Summary

This PR adds the logic to update a month string variable for the time cycle system.

### Motivation

This allows the month string update to be managed by FFNx instead of requiring a field script to update. It also allows it to be updated when in other modes such as battle and worldmap.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
