### PR TITLE
Common: Use Game loop to render the FFNx logo

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -932,8 +932,10 @@ uint32_t common_init(struct game_obj *game_object)
 
 	proxyWndProc = true;
 
-	// Small rendering loop to draw the FFNx logo before the game starts
-	drawFFNxLogo(game_object);
+	if (!ff8) {
+		// Small rendering loop to draw the FFNx logo before the game starts
+		drawFFNxLogo(game_object);
+	}
 
 	return true;
 }
@@ -3330,6 +3332,10 @@ void ffnx_inject_driver(struct game_obj* game_object)
 	VRASS(game_object, create_gfx_driver, new_dll_graphics_driver);
 }
 
+#if defined(__cplusplus)
+}
+#endif
+
 void drawFFNxLogo(struct game_obj* game_object)
 {
 	VOBJ(game_obj, game_object, game_object);
@@ -3338,24 +3344,13 @@ void drawFFNxLogo(struct game_obj* game_object)
 	time_t gametime;
 	double framerate = 60.0f;
 
-	int frame_count = 180;
-	int fade_frame_count = frame_count / 3;
-	float fade = 0.0;
+	int frame_count = FFNX_LOGO_FRAME_COUNT;
 
 	qpc_get_time(&last_gametime);
 
 	for(int i = 0; i < frame_count; ++i)
 	{
-		if(i < fade_frame_count)
-			fade =  i / static_cast<float>(fade_frame_count);
-		else if(i < 2 * fade_frame_count)
-			fade = 1.0f;
-		else
-			fade =  1.0f - (i - 2 * fade_frame_count) / static_cast<float>(fade_frame_count);
-
-		newRenderer.drawFFNxLogo(fade);
-
-		common_flip(game_object);
+		drawFFNxLogoFrame(game_object, i, frame_count);
 
 		do qpc_get_time(&gametime);
 		while ((gametime > last_gametime) && qpc_diff_time(&gametime, &last_gametime, NULL) < VREF(game_object, countspersecond) / framerate);
@@ -3364,6 +3359,21 @@ void drawFFNxLogo(struct game_obj* game_object)
 	}
 }
 
-#if defined(__cplusplus)
+void drawFFNxLogoFrame(struct game_obj* game_object, int frame, int frame_count)
+{
+	VOBJ(game_obj, game_object, game_object);
+
+	int fade_frame_count = frame_count / 3;
+	float fade = 0.0;
+
+	if(frame < fade_frame_count)
+		fade = frame / static_cast<float>(fade_frame_count);
+	else if(frame < 2 * fade_frame_count)
+		fade = 1.0f;
+	else
+		fade = 1.0f - (frame - 2 * fade_frame_count) / static_cast<float>(fade_frame_count);
+
+	newRenderer.drawFFNxLogo(fade);
+
+	common_flip(game_object);
 }
-#endif

--- a/src/common.h
+++ b/src/common.h
@@ -344,7 +344,5 @@ void ffnx_inject_driver(struct game_obj* game_object);
 }
 #endif
 
-constexpr int FFNX_LOGO_FRAME_COUNT = 180;
-
-void drawFFNxLogo(struct game_obj* game_object);
-void drawFFNxLogoFrame(struct game_obj* game_object, int frame, int frame_count);
+bool drawFFNxLogoFrame(struct game_obj* game_object);
+void stopDrawFFNxLogo();

--- a/src/common.h
+++ b/src/common.h
@@ -340,8 +340,11 @@ extern "C" {
 
 void ffnx_inject_driver(struct game_obj* game_object);
 
-void drawFFNxLogo(struct game_obj* game_object);
-
 #if defined(__cplusplus)
 }
 #endif
