### PR TITLE
Improve clarity of data_drive usage

### DIFF
--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -680,7 +680,8 @@ ff8_fix_uv_coords_precision = true
 app_path = ""
 
 #[DATA DRIVE]
-# Overrides the data drive to read disks if set. Ignored in the Steam edition. Include : but not \ (e.g. data_drive = "F:")
+# Overrides the data drive to read disks if set. Ignored in the Steam edition.
+# Example: "F:"
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 data_drive = ""
 

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -680,7 +680,7 @@ ff8_fix_uv_coords_precision = true
 app_path = ""
 
 #[DATA DRIVE]
-# Overrides the data drive to read disks if set. Ignored in the Steam edition
+# Overrides the data drive to read disks if set. Ignored in the Steam edition. Include : but not \ (e.g. data_drive = "F:")
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 data_drive = ""
 


### PR DESCRIPTION
## Summary
Provide instruction on proper use of data_drive directive in FF8

### Motivation
I choked on it tonight figuring "F" was good enough, then Windows barfed on me for attempting "F:\\"

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [x] I did test my code on FF8
