### PR TITLE
FF7: Removed snowboard minigame vertices limit for models #440

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -6,6 +6,7 @@
 //    Copyright (C) 2020 Chris Rizzitello                                   //
 //    Copyright (C) 2020 John Pritchard                                     //
 //    Copyright (C) 2023 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2023 Marcin 'Maki' Gomulak                                   //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //
@@ -3070,6 +3071,7 @@ struct ff7_externals
 	uint32_t snowboard_submit_draw_black_quad_graphics_object_72DD94;
 	uint32_t snowboard_submit_draw_white_fade_quad_graphics_object_72DD53;
 	uint32_t snowboard_submit_draw_opaque_quad_graphics_object_72DDD5;
+	uint32_t snowboard_parse_model_vertices_732159;
 
 	// condor
 	uint32_t condor_enter;

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -6,6 +6,7 @@
 //    Copyright (C) 2020 Chris Rizzitello                                   //
 //    Copyright (C) 2020 John Pritchard                                     //
 //    Copyright (C) 2023 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2023 Marcin 'Maki' Gomulak                                   //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //
@@ -1271,6 +1272,9 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.snowboard_submit_draw_white_fade_quad_graphics_object_72DD53 = get_relative_call(snowboard_submit_draw_white_fade_quad_729912, 0xD);
 	uint32_t snowboard_submit_draw_opaque_quad_72993A = get_relative_call(snowboard_callable_draw_white_quad_7240D6, 0xCC);
 	ff7_externals.snowboard_submit_draw_opaque_quad_graphics_object_72DDD5 = get_relative_call(snowboard_submit_draw_opaque_quad_72993A, 0xD);
+	uint32_t snowboard_sub_735220 = get_relative_call(ff7_externals.snowboard_loop_sub_72381C, 0xBF);
+	uint32_t snowboard_sub_735332 = get_relative_call(snowboard_sub_735220, 0xE6);
+	ff7_externals.snowboard_parse_model_vertices_732159 = get_relative_call(snowboard_sub_735332, 0x29);
 	// --------------------------------
 
 	// Steam achievement

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -7,6 +7,7 @@
 //    Copyright (C) 2020 John Pritchard                                     //
 //    Copyright (C) 2023 Julian Xhokaxhiu                                   //
 //    Copyright (C) 2023 Cosmos                                             //
+//    Copyright (C) 2023 Marcin 'Maki' Gomulak                                   //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //
@@ -417,6 +418,11 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	}
 
 	replace_call(ff7_externals.credits_main_loop + 0xAC, ff7_credits_loop_gfx_begin_scene);
+
+	//######################
+	// snowboard .P model vertices limit fix
+	//######################
+	memset_code(ff7_externals.snowboard_parse_model_vertices_732159 + 0x7E, 0x90,6);
 }
 
 struct ff7_gfx_driver *ff7_load_driver(void* _game_object)


### PR DESCRIPTION
## Summary

Basically gets via `snowboard_loop > sub_72381C > sub_735220 > sub_735332` and changes `007321D7                 cmp     dword ptr [ebp-0Ch], 54h ; 'T' ; AND vertexIndex<0x5` and it's next JGE, so summary 6 bytes to `NOP`

### Motivation

Issue #440 

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [ ] I did test my code on FF8
