### PR TITLE
FF8: Enhance field texture replacement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,7 +15,8 @@
 
 - Common: Fix startup hang on launch
 - Common: Fix jp version crash
-- Graphics: Add Field texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/542 )
+- Graphics: Add Field texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/542 https://github.com/julianxhokaxhiu/FFNx/pull/545 )
+- Graphics: Fix wrong texture replacements in battle
 
 # 1.15.0
 

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -131,9 +131,7 @@ bool NxAudioEngine::getFilenameFullPath(char *_out, T _key, NxAudioEngineLayer _
 
 bool NxAudioEngine::fileExists(const char* filename)
 {
-	struct stat dummy;
-
-	bool ret = (stat(filename, &dummy) == 0);
+	bool ret = ::fileExists(filename);
 
 	if (!ret && (trace_all || trace_music || trace_sfx || trace_voice || trace_ambient))
 		ffnx_warning("NxAudioEngine::%s: Could not find file %s\n", __func__, filename);

--- a/src/audio/openpsf/openpsf.cpp
+++ b/src/audio/openpsf/openpsf.cpp
@@ -21,8 +21,6 @@
 
 #include "openpsf.h"
 
-#include <sys/stat.h>
-
 constexpr auto SOLOUD_OPENPSF_VOLUME_SCALE = float(3.2f / double(0x8000));
 
 namespace SoLoud
@@ -151,8 +149,7 @@ namespace SoLoud
 			return INVALID_PARAMETER;
 		}
 
-		struct stat dummy;
-		if (stat(aFilename, &dummy) != 0) {
+		if (! fileExists(aFilename)) {
 			return FILE_NOT_FOUND;
 		}
 

--- a/src/audio/vgmstream/vgmstream.cpp
+++ b/src/audio/vgmstream/vgmstream.cpp
@@ -20,8 +20,7 @@
 /****************************************************************************/
 
 #include "vgmstream.h"
-
-#include <sys/stat.h>
+#include "../../utils.h"
 
 namespace SoLoud
 {
@@ -127,8 +126,7 @@ namespace SoLoud
 		if (aFilename == 0)
 			return INVALID_PARAMETER;
 
-		struct stat dummy;
-		if (stat(aFilename, &dummy) != 0)
+		if (! fileExists(aFilename))
 			return FILE_NOT_FOUND;
 
 		stop();

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1047,6 +1047,7 @@ struct ff8_externals
 	struct struc_51 *psx_texture_pages; // One per bpp (bpp 4, 8 and 16)
 	uint32_t read_field_data;
 	uint32_t upload_mim_file;
+	uint32_t upload_pmp_file;
 	char *field_filename;
 	uint32_t field_scripts_init;
 	uint8_t *field_state_background_count;

--- a/src/ff8/field/background.cpp
+++ b/src/ff8/field/background.cpp
@@ -62,6 +62,52 @@ std::vector<Tile> ff8_background_parse_tiles(const uint8_t *map_data)
 	return tiles;
 }
 
+void ff8_background_draw_tile(const Tile &tile, uint32_t *target, const uint16_t target_width, const uint8_t* const textures_data, const uint16_t* const palettes_data)
+{
+	Tim::Bpp bpp = Tim::Bpp((tile.texID >> 7) & 3);
+	uint8_t texture_id = tile.texID & 0xF;
+	uint8_t pal_id = (tile.palID >> 6) & 0xF;
+	const uint8_t *texture_data_start = textures_data + texture_id * TEXTURE_WIDTH_BYTES + tile.srcY * MIM_DATA_WIDTH_BYTES;
+	const uint16_t *palette_data_start = bpp == Tim::Bpp16 ? nullptr : palettes_data + pal_id * PALETTE_SIZE;
+
+	if (bpp == Tim::Bpp16) {
+		const uint16_t *texture_data = reinterpret_cast<const uint16_t *>(texture_data_start) + tile.srcX;
+
+		for (int y = 0; y < TILE_SIZE; ++y) {
+			for (int x = 0; x < TILE_SIZE; ++x) {
+				*(target + x) = fromR5G5B5Color(*(texture_data + x), true);
+			}
+
+			target += target_width;
+			texture_data += MIM_DATA_WIDTH_BYTES / 2;
+		}
+	} else if (bpp == Tim::Bpp8) {
+		const uint8_t *texture_data = texture_data_start + tile.srcX;
+
+		for (int y = 0; y < TILE_SIZE; ++y) {
+			for (int x = 0; x < TILE_SIZE; ++x) {
+				*(target + x) = fromR5G5B5Color(palette_data_start[*(texture_data + x)], true);
+			}
+
+			target += target_width;
+			texture_data += MIM_DATA_WIDTH_BYTES;
+		}
+	} else {
+		const uint8_t *texture_data = texture_data_start + tile.srcX / 2;
+
+		for (int y = 0; y < TILE_SIZE; ++y) {
+			for (int x = 0; x < TILE_SIZE / 2; ++x) {
+				uint8_t index = *(texture_data + x);
+				*(target + x * 2) = fromR5G5B5Color(palette_data_start[index & 0xF], true);
+				*(target + x * 2 + 1) = fromR5G5B5Color(palette_data_start[index >> 4], true);
+			}
+
+			target += target_width;
+			texture_data += MIM_DATA_WIDTH_BYTES;
+		}
+	}
+}
+
 bool ff8_background_save_textures(const std::vector<Tile> &tiles, const uint8_t *mim_data, const char *filename)
 {
 	if (trace_all || trace_vram) ffnx_trace("%s %s\n", __func__, filename);
@@ -85,58 +131,86 @@ bool ff8_background_save_textures(const std::vector<Tile> &tiles, const uint8_t 
 	uint32_t tile_id = 0;
 
 	for (const Tile &tile: tiles) {
-		Tim::Bpp bpp = Tim::Bpp((tile.texID >> 7) & 3);
-		uint8_t texture_id = tile.texID & 0xF;
-		uint8_t pal_id = (tile.palID >> 6) & 0xF;
-		const uint8_t *texture_data_start = textures_data + texture_id * TEXTURE_WIDTH_BYTES + tile.srcY * MIM_DATA_WIDTH_BYTES;
-		const uint16_t *palette_data_start = bpp == Tim::Bpp16 ? nullptr : palettes_data + pal_id * PALETTE_SIZE;
 		uint8_t row = tile_id / cols_count, col = tile_id % cols_count;
-		uint32_t *target = image_data_start + row * TILE_SIZE * width;
+		uint32_t *target = image_data_start + row * TILE_SIZE * width + col * TILE_SIZE;
 
-		if (bpp == Tim::Bpp16) {
-			const uint16_t *texture_data = reinterpret_cast<const uint16_t *>(texture_data_start) + tile.srcX;
-			target += col * TILE_SIZE;
-
-			for (int y = 0; y < TILE_SIZE; ++y) {
-				for (int x = 0; x < TILE_SIZE; ++x) {
-					*(target + x) = fromR5G5B5Color(*(texture_data + x), true);
-				}
-
-				target += width;
-				texture_data += MIM_DATA_WIDTH_BYTES / 2;
-			}
-		} else if (bpp == Tim::Bpp8) {
-			const uint8_t *texture_data = texture_data_start + tile.srcX;
-			target += col * TILE_SIZE;
-
-			for (int y = 0; y < TILE_SIZE; ++y) {
-				for (int x = 0; x < TILE_SIZE; ++x) {
-					*(target + x) = fromR5G5B5Color(palette_data_start[*(texture_data + x)], true);
-				}
-
-				target += width;
-				texture_data += MIM_DATA_WIDTH_BYTES;
-			}
-		} else {
-			const uint8_t *texture_data = texture_data_start + tile.srcX / 2;
-			target += col * TILE_SIZE;
-
-			for (int y = 0; y < TILE_SIZE; ++y) {
-				for (int x = 0; x < TILE_SIZE / 2; ++x) {
-					uint8_t index = *(texture_data + x);
-					*(target + x * 2) = fromR5G5B5Color(palette_data_start[index & 0xF], true);
-					*(target + x * 2 + 1) = fromR5G5B5Color(palette_data_start[index >> 4], true);
-				}
-
-				target += width;
-				texture_data += MIM_DATA_WIDTH_BYTES;
-			}
-		}
+		ff8_background_draw_tile(tile, target, width, textures_data, palettes_data);
 
 		++tile_id;
 	}
 
 	save_texture(image_data_start, image_data_size, width, TEXTURE_HEIGHT, uint32_t(-1), filename, false);
+
+	delete[] image_data_start;
+
+	return true;
+}
+
+bool ff8_background_save_textures_legacy(const std::vector<Tile> &tiles, const uint8_t *mim_data, const char *filename)
+{
+	if (trace_all || trace_vram) ffnx_trace("%s %s\n", __func__, filename);
+
+	std::unordered_map<uint16_t, Tile> tiles_per_position_in_texture;
+	std::unordered_map<uint8_t, Tim::Bpp> min_depths_per_texture_id;
+
+	const uint16_t *palettes_data = reinterpret_cast<const uint16_t *>(mim_data + 0x1000);
+	const uint8_t *textures_data = mim_data + 0x3000;
+
+	for (const Tile &tile: tiles) {
+		uint8_t texture_id = tile.texID & 0xF;
+		Tim::Bpp bpp = Tim::Bpp((tile.texID >> 7) & 3);
+
+		ffnx_info("dst %d %d %d src %d %d texid %d bpp %d\n", tile.x, tile.y, tile.z, tile.srcX, tile.srcY, texture_id, int(bpp));
+
+		tiles_per_position_in_texture[texture_id | ((tile.srcX / 16) << 4) | ((tile.srcY / 16) << 8)] = tile;
+
+		auto it = min_depths_per_texture_id.find(texture_id);
+		if (it == min_depths_per_texture_id.end()) {
+			min_depths_per_texture_id[texture_id] = bpp;
+		} else {
+			min_depths_per_texture_id[texture_id] = Tim::Bpp(std::min(int(bpp), int(it->second)));
+		}
+	}
+
+	uint32_t* const image_data_start = new uint32_t[TEXTURE_WIDTH_BPP4 * TEXTURE_HEIGHT];
+
+	if (image_data_start == nullptr) {
+		return false;
+	}
+
+	// Save textures
+	for (const std::pair<uint8_t, Tim::Bpp> &pair: min_depths_per_texture_id) {
+		const uint8_t texture_id = pair.first;
+		const Tim::Bpp min_depth = pair.second;
+		const uint16_t width = TEXTURE_WIDTH_BPP4 >> min_depth;
+		const uint32_t image_data_size = width * TEXTURE_HEIGHT * sizeof(uint32_t);
+
+		// Fill with zeroes (transparent image)
+		memset(image_data_start, 0, image_data_size);
+
+		char filename_tex[MAX_PATH] = {};
+
+		snprintf(filename_tex, sizeof(filename_tex), "%s_%d", filename, texture_id);
+
+		for (uint8_t row = 0; row < 16; ++row) {
+			for (uint8_t col = 0; col < width / 16; ++col) {
+				auto it = tiles_per_position_in_texture.find(texture_id | (col << 4) | (row << 8));
+				if (it == tiles_per_position_in_texture.end()) {
+					ffnx_info("texture_id=%d row=%d col=%d not found\n", texture_id, row, col);
+					continue;
+				}
+
+				ffnx_info("texture_id=%d row=%d col=%d\n", texture_id, row, col);
+
+				const Tile &tile = it->second;
+				uint32_t *target = image_data_start + row * TILE_SIZE * width + col * TILE_SIZE;
+
+				ff8_background_draw_tile(tile, target, width, textures_data, palettes_data);
+			}
+		}
+
+		save_texture(image_data_start, image_data_size, width, TEXTURE_HEIGHT, -1, filename_tex, false);
+	}
 
 	delete[] image_data_start;
 

--- a/src/ff8/field/background.h
+++ b/src/ff8/field/background.h
@@ -53,3 +53,4 @@ bool ff8_background_tiles_looks_alike(const Tile &tile, const Tile &other);
 
 std::vector<Tile> ff8_background_parse_tiles(const uint8_t *map_data);
 bool ff8_background_save_textures(const std::vector<Tile> &tiles, const uint8_t *mim_data, const char *filename);
+bool ff8_background_save_textures_legacy(const std::vector<Tile> &tiles, const uint8_t *mim_data, const char *filename);

--- a/src/ff8/file.cpp
+++ b/src/ff8/file.cpp
@@ -26,7 +26,6 @@
 
 #include <fcntl.h>
 #include <io.h>
-#include <sys/stat.h>
 
 char next_direct_file[MAX_PATH] = "";
 
@@ -93,9 +92,7 @@ int ff8_fs_archive_search_filename_sub_archive(const char *fullpath, ff8_file_fi
 
 	set_direct_path(fullpath, direct_path, sizeof(direct_path));
 
-	struct stat dummy;
-
-	if (stat(direct_path, &dummy) == 0)
+	if (fileExists(direct_path))
 	{
 		strncpy(next_direct_file, direct_path, sizeof(next_direct_file));
 

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -330,6 +330,7 @@ void ff8_find_externals()
 
 	ff8_externals.read_field_data = get_relative_call(ff8_externals.sub_471F70, 0x23A);
 	ff8_externals.upload_mim_file = get_relative_call(ff8_externals.read_field_data, JP_VERSION ? 0x723 : 0x729);
+	ff8_externals.upload_pmp_file = get_relative_call(ff8_externals.read_field_data, JP_VERSION ? 0x80C : 0x812);
 	ff8_externals.field_filename = (char *)get_absolute_value(ff8_externals.read_field_data, 0xF0);
 
 	ff8_externals.field_scripts_init = get_relative_call(ff8_externals.read_field_data, JP_VERSION ? 0xEDC : 0xE49);

--- a/src/saveload.cpp
+++ b/src/saveload.cpp
@@ -20,7 +20,6 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include <sys/stat.h>
 #include <stdio.h>
 #include <direct.h>
 #include "renderer.h"
@@ -75,7 +74,6 @@ void normalize_path(char *name)
 void save_texture(const void *data, uint32_t dataSize, uint32_t width, uint32_t height, uint32_t palette_index, const char *name, bool is_animated)
 {
 	char filename[sizeof(basedir) + 1024];
-	struct stat dummy;
 	uint64_t hash;
 
 	if (is_animated)
@@ -97,7 +95,7 @@ void save_texture(const void *data, uint32_t dataSize, uint32_t width, uint32_t 
 
 	make_path(filename);
 
-	if (stat(filename, &dummy) != 0)
+	if (! fileExists(filename))
 	{
 		if (!newRenderer.saveTexture(filename, width, height, data)) ffnx_error("Save texture failed for the file [ %s ].\n", filename);
 	}
@@ -131,7 +129,6 @@ uint32_t load_normal_texture(const void* data, uint32_t dataSize, const char* na
 {
 	uint32_t ret = 0;
 	char filename[sizeof(basedir) + 1024]{ 0 };
-	struct stat dummy;
 
 	for (int idx = 0; idx < mod_ext.size(); idx++)
 	{
@@ -168,7 +165,7 @@ uint32_t load_normal_texture(const void* data, uint32_t dataSize, const char* na
 			{
 				_snprintf(filename, sizeof(filename), "%s/%s/%s_%02i_%s.%s", basedir, tex_path.c_str(), name, palette_index, it.second.c_str(), mod_ext[idx].c_str());
 
-				if (stat(filename, &dummy) == 0)
+				if (fileExists(filename))
 				{
 					if (gl_set->additional_textures.count(it.first)) newRenderer.deleteTexture(gl_set->additional_textures[it.first]);
 					gl_set->additional_textures[it.first] = load_texture_helper(filename, width, height, mod_ext[idx] == "png", false);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,40 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//    Copyright (C) 2020 John Pritchard                                     //
+//    Copyright (C) 2023 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2023 myst6re                                            //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+#include "utils.h"
+
+#include "globals.h"
+
+#include <sys/stat.h>
+#include <filesystem>
+
+bool fileExists(const char *filename)
+{
+    if (ff8)
+    {
+        // Fastest way
+        return std::filesystem::exists(filename);
+    }
+
+    struct stat dummy;
+
+    // Use stat to keep compatibility with 7th Heaven
+    return stat(filename, &dummy) == 0;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -126,3 +126,15 @@ inline int getRandomInt(int min, int max)
 
     return distrib(gen);
 }
+
+inline std::chrono::time_point<std::chrono::high_resolution_clock> highResolutionNow()
+{
+    return std::chrono::high_resolution_clock::now();
+}
+
+inline long double elapsedMicroseconds(std::chrono::time_point<std::chrono::high_resolution_clock> startTime)
+{
+    return std::chrono::duration<long double, std::micro>(highResolutionNow() - startTime).count();
+}
+
+bool fileExists(const char *filename);


### PR DESCRIPTION
## Summary

Try to load texture files from `field/mapdata/{first two letters of the field name}/{field name}/{field name}_{texture number}`
if the image from `field/mapdata/{field name}/{field name}` is not found.

+ PMP (field effects) texture replacement support at `field/mapdata/{field name}/{field name}_pmp`
+ Tiny improvements for VRAM texture replacements
+ adding helper functions to check if a file exist and to measure the elasped time a functions (in microseconds)

### Motivation

Existing mods on Tonberry or Demastered can have a lot of work to adapt for the background replacement mecanism in FFNx.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
