### PR TITLE
FF8: Add more overridable textures for Worldmap + fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,9 +22,11 @@
 
 - Common: Fix startup hang on launch
 - Common: Fix jp version crash
+- Common: Fix ger version crash on entering worldmap
 - Config: enable worldmap fixes by default
 - Graphics: Add Field texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/542 https://github.com/julianxhokaxhiu/FFNx/pull/545 )
 - Graphics: Add Battle texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/564 )
+- Graphics: Add Worldmap texture replacement for roads and some vehicles ( https://github.com/julianxhokaxhiu/FFNx/pull/584 )
 - Graphics: Fix wrong texture replacements in battle
 - Graphics: Fix bad texture UVs in worldmap ( https://github.com/julianxhokaxhiu/FFNx/pull/564 )
 - Graphics: Disable texture filtering for external textures, as sprites can overlap or look bad in FF8

--- a/docs/ff8/mods/external_textures.md
+++ b/docs/ff8/mods/external_textures.md
@@ -1,0 +1,70 @@
+# List of external textures names in FF8
+
+Texture names pattern in FF8 mostly follows the paths used in FS/FL/FI archives in the original game.
+
+Except for the Menu module, you can add the language at the beginning of the path for localization:
+`{mod_path}\fre\cardgame\cards_00.dds`
+
+## Triple Triad
+
+Path: `{mod_path}\cardgame`
+
+| File name | Description             | Animated |
+| --------- | ----------------------- | -------- |
+| cards_00  | Cards front and back    | No       |
+| game_00   | Game background         | No       |
+| icons_00  | Numbers, icons and text | No       |
+| intro_00  | Intro/outro background  | No       |
+
+## Battle
+
+Path: `{mod_path}\battle\{filename with extension in FS archive}-0_00`
+
+Example: `.\mods\Textures\battle\A0STG101.X-0_00.dds`
+
+## Worldmap
+
+Path: `{mod_path}\world`
+
+### wmsetxx.obj
+
+Path: `{mod_path}\world\dat\wmset\section{section number}\texture{texture number}_00`
+
+### texl.obj
+
+Path: `{mod_path}\world\dat\texl\texture{texture number}_00`
+
+## Menu
+
+Path: `{mod_path}\data\{lang}\menu`
+
+**Note:** this can change in the future for more consistency with other modules.
+
+## Field
+
+Path: `{mod_path}\field`
+
+### Maps
+
+One texture per map.
+
+Path: `{mod_path}\field\mapdata\{map name}\{map name}.png`
+
+Example: `mods\Textures\field\mapdata\bccent_1\bccent_1.png`
+
+#### Legacy support for Tomberry's mods
+
+There is an alternative way to override maps, but on some edge cases it can be buggy.
+This is compatible with mods made for [Tomberry](https://forums.qhimm.com/index.php?topic=15945.0).
+
+Path: `{mod_path}\field\mapdata\{first two letters of map name}\{map name}\{map name}_{number}.png`
+
+Example: `mods\Textures\field\mapdata\bc\bccent_1\bccent_1_0.png`
+
+### Models
+
+Path: `{mod_path}\field\model`
+
+ - main_chr: textures that come from field/model/main_chr.fs subarchive
+ - second_chr: textures that come from field/mapdata/.../chara.one files,
+   merged together in one directory and named with theirs original identifiers (o001 for object, p001 for persona)

--- a/docs/ff8/readme.md
+++ b/docs/ff8/readme.md
@@ -1,3 +1,4 @@
 # FF8
 
  - [VRAM](vram.md)
+ - [List of external textures](mods/external_textures.md)

--- a/docs/mods/external_textures.md
+++ b/docs/mods/external_textures.md
@@ -1,0 +1,13 @@
+# External textures
+
+You can override game's textures with images in DDS (recommended) or PNG format.
+To know where to put your custom textures, set the option `trace_loaders` to `true` and look at the content of FFNx.log
+when the game is running.
+
+It is also possible to dump textures on runtime in PNG format by setting the option `save_textures` to true.
+
+By default, FFNx looks for textures relatively to the `./mods/Textures` directory, this path can be changed via the option `mod_path`.
+
+## FF8
+
+[List of external textures](../ff8/mods/external_textures.md)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -19,3 +19,4 @@ Welcome to the FFNx documentation!
 - [DevTools](mods/devtools.md)
 - [Audio Engine](mods/audio_engine.md)
 - [Video Encoding Guide](mods/video_encoding_guide.md)
+- [External textures](mods/external_textures.md)

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -377,6 +377,12 @@ show_missing_textures = false
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 save_textures = false
 
+# Dump internal legacy textures to PNG files in the mod_path
+# FF7: There is currently no legacy format
+# FF8: Field backgrounds will be saved in Tomberry's format, instead of FFNx one
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+save_textures_legacy = false
+
 # This path is where the Hext patching layer will look for txt files.
 # The path will ALWAYS have appended:
 # 1. The game name ( if FF7 it will be "ff7/", if FF8 will be "ff8/")

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -52,6 +52,7 @@ long external_voice_music_fade_volume;
 bool enable_voice_auto_text;
 bool enable_auto_run;
 bool save_textures;
+bool save_textures_legacy;
 bool trace_all;
 bool trace_renderer;
 bool trace_movies;
@@ -197,6 +198,7 @@ void read_cfg()
 	external_widescreen_path = config["external_widescreen_path"].value_or("");
 	external_time_cycle_path = config["external_time_cycle_path"].value_or("");
 	save_textures = config["save_textures"].value_or(false);
+	save_textures_legacy = config["save_textures_legacy"].value_or(false);
 	trace_all = config["trace_all"].value_or(false);
 	trace_renderer = config["trace_renderer"].value_or(false);
 	trace_movies = config["trace_movies"].value_or(false);
@@ -342,7 +344,7 @@ void read_cfg()
 		hext_patching_path += "/de";
 		break;
 	case VERSION_FF8_12_DE_NV:
-		hext_patching_path += "/de";
+		hext_patching_path += "/de_nv";
 		break;
 	case VERSION_FF8_12_SP:
 		hext_patching_path += "/es";

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -64,6 +64,7 @@ extern bool enable_voice_music_fade;
 extern long external_voice_music_fade_volume;
 extern bool enable_voice_auto_text;
 extern bool save_textures;
+extern bool save_textures_legacy;
 extern bool trace_all;
 extern bool trace_renderer;
 extern bool trace_movies;

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1061,7 +1061,11 @@ struct ff8_externals
 	uint32_t worldmap_sub_53F310;
 	uint32_t worldmap_sub_53F310_call_2A9;
 	uint32_t worldmap_sub_53F310_call_30D;
+	uint32_t worldmap_sub_53F310_call_330;
+	uint32_t worldmap_sub_53F310_call_366;
 	uint32_t worldmap_sub_53F310_loc_53F7EE;
+	uint32_t worldmap_sub_541970_upload_tim;
+	uint32_t worldmap_sub_548020;
 	uint32_t worldmap_sub_5531F0;
 	int32_t (*open_file_world)(const char*, int32_t, uint32_t, void *);
 	uint32_t open_file_world_sub_52D670_texl_call1;
@@ -1069,6 +1073,9 @@ struct ff8_externals
 	uint32_t upload_psxvram_texl_pal_call1;
 	uint32_t upload_psxvram_texl_pal_call2;
 	uint32_t **worldmap_section38_position;
+	uint32_t **worldmap_section39_position;
+	uint32_t **worldmap_section40_position;
+	uint32_t **worldmap_section42_position;
 	uint32_t (*worldmap_prepare_tim_for_upload)(uint8_t *, ff8_tim *);
 	uint32_t engine_eval_process_input;
 	void (*engine_eval_keyboard_gamepad_input)();

--- a/src/ff8/texture_packer.cpp
+++ b/src/ff8/texture_packer.cpp
@@ -83,7 +83,7 @@ void TexturePacker::cleanTextures(ModdedTextureId previousTextureId, bool keepMo
 
 void TexturePacker::setVramTextureId(ModdedTextureId textureId, int xBpp2, int y, int wBpp2, int h, bool keepMods)
 {
-	if (trace_all || trace_vram) ffnx_trace("%s: textureId=%d\n", __func__, textureId);
+	if (trace_all || trace_vram) ffnx_trace("%s: textureId=%d xBpp2=%d y=%d wBpp2=%d h=%d keepMods=%d\n", __func__, textureId, xBpp2, y, wBpp2, h, keepMods);
 
 	for (int i = 0; i < h; ++i)
 	{
@@ -97,6 +97,10 @@ void TexturePacker::setVramTextureId(ModdedTextureId textureId, int xBpp2, int y
 
 			if (previousTextureId != INVALID_TEXTURE)
 			{
+				if (keepMods) {
+					continue;
+				}
+
 				cleanTextures(previousTextureId, keepMods);
 			}
 
@@ -458,6 +462,18 @@ void TexturePacker::registerTiledTex(const uint8_t *texData, int x, int y, Tim::
 	_tiledTexs[texData] = TiledTex(x, y, bpp, palX, palY);
 }
 
+TexturePacker::TiledTex TexturePacker::getTiledTex(const uint8_t *texData) const
+{
+	auto it = _tiledTexs.find(texData);
+
+	if (it != _tiledTexs.end())
+	{
+		return it->second;
+	}
+
+	return TiledTex();
+}
+
 void TexturePacker::debugSaveTexture(int textureId, const uint32_t *source, int w, int h, bool removeAlpha, bool after)
 {
 	uint32_t *target = new uint32_t[w * h];
@@ -781,7 +797,7 @@ uint8_t TexturePacker::TextureBackground::computeScale() const
 }
 
 TexturePacker::TiledTex::TiledTex()
- : x(0), y(0), palX(0), palY(0), bpp(Tim::Bpp4), renderedOnce(false)
+ : x(-1), y(-1), palX(0), palY(0), bpp(Tim::Bpp4), renderedOnce(false)
 {
 }
 

--- a/src/ff8/texture_packer.h
+++ b/src/ff8/texture_packer.h
@@ -80,6 +80,18 @@ public:
 		Tim::Bpp _bpp;
 	};
 
+	struct TiledTex {
+		TiledTex();
+		TiledTex(int x, int y, Tim::Bpp bpp, int palX, int palY);
+		inline bool isValid() const {
+			return x >= 0;
+		}
+		int x, y;
+		int palX, palY;
+		Tim::Bpp bpp;
+		bool renderedOnce;
+	};
+
 	enum TextureTypes {
 		NoTexture = 0,
 		ExternalTexture = 1,
@@ -98,6 +110,7 @@ public:
 	uint8_t getMaxScale(const uint8_t *texData) const;
 	void getTextureNames(const uint8_t *texData, std::list<std::string> &names) const;
 	void registerTiledTex(const uint8_t *texData, int x, int y, Tim::Bpp bpp, int palX = 0, int palY = 0);
+	TiledTex getTiledTex(const uint8_t *texData) const;
 
 	void disableDrawTexturesBackground(bool disabled);
 	inline bool drawTexturesBackgroundIsDisabled() const {
@@ -175,14 +188,6 @@ private:
 		std::unordered_multimap<uint16_t, size_t> _tileIdsByPosition;
 		uint8_t _colsCount;
 		int _textureId;
-	};
-	struct TiledTex {
-		TiledTex();
-		TiledTex(int x, int y, Tim::Bpp bpp, int palX, int palY);
-		int x, y;
-		int palX, palY;
-		Tim::Bpp bpp;
-		bool renderedOnce;
 	};
 	struct TextureRedirection : public TextureInfos {
 		TextureRedirection();

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -493,10 +493,17 @@ void ff8_find_externals()
 	if(version == VERSION_FF8_12_US || version == VERSION_FF8_12_US_NV || version == VERSION_FF8_12_US_EIDOS || version == VERSION_FF8_12_US_EIDOS_NV)
 	{
 		ff8_externals.worldmap_section38_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x296);
+		ff8_externals.worldmap_section39_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x321);
+		ff8_externals.worldmap_section40_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x349);
+		ff8_externals.worldmap_section42_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x3BB);
 		ff8_externals.worldmap_prepare_tim_for_upload = (uint32_t(*)(uint8_t*,ff8_tim*))get_relative_call(ff8_externals.worldmap_sub_53F310, 0x2A9);
+		ff8_externals.worldmap_sub_548020 = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x3C5);
 		ff8_externals.worldmap_sub_53F310_call_2A9 = ff8_externals.worldmap_sub_53F310 + 0x2A9;
 		ff8_externals.worldmap_sub_53F310_call_30D = ff8_externals.worldmap_sub_53F310 + 0x30D;
+		ff8_externals.worldmap_sub_53F310_call_330 = ff8_externals.worldmap_sub_53F310 + 0x330;
+		ff8_externals.worldmap_sub_53F310_call_366 = ff8_externals.worldmap_sub_53F310 + 0x366;
 		ff8_externals.worldmap_sub_53F310_loc_53F7EE = ff8_externals.worldmap_sub_53F310 + 0x4DE;
+		ff8_externals.worldmap_sub_541970_upload_tim = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x330);
 		ff8_externals.worldmap_sub_5531F0 = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x614);
 		ff8_externals.open_file_world = (int32_t(*)(const char*, int32_t, uint32_t, void *))get_relative_call(ff8_externals.worldmap_sub_5531F0, 0x395);
 		ff8_externals.open_file_world_sub_52D670_texl_call1 = ff8_externals.worldmap_sub_5531F0 + 0x395;
@@ -537,10 +544,17 @@ void ff8_find_externals()
 	else
 	{
 		ff8_externals.worldmap_section38_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x292);
+		ff8_externals.worldmap_section39_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x33D);
+		ff8_externals.worldmap_section40_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x365);
+		ff8_externals.worldmap_section42_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x3DC);
 		ff8_externals.worldmap_prepare_tim_for_upload = (uint32_t(*)(uint8_t*,ff8_tim*))get_relative_call(ff8_externals.worldmap_sub_53F310, 0x2AC);
