### PR TITLE
FF8: Fix crash on JP version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 ## FF8
 
 - Common: Fix startup hang on launch
+- Common: Fix jp version crash
 - Graphics: Add Field texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/542 )
 
 # 1.15.0

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1067,7 +1067,6 @@ struct ff8_externals
 	uint32_t upload_psxvram_texl_pal_call2;
 	uint32_t **worldmap_section38_position;
 	uint32_t (*worldmap_prepare_tim_for_upload)(uint8_t *, ff8_tim *);
-	uint32_t wm_upload_psx_vram;
 	uint32_t engine_eval_process_input;
 	uint32_t engine_eval_keyboard_gamepad_input;
 	uint32_t has_keyboard_gamepad_input;

--- a/src/ff8/texture_packer.cpp
+++ b/src/ff8/texture_packer.cpp
@@ -243,6 +243,13 @@ uint8_t TexturePacker::getMaxScale(const uint8_t *texData) const
 		}
 	}
 
+	if (maxScale > MAX_SCALE)
+	{
+		ffnx_warning("External texture size cannot exceed original size * %d\n", MAX_SCALE);
+
+		return MAX_SCALE;
+	}
+
 	return maxScale;
 }
 
@@ -523,13 +530,6 @@ uint8_t TexturePacker::TextureInfos::computeScale(int sourcePixelW, int sourceH,
 		ffnx_warning("Texture redirection size must have the same ratio as the original texture: (%d / %d)\n", sourcePixelW, sourceH);
 
 		return 0;
-	}
-
-	if (scaleW > MAX_SCALE)
-	{
-		ffnx_warning("Texture redirection size cannot exceed original size * %d\n", MAX_SCALE);
-
-		return MAX_SCALE;
 	}
 
 	return scaleW;

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -51,11 +51,13 @@ void ff8_find_externals()
 	common_externals.diff_time = (uint64_t (*)(uint64_t*,uint64_t*,uint64_t*))get_relative_call(common_externals.winmain, 0x41E);
 	ff8_externals.init_config = get_relative_call(ff8_externals.main_entry, 0x73);
 	ff8_externals.pubintro_init = get_absolute_value(ff8_externals.main_entry, 0x158);
+	ff8_externals.pubintro_cleanup = get_absolute_value(ff8_externals.main_entry, 0x162);
 
 	if (JP_VERSION)
 	{
 		ff8_externals.init_config = get_relative_call(ff8_externals.init_config, 0x0);
 		ff8_externals.pubintro_init = get_relative_call(ff8_externals.pubintro_init, 0x0);
+		ff8_externals.pubintro_cleanup = get_relative_call(ff8_externals.pubintro_cleanup, 0x0);
 	}
 
 	ff8_externals.sub_467C00 = get_relative_call(ff8_externals.pubintro_init, 0xB5);
@@ -65,7 +67,6 @@ void ff8_find_externals()
 	ff8_externals.sub_468BD0 = get_relative_call(ff8_externals.sub_468810, 0x5B);
 	common_externals.dinput_hack1 = ff8_externals.sub_468BD0 + 0x64;
 
-	ff8_externals.pubintro_cleanup = get_absolute_value(ff8_externals.main_entry, 0x162);
 	ff8_externals.pubintro_exit = get_absolute_value(ff8_externals.main_entry, 0x176);
 	ff8_externals.pubintro_main_loop = get_absolute_value(ff8_externals.main_entry, 0x180);
 	ff8_externals.credits_main_loop = get_absolute_value(ff8_externals.pubintro_main_loop, 0x6D);
@@ -338,8 +339,6 @@ void ff8_find_externals()
 	ff8_externals.chara_one_upload_texture = get_relative_call(ff8_externals.load_field_models, 0xB72);
 
 	ff8_externals.worldmap_sub_53F310 = get_relative_call(ff8_externals.worldmap_enter_main, 0xA7);
-
-	ff8_externals.wm_upload_psx_vram = get_relative_call(ff8_externals.load_field_models, 0xB72);
 
 	ff8_externals.engine_eval_process_input = get_relative_call(ff8_externals.pubintro_main_loop, 0x4);
 	ff8_externals.engine_eval_keyboard_gamepad_input = get_relative_call(ff8_externals.engine_eval_process_input, 0x16);


### PR DESCRIPTION
## Summary

- Jp version crash on start since the external SFX layer feature
- Fix a bad behavior when a texture is bigger than x10 the original size

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
