### PR TITLE
FF8: Fix battle stage texture dump + option to use music files from remastered

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 
 - Graphics: Fix crash when using external texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/588 )
 - Graphics: Fix texture glitches using external texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/591 )
+- Music: Add `ff8_external_music_force_original_filenames` option to use original music names (eg 018s-julia.ogg) instead of just the main identifier in external music ( https://github.com/julianxhokaxhiu/FFNx/pull/594 )
 
 # 1.16.0
 

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -672,6 +672,12 @@ ff8_worldmap_internal_highres_textures = true
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ff8_fix_uv_coords_precision = true
 
+# Always use original filenames when looking for external music files.
+# Example: `005s-battle.ogg` instead of `battle.ogg`.
+# Use this option if you want to use OGG files from Remastered Edition directly in external music
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ff8_external_music_force_original_filenames = false
+
 ## GAME INSTALLATION OPTIONS
 
 #[APP PATH]

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -130,6 +130,7 @@ long external_audio_number_of_channels;
 long external_audio_sample_rate;
 bool ff8_worldmap_internal_highres_textures;
 bool ff8_fix_uv_coords_precision;
+bool ff8_external_music_force_original_filenames;
 std::string app_path;
 std::string data_drive;
 bool enable_ntscj_gamut_mode;
@@ -282,6 +283,7 @@ void read_cfg()
 	external_audio_sample_rate = config["external_audio_sample_rate"].value_or(44100);
 	ff8_worldmap_internal_highres_textures = config["ff8_worldmap_internal_highres_textures"].value_or(true);
 	ff8_fix_uv_coords_precision = config["ff8_fix_uv_coords_precision"].value_or(true);
+	ff8_external_music_force_original_filenames = config["ff8_external_music_force_original_filenames"].value_or(false);
 	app_path = config["app_path"].value_or("");
 	data_drive = config["data_drive"].value_or("");
 	enable_ntscj_gamut_mode = config["enable_ntscj_gamut_mode"].value_or(false);

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -143,6 +143,7 @@ extern long external_audio_number_of_channels;
 extern long external_audio_sample_rate;
 extern bool ff8_worldmap_internal_highres_textures;
 extern bool ff8_fix_uv_coords_precision;
+extern bool ff8_external_music_force_original_filenames;
 extern std::string app_path;
 extern std::string data_drive;
 extern bool enable_ntscj_gamut_mode;

--- a/src/ff8/battle/stage.cpp
+++ b/src/ff8/battle/stage.cpp
@@ -151,7 +151,6 @@ bool ff8_battle_state_save_texture(const Stage &stage, const Tim &tim, const cha
         palsPerTexture[quad.tex_id & 0xF].insert((quad.pal_id >> 6) & 0xF);
     }
 
-    std::vector<uint8_t> texturesWithMultiPalette, texturesWithOnePalette;
     std::vector<TimRect> rectangles;
 
     for (const std::pair<uint8_t, std::set<uint8_t> > &pair: palsPerTexture) {
@@ -249,14 +248,10 @@ bool ff8_battle_state_save_texture(const Stage &stage, const Tim &tim, const cha
             for (const TimRect &rect: rectsMerged) {
                 rectangles.push_back(TimRect(rect.palIndex, texId * 128 + rect.x1, rect.y1, texId * 128 + rect.x2, rect.y2));
             }
-
-            texturesWithMultiPalette.push_back(texId);
-        } else {
-            texturesWithOnePalette.push_back(texId);
         }
 
         // Use first palette by default
-        rectangles.push_back(TimRect(*(pair.second.begin()), texId * 128, 0, texId * 128 + 255, 255));
+        rectangles.push_back(TimRect(*(pair.second.begin()), texId * 128, 0, texId * 128 + 128, 255));
     }
 
     tim.saveMultiPaletteTrianglesAndQuads(filename, rectangles, true);

--- a/src/music.cpp
+++ b/src/music.cpp
@@ -117,15 +117,20 @@ char ff8_midi[32];
 char* ff8_format_midi_name(const char* midi_name)
 {
 	// midi_name format: {num}{type}-{name}.sgt or {name}.sgt or _Missing.sgt
-	const char* truncated_name = strchr(midi_name, '-');
+	const char* truncated_name = midi_name;
 
-	if (nullptr != truncated_name) {
-		truncated_name += 1; // Remove "-"
-	}
-	else {
-		truncated_name = midi_name;
+	if (!ff8_external_music_force_original_filenames) {
+		truncated_name = strchr(midi_name, '-');
+
+		if (nullptr != truncated_name) {
+			truncated_name += 1; // Remove "-"
+		}
+		else {
+			truncated_name = midi_name;
+		}
 	}
 
+	// Remove extension
 	const char* max_midi_name = strchr(truncated_name, '.');
 
 	if (nullptr != max_midi_name) {


### PR DESCRIPTION
## Summary

Fix battle stage texture dump with save_textures on.

option to use music files from remastered => if you extract the ogg files from remastered archives, you obtain files named like:
- 008s-antena.ogg
- 018s-julia.ogg
It is the same format as the original game, but the extension is replaced from sgt to ogg. Also this does not use xg files naming

### Motivation

I expected at first that Roses and Wine mod was using the same file name pattern than the original game.
That's not the case, we need to maintain a list of filename, that I don't want to.

But as a quickwin I can add the option for users who want to import oggs files from the remastered version to the 2013 version.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
