### PR TITLE
60FPS: Fix las0_5 map softlock in FF7

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@
 - Input: Allow Cloud to walk/run based on the left analogue stick position ( https://github.com/julianxhokaxhiu/FFNx/issues/523 + https://github.com/julianxhokaxhiu/FFNx/issues/557 )
 - Lighting: Fix model normal data inheritance
 - Modding: Allow snowboard model swapping ( https://github.com/julianxhokaxhiu/FFNx/issues/440 )
+- 60FPS: Fix softlock on one of the last map (las0_5) ( https://github.com/julianxhokaxhiu/FFNx/discussions/569 )
 
 ## FF8
 

--- a/src/ff7/field/enter.h
+++ b/src/ff7/field/enter.h
@@ -42,6 +42,7 @@ namespace ff7::field
         for(auto &external_data : external_model_data){
             external_data.moveFrameIndex = 0;
             external_data.rotationMoveFrameIndex = 0;
+            external_data.prevCollisionRadius = 0;
 
             external_data.blinkFrameIndex = BLINKING_FRAMES;
         }

--- a/src/ff7/field/model.h
+++ b/src/ff7/field/model.h
@@ -36,6 +36,7 @@ namespace ff7::field
         vector3<int> finalPosition;
         int wasNotCollidingWithTarget;
         int updateMovementReturnValue;
+        int prevCollisionRadius;
 
         int rotationMoveFrameIndex;
 


### PR DESCRIPTION
## Summary

There was a lot of reports of softlock when using 60 FPS on one of the last map of the game (https://github.com/julianxhokaxhiu/FFNx/discussions/569). This PR is to finally fix this softlock.

### Motivation

Save the poor players from rage quitting!

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