+		ff8_externals.worldmap_sub_548020 = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x3E6);
 		ff8_externals.worldmap_sub_53F310_call_2A9 = ff8_externals.worldmap_sub_53F310 + 0x2AC;
 		ff8_externals.worldmap_sub_53F310_call_30D = ff8_externals.worldmap_sub_53F310 + 0x325;
+		ff8_externals.worldmap_sub_53F310_call_330 = ff8_externals.worldmap_sub_53F310 + 0x34C;
+		ff8_externals.worldmap_sub_53F310_call_366 = ff8_externals.worldmap_sub_53F310 + 0x382;
 		ff8_externals.worldmap_sub_53F310_loc_53F7EE = ff8_externals.worldmap_sub_53F310 + 0x507;
+		ff8_externals.worldmap_sub_541970_upload_tim = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x34C);
 		ff8_externals.worldmap_sub_5531F0 = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x63D);
 		ff8_externals.open_file_world = (int32_t(*)(const char*, int32_t, uint32_t, void *))get_relative_call(ff8_externals.worldmap_sub_5531F0, 0x38F);
 		ff8_externals.open_file_world_sub_52D670_texl_call1 = ff8_externals.worldmap_sub_5531F0 + 0x38F;

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -214,6 +214,17 @@ void texture_reload_hack(struct ff8_texture_set *texture_set)
 		}
 	}
 
