### PR TITLE
30FPS: Fix crash conflict in FF7 with ESUI mod

### DIFF
--- a/src/ff7/battle/animations.cpp
+++ b/src/ff7/battle/animations.cpp
@@ -1274,7 +1274,7 @@ namespace ff7::battle
         // Effect60 related
         patch_multiply_code<WORD>(ff7_externals.battle_sub_425E5F + 0x3A, battle_frame_multiplier);
 
-        patch_multiply_code<WORD>(ff7_externals.battle_sub_5BCF9D + 0x3A, battle_frame_multiplier);
+        patch_multiply_code_if_as_expected<WORD>(ff7_externals.battle_sub_5BCF9D + 0x3A, battle_frame_multiplier, 0x15);
         patch_code_byte(ff7_externals.battle_sub_5BD050 + 0x1DC, 0x2 - battle_frame_multiplier / 2);
         patch_code_byte(ff7_externals.battle_sub_5BD050 + 0x203, 0x2 - battle_frame_multiplier / 2);
 

--- a/src/patch.h
+++ b/src/patch.h
@@ -69,6 +69,20 @@ void patch_divide_code(uint32_t offset, int multiplier)
     // TODO Add assertion
 }
 
+template<typename T>
+void patch_multiply_code_if_as_expected(uint32_t offset, int multiplier, T expected_value)
+{
+	T current_value = *(T *)offset;
+	if (current_value == expected_value) 
+	{
+		patch_multiply_code<T>(offset, multiplier);
+	}
+	else 
+	{
+		ffnx_warning("%X: Unexpected value in offset (expected: %X, found: %X)\n", offset, expected_value, current_value);
+	}
+}
+
 void memcpy_code(uint32_t offset, void *data, uint32_t size);
 void memset_code(uint32_t offset, uint32_t val, uint32_t size);
 


### PR DESCRIPTION
## Summary

Fix crash in battle mode when using 30fps mod and ESUI mod

### Motivation

Because yes!

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
