### PR TITLE
FF8: Fix crash with external texture replacement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@
 - Core: Add additional main models eye-to-model mapping
 - Renderer: Fix black color in some field maps (`spipe2` for example) ( https://github.com/julianxhokaxhiu/FFNx/pull/587 )
 
+## FF8
+
+- Graphics: Fix crash when using external texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/588 )
+
 # 1.16.0
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.15.0...1.16.0

--- a/src/ff8/texture_packer.cpp
+++ b/src/ff8/texture_packer.cpp
@@ -200,6 +200,8 @@ bool TexturePacker::setTextureRedirection(const TextureInfos &oldTexture, const 
 
 uint8_t TexturePacker::getMaxScale(const uint8_t *texData) const
 {
+	if (trace_all || trace_vram) ffnx_trace("TexturePacker::%s\n", __func__);
+
 	if (_externalTextures.empty() && _backgroundTextures.empty() && _textureRedirections.empty())
 	{
 		return 1;
@@ -220,9 +222,20 @@ uint8_t TexturePacker::getMaxScale(const uint8_t *texData) const
 	{
 		int vramY = tiledTex.y + y;
 
+		if (vramY >= VRAM_HEIGHT)
+		{
+			break;
+		}
+
 		for (int x = 0; x < 64; ++x)
 		{
 			int vramX = tiledTex.x + x;
+
+			if (vramX >= VRAM_WIDTH)
+			{
+				break;
+			}
+
 			ModdedTextureId textureId = _vramTextureIds.at(vramX + vramY * VRAM_WIDTH);
 
 			if (textureId != INVALID_TEXTURE)
@@ -282,9 +295,20 @@ void TexturePacker::getTextureNames(const uint8_t *texData, std::list<std::strin
 	{
 		int vramY = tiledTex.y + y;
 
+		if (vramY >= VRAM_HEIGHT)
+		{
+			break;
+		}
+
 		for (int x = 0; x < 64; ++x)
 		{
 			int vramX = tiledTex.x + x;
+
+			if (vramX >= VRAM_WIDTH)
+			{
+				break;
+			}
+
 			ModdedTextureId textureId = _vramTextureIds.at(vramX + vramY * VRAM_WIDTH);
 
 			if (textureId != INVALID_TEXTURE)
@@ -375,7 +399,8 @@ TexturePacker::TextureTypes TexturePacker::drawTextures(uint32_t *target, const 
 	{
 		int vramY = tiledTex.y + y;
 
-		if (vramY >= VRAM_HEIGHT) {
+		if (vramY >= VRAM_HEIGHT)
+		{
 			break;
 		}
 
@@ -383,7 +408,8 @@ TexturePacker::TextureTypes TexturePacker::drawTextures(uint32_t *target, const 
 		{
 			int vramX = tiledTex.x + x;
 
-			if (vramX >= VRAM_WIDTH) {
+			if (vramX >= VRAM_WIDTH)
+			{
 				break;
 			}
 

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -664,6 +664,8 @@ Stage stage;
 
 int16_t ff8_battle_open_and_read_file(int fileId, void *data, int a3, int callback)
 {
+	if (trace_all || trace_vram) ffnx_trace("%s: %d\n", __func__, fileId);
+
 	snprintf(battle_texture_name, sizeof(battle_texture_name), "battle/%s", ff8_externals.battle_filenames[fileId]);
 
 	return ((int16_t(*)(int,void*,int,int))ff8_externals.battle_open_file)(fileId, data, a3, callback);
@@ -671,6 +673,8 @@ int16_t ff8_battle_open_and_read_file(int fileId, void *data, int a3, int callba
 
 size_t ff8_battle_read_file(char *fileName, void *data)
 {
+	if (trace_all || trace_vram) ffnx_trace("%s: %s\n", __func__, fileName);
+
 	battle_texture_id = 0;
 
 	size_t file_size = ff8_externals.sm_pc_read(fileName, data);


### PR DESCRIPTION
## Summary

Fix crash with external texture replacement. When replacing battle stage background, I detected a crash by using Quezacotl.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