+	TexturePacker::TiledTex tiledTex = texturePacker.getTiledTex(VREF(tex_header, image_data));
+	if (tiledTex.isValid()) {
+		Tim::Bpp bpp = tiledTex.bpp == 0 ? Tim::Bpp8 : tiledTex.bpp;
+
+		if (VREF(tex_header, tex_format.bytesperpixel) != int(bpp)) {
+			if(trace_all || trace_vram) ffnx_trace("texture_reload_hack: ignore reload because BPP does not match 0x%X (bpp vram=%d, bpp tex=%d) image_data=0x%X\n", texture_set, tiledTex.bpp, VREF(tex_header, tex_format.bytesperpixel), VREF(tex_header, image_data));
+
+			return;
+		}
+	}
+
 	common_unload_texture((struct texture_set *)texture_set);
 	common_load_texture((struct texture_set *)texture_set, texture_set->tex_header, texture_set->texture_format);
 
@@ -231,7 +242,7 @@ void texture_reload_hack(struct ff8_texture_set *texture_set)
 
 	stats.texture_reloads++;
 
-	if(trace_all || trace_vram) ffnx_trace("texture_reload_hack: 0x%x\n", texture_set);
+	if(trace_all || trace_vram) ffnx_trace("texture_reload_hack: 0x%X (bpp=%d) image_data=0x%X\n", texture_set, VREF(tex_header, tex_format.bytesperpixel), VREF(tex_header, image_data));
 }
 
 void texture_reload_hack1(struct texture_page *texture_page, uint32_t unknown1, uint32_t unknown2)