+
+constexpr int FFNX_LOGO_FRAME_COUNT = 180;
+
+void drawFFNxLogo(struct game_obj* game_object);
+void drawFFNxLogoFrame(struct game_obj* game_object, int frame, int frame_count);

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -3051,6 +3051,8 @@ struct ff7_externals
 	uint32_t shadow_flare_draw_white_bg_57747E;
 	uint32_t credits_submit_draw_fade_quad_7AA89B;
 	uint32_t menu_submit_draw_fade_quad_6CD64E;
+	int (*get_button_pressed)(int);
+	uint32_t credits_main_loop;
 	uint32_t highway_submit_fade_quad_659532;
 	uint32_t chocobo_enter_76D597;
 	uint32_t chocobo_initialize_variables_76BAFD;

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -661,7 +661,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	common_externals.previous_field_id = (WORD*)get_absolute_value(ff7_externals.sub_408074, 0x4F); // 0xCC0DEC
 	common_externals.update_entities_call = common_externals.update_field_entities + 0x461; // 0x60CDAE
 
-	ff7_externals.field_level_data_pointer = (byte**)get_absolute_value(ff7_externals.read_field_file, 0xB2); // 0xCFF594
+	ff7_externals.field_level_data_pointer = (byte**)ff7_externals.field_file_buffer; // 0xCFF594
 
 	ff7_externals.sub_408116 = get_relative_call(ff7_externals.field_loop_sub_63C17F, 0x2A);
 	ff7_externals.word_CC16E8 = (char *)get_absolute_value(ff7_externals.sub_408116, 0x8E);
@@ -1238,6 +1238,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 
 	ff7_externals.cdcheck_enter_sub = get_absolute_value(main_loop, 0x390);
 	ff7_externals.credits_submit_draw_fade_quad_7AA89B = get_relative_call(credits_main_loop, 0xD9);
+	ff7_externals.get_button_pressed = (int(*)(int))get_relative_call(credits_main_loop, 0x14C);
+	ff7_externals.credits_main_loop = credits_main_loop;
 	ff7_externals.menu_submit_draw_fade_quad_6CD64E = get_relative_call(ff7_externals.menu_battle_end_sub_6C9543, 0x104);
 	ff7_externals.highway_submit_fade_quad_659532 = get_relative_call(ff7_externals.highway_loop_sub_650F36, 0x126);
 	ff7_externals.chocobo_init_viewport_values_76D320 = get_relative_call(main_init_loop, 0x38B);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -35,6 +35,19 @@
 unsigned char midi_fix[] = {0x8B, 0x4D, 0x14};
 WORD snowboard_fix[] = {0x0F, 0x10, 0x0F};
 
+uint32_t ff7_credits_loop_gfx_begin_scene(uint32_t unknown, struct game_obj *game_object)
+{
+	if (drawFFNxLogoFrame(game_object)) {
+		if (ff7_externals.get_button_pressed(-1)) {
+			stopDrawFFNxLogo();
+		}
+
+		return 0;
+	}
+
+	return common_begin_scene(unknown, game_object);
+}
+
 void ff7_init_hooks(struct game_obj *_game_object)
 {
 	struct ff7_game_obj *game_object = (struct ff7_game_obj *)_game_object;
@@ -394,6 +407,8 @@ void ff7_init_hooks(struct game_obj *_game_object)
 				break;
 		}
 	}
+
+	replace_call(ff7_externals.credits_main_loop + 0xAC, ff7_credits_loop_gfx_begin_scene);
 }
 
 struct ff7_gfx_driver *ff7_load_driver(void* _game_object)

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1022,6 +1022,8 @@ struct ff8_externals
 	uint32_t sub_559910;
 	uint32_t swirl_sub_56D1D0;
 	uint32_t load_credits_image;
+	void (*input_fill_keystate)();
+	int (*input_get_keyscan)(int, int);
 	uint32_t sub_52FE80;
 	uint32_t sub_45D610;
 	uint32_t sub_45D080;

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -75,6 +75,9 @@ void ff8_find_externals()
 
 	ff8_externals.load_credits_image = get_relative_call(ff8_externals.credits_main_loop, 0xBF);
 
