### PR TITLE
FF7: Fix FIELD mode text box flickering rendering

### DIFF
--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1098,8 +1098,10 @@ void Renderer::show()
 
     bgfx::dbgTextClear();
 
-    for(int i = 1; i <= backendViewId; i++)
-        bgfx::resetView(i);
+    if(!ff8 && getmode_cached()->driver_mode == MODE_BATTLE) {
+        for(int i = 0; i <= backendViewId; i++)
+            bgfx::resetView(i);
+    }
 
     backendViewId = 1;
 


### PR DESCRIPTION
## Summary

Apply bgfx reset view only when it is FF7 and in battle mode.

### Motivation

The reset view caused a regression bug on FIELD mode where some text box when closed caused flickering. By applying the reset view only in battle mode, we avoid the issue and still keep this fix https://github.com/julianxhokaxhiu/FFNx/pull/508

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
