### PR TITLE
60FPS: Fix char status menu rendering speed in FF7

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -3239,6 +3239,7 @@ struct ff7_externals
 	void (*display_cait_sith_slots_handler_6E2170)();
 	void (*display_tifa_slots_handler_6E3135)();
 	void (*display_battle_arena_menu_handler_6E384F)();
+	void (*display_battle_char_status_menu_6E1308)();
 	uint32_t battle_draw_text_ui_graphics_objects_call;
 	uint32_t battle_draw_box_ui_graphics_objects_call;
 	void (*battle_draw_call_42908C)(int, int);

--- a/src/ff7/battle/animations.cpp
+++ b/src/ff7/battle/animations.cpp
@@ -1332,6 +1332,7 @@ namespace ff7::battle
             replace_call_function(ff7_externals.display_battle_menu_6D797C + 0x1BB, display_cait_sith_slots_handler);
             replace_call_function(ff7_externals.display_battle_menu_6D797C + 0x1C2, display_tifa_slots_handler);
             replace_call_function(ff7_externals.display_battle_menu_6D797C + 0x1C9, display_battle_arena_menu_handler);
+            replace_call_function(ff7_externals.display_battle_menu_6D797C + 0x1AD, display_battle_char_status_menu_handler);
             memset_code(ff7_externals.battle_menu_update_6CE8B3 + 0x148, 0x90, 3);
         }
 

--- a/src/ff7/battle/menu.cpp
+++ b/src/ff7/battle/menu.cpp
@@ -69,6 +69,12 @@ namespace ff7::battle
             ff7_externals.display_battle_arena_menu_handler_6E384F();
     }
 
+    void display_battle_char_status_menu_handler()
+    {
+        if(*ff7_externals.g_do_render_menu)
+            ff7_externals.display_battle_char_status_menu_6E1308();
+    }
+
     void delay_battle_target_pointer_animation_type()
     {
         if(frame_counter % battle_frame_multiplier == 0)

--- a/src/ff7/battle/menu.h
+++ b/src/ff7/battle/menu.h
@@ -29,6 +29,7 @@ namespace ff7::battle
     void display_tifa_slots_handler();
     void display_cait_sith_slots_handler();
     void display_battle_arena_menu_handler();
+    void display_battle_char_status_menu_handler();
     void delay_battle_target_pointer_animation_type();
     void battle_depth_clear();
 }

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1118,6 +1118,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.display_cait_sith_slots_handler_6E2170 = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1BB);
 	ff7_externals.display_tifa_slots_handler_6E3135 = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1C2);
 	ff7_externals.display_battle_arena_menu_handler_6E384F = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1C9);
+	ff7_externals.display_battle_char_status_menu_6E1308 = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1AD);
 	ff7_externals.battle_draw_text_ui_graphics_objects_call = battle_main_loop + 0x289;
 	ff7_externals.battle_draw_box_ui_graphics_objects_call = battle_main_loop + 0x2CF;
 	ff7_externals.battle_draw_call_42908C = (void(*)(int, int))get_relative_call(battle_main_loop, 0x2CF);


### PR DESCRIPTION
## Summary

In 60 FPS battles, currently the status menu skips the character status when a character has more than one status. 
This patch fixes it.

### Motivation

💯 

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