+	ff8_externals.sub_52FE80 = get_relative_call(ff8_externals.load_credits_image, 0xA4);
+	ff8_externals.input_fill_keystate = (void(*)())get_relative_call(ff8_externals.sub_52FE80, 0xC8);
+	ff8_externals.input_get_keyscan = (int(*)(int,int))get_relative_call(ff8_externals.sub_52FE80, 0xD1);
 	ff8_externals.credits_loop_state = (DWORD*)get_absolute_value(ff8_externals.load_credits_image, 0x7);
 	ff8_externals.credits_counter = (DWORD *)get_absolute_value(ff8_externals.load_credits_image, 0x59);
 	ff8_externals.sub_470520 = get_absolute_value(ff8_externals.credits_main_loop, 0xE2);
@@ -281,7 +284,6 @@ void ff8_find_externals()
 	ff8_externals.swirl_sub_56D390 = get_relative_call(ff8_externals.swirl_sub_56D1D0, 0x2A);
 	ff8_externals.swirl_texture1 = (ff8_graphics_object **)get_absolute_value(ff8_externals.swirl_sub_56D1D0, 0x1);
 
-	ff8_externals.sub_52FE80 = get_relative_call(ff8_externals.load_credits_image, 0xA4);
 	ff8_externals.sub_45D610 = get_relative_call(ff8_externals.sub_52FE80, 0x90);
 	ff8_externals.sub_45D080 = get_relative_call(ff8_externals.sub_45D610, 0x5);
 	ff8_externals.sub_464BD0 = get_relative_call(ff8_externals.sub_45D080, 0x208);

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -541,24 +541,19 @@ uint32_t ff8_retry_configured_drive(char* filename, uint8_t* data)
 	return res;
 }
 
-int ffnx_logo_current_frame = 0;
-
-int ff8_credits_main_loop_controller()
+uint32_t ff8_credits_main_loop_gfx_begin_scene(uint32_t unknown, struct game_obj *game_object)
 {
-	if (*ff8_externals.credits_loop_state == 0 && ffnx_logo_current_frame < FFNX_LOGO_FRAME_COUNT) {
+	if (drawFFNxLogoFrame(game_object)) {
 		ff8_externals.input_fill_keystate();
+
 		if (((ff8_externals.input_get_keyscan(0, 0) & ff8_externals.input_get_keyscan(1, 0)) & 0xF0) != 0) {
-			ffnx_logo_current_frame = FFNX_LOGO_FRAME_COUNT;
-
-			return ((int(*)())ff8_externals.load_credits_image)();
+			stopDrawFFNxLogo();
 		}
-
-		drawFFNxLogoFrame(common_externals.get_game_object(), ffnx_logo_current_frame++, FFNX_LOGO_FRAME_COUNT);
 
 		return 0;
 	}
 
-	return ((int(*)())ff8_externals.load_credits_image)();
+	return common_begin_scene(unknown, game_object);
 }
 
 void ff8_init_hooks(struct game_obj *_game_object)
@@ -681,7 +676,7 @@ void ff8_init_hooks(struct game_obj *_game_object)
 	// Allow squaresoft logo skip by pressing a button
 	patch_code_byte(ff8_externals.load_credits_image + 0x5FD, 0); // if (intro_step >= 0) ...
 	// Add FFNx Logo
-	replace_call(ff8_externals.credits_main_loop + 0xBF, ff8_credits_main_loop_controller);
+	replace_call(ff8_externals.credits_main_loop + 0x6D, ff8_credits_main_loop_gfx_begin_scene);
 
 	if (!steam_edition) {
 		// Look again with the DataDrive specified in the register


### PR DESCRIPTION
## Summary

- Fix FFNx logo game freeze by moving it before the squaresoft logo using the same timing logic (the consequence is the publisher movie will be before the FFNx logo)
- Add the ability to skip the FFNx logo, like the squaresoft logo
- Fix jp version + hook cleaning

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
