### PR TITLE
FF7: Fix direct color

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ## FF7
 
 - Ambient: Allow ambient effects to playback in fields that use movies as background
+- Renderer: Fix black color in some field maps (spipe2 for example)
 
 # 1.16.0
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1650,7 +1650,7 @@ void convert_image_data(const unsigned char *image_data, uint32_t *converted_ima
 				o += tex_format->bytesperpixel;
 
 				// PSX style mask bit
-				if(color_key && (pixel & ~tex_format->alpha_mask) == 0)
+				if((color_key == 1 && (pixel & ~tex_format->alpha_mask) == 0) || (color_key == 3 && pixel == 0))
 				{
 					converted_image_data[c++] = 0;
 					continue;

--- a/src/ff7/field/field.cpp
+++ b/src/ff7/field/field.cpp
@@ -52,7 +52,10 @@ namespace ff7::field
         ff7_externals.field_layers[dst]->tex_header = tex_header;
 
         if(ff7_externals.field_layers[src]->type == 1) ff7_externals.make_field_tex_header_pal(tex_header);
-        if(ff7_externals.field_layers[src]->type == 2) ff7_externals.make_field_tex_header(tex_header);
+        if(ff7_externals.field_layers[src]->type == 2) {
+            ff7_externals.make_field_tex_header(tex_header);
+            tex_header->color_key = 3;
+        }
 
         struc_3->tex_header = tex_header;
 

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -291,6 +291,11 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		patch_code_int(ff7_externals.field_init_viewport_values + 0x6E, 240);
 	}
 
+	// ########################
+	// field direct color black
+	// ########################
+	patch_code_short(uint32_t(ff7_externals.field_convert_type2_layers) + 0xE3, 0x8000);
+
 	// #####################
 	// worldmap footsteps
 	// #####################


### PR DESCRIPTION
## Summary

Fix black color on field backgrounds

### Motivation

The PC rendering is different from the PSX rendering.

The PSX data clearly shows black pixels when the 15th bit is active in the 16-bit direct color (0x8000).
The PC version converted this black pixel to 0x0821 in data and at runtime it is converted again to 0x0403 (dark purple).

We also need to distinguish the black pixel to the transparent one using color key (0x0000).

#### PSX rendering
![PSX rendering](https://github.com/julianxhokaxhiu/FFNx/assets/8015696/31c11ee2-d7c6-4c22-8849-29d0ec1909c8)

#### FFNx rendering (and original PC)
![FFNx rendering (and original PC)](https://github.com/julianxhokaxhiu/FFNx/assets/8015696/282a65ba-6b0b-4f25-ba2e-eece66dc1fd6)

#### Comparison of black

![black-comparison](https://github.com/julianxhokaxhiu/FFNx/assets/8015696/65163444-edaa-49db-81d5-9f04bf80aee1)


### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