--- a/src/image/tim.cpp
+++ b/src/image/tim.cpp
@@ -224,21 +224,34 @@ bool Tim::toRGBA32(uint32_t *target, PaletteDetectionStrategy *paletteDetectionS
 	{
 		if (_tim.pal_data == nullptr || paletteDetectionStrategy == nullptr)
 		{
-			ffnx_error("%s bpp 1 without palette\n", __func__);
+			uint8_t *img_data8 = (uint8_t *)_tim.img_data;
 
-			return false;
-		}
-
-		uint8_t *img_data = _tim.img_data;
-
-		for (int y = 0; y < _tim.img_h; ++y)
-		{
-			for (int x = 0; x < _tim.img_w; ++x)
+			for (int y = 0; y < _tim.img_h; ++y)
 			{
-				*target = fromR5G5B5Color((_tim.pal_data + paletteDetectionStrategy->palOffset(x, y))[*img_data], withAlpha);
+				for (int x = 0; x < _tim.img_w; ++x)
+				{
+					// Grey color
+					*target = ((*img_data8 == 0 && withAlpha ? 0x00 : 0xffu) << 24) |
+						(*img_data8 << 16) | (*img_data8 << 8) | *img_data8;
 
-				++target;
-				++img_data;
+					++target;
+					++img_data8;
+				}
+			}
+		}
+		else
+		{
+			uint8_t *img_data = _tim.img_data;
+
+			for (int y = 0; y < _tim.img_h; ++y)
+			{
+				for (int x = 0; x < _tim.img_w; ++x)
+				{
+					*target = fromR5G5B5Color((_tim.pal_data + paletteDetectionStrategy->palOffset(x, y))[*img_data], withAlpha);
+
+					++target;
+					++img_data;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Adding ability to override textures from wmset section 39 (rails and roads), 40 and 42 (vehicles).
- Restore ability to mod "texl" textures, even with ff8_worldmap_internal_highres_textures option enabled. + bug fixes
- Add save_textures_legacy to save texture in legacy format instead of recommended one
- Fixes #565
- Texture reload hack mini optimization on worldmap

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
