### PR TITLE
FF7: Refactor 60FPS battle menu fix and fix ESUI compatibility

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -3236,25 +3236,19 @@ struct ff7_externals
 
 	// battle menu
 	uint32_t display_battle_menu_6D797C;
-	void (*display_cait_sith_slots_handler_6E2170)();
 	void (*display_tifa_slots_handler_6E3135)();
-	void (*display_battle_arena_menu_handler_6E384F)();
-	void (*display_battle_char_status_menu_6E1308)();
 	uint32_t battle_draw_text_ui_graphics_objects_call;
 	uint32_t battle_draw_box_ui_graphics_objects_call;
 	void (*battle_draw_call_42908C)(int, int);
 	uint32_t battle_set_do_render_menu_call;
 	uint32_t battle_set_do_render_menu;
 	int *g_do_render_menu;
-	uint32_t battle_menu_update_call;
-	int *battle_menu_animation_idx;
-	uint32_t set_battle_speed_4385CC;
-	uint32_t battle_set_actor_timer_data_4339C2;
 	uint32_t battle_sub_42F3E8;
 	uint32_t battle_handle_player_mark_5B9C8E;
 	uint32_t battle_handle_status_effect_anim_5BA7C0;
 	uint32_t battle_update_targeting_info_6E6291;
 	byte *targeting_actor_id_DC3C98;
+	uint32_t battle_menu_closing_window_box_6DAEF0;
 
 	//battle 3d battleground
 	uint32_t update_3d_battleground;

--- a/src/ff7/battle/animations.cpp
+++ b/src/ff7/battle/animations.cpp
@@ -1274,7 +1274,11 @@ namespace ff7::battle
         // Effect60 related
         patch_multiply_code<WORD>(ff7_externals.battle_sub_425E5F + 0x3A, battle_frame_multiplier);
 
-        patch_multiply_code<WORD>(ff7_externals.battle_sub_5BCF9D + 0x3A, battle_frame_multiplier);
+        // Bad workaround to fix ESUI compatibility with 30fps when no widescreen mod is enabled
+        if (ff7_fps_limiter == FF7_LIMITER_60FPS || (ff7_fps_limiter == FF7_LIMITER_30FPS && aspect_ratio == AR_WIDESCREEN)) 
+        {
+            patch_multiply_code<WORD>(ff7_externals.battle_sub_5BCF9D + 0x3A, battle_frame_multiplier);
+        }
         patch_code_byte(ff7_externals.battle_sub_5BD050 + 0x1DC, 0x2 - battle_frame_multiplier / 2);
         patch_code_byte(ff7_externals.battle_sub_5BD050 + 0x203, 0x2 - battle_frame_multiplier / 2);
 

--- a/src/ff7/battle/animations.cpp
+++ b/src/ff7/battle/animations.cpp
@@ -1325,15 +1325,9 @@ namespace ff7::battle
 
         if(ff7_fps_limiter == FF7_LIMITER_60FPS)
         {
-            // Fix battle speed and menu for 60 FPS only
-            patch_divide_code<int>(ff7_externals.set_battle_speed_4385CC + 0x2E, battle_frame_multiplier / 2);
-            patch_divide_code<int>(ff7_externals.battle_set_actor_timer_data_4339C2 + 0x89, battle_frame_multiplier / 2);
-            replace_call_function(ff7_externals.battle_menu_update_call, update_battle_menu);
-            replace_call_function(ff7_externals.display_battle_menu_6D797C + 0x1BB, display_cait_sith_slots_handler);
-            replace_call_function(ff7_externals.display_battle_menu_6D797C + 0x1C2, display_tifa_slots_handler);
-            replace_call_function(ff7_externals.display_battle_menu_6D797C + 0x1C9, display_battle_arena_menu_handler);
-            replace_call_function(ff7_externals.display_battle_menu_6D797C + 0x1AD, display_battle_char_status_menu_handler);
-            memset_code(ff7_externals.battle_menu_update_6CE8B3 + 0x148, 0x90, 3);
+            // Speed up window menu closing speed to fix Bizarro menu box softlock
+            patch_code_byte(ff7_externals.battle_menu_closing_window_box_6DAEF0 + 0x29, 0x2 - 1);
+            patch_code_byte(ff7_externals.battle_menu_closing_window_box_6DAEF0 + 0x72, 0x2 - 1);
         }
 
         // Delay animation of battle target pointer

--- a/src/ff7/battle/menu.cpp
+++ b/src/ff7/battle/menu.cpp
@@ -44,37 +44,6 @@ namespace ff7::battle
         newRenderer.clearDepthBuffer();
     }
 
-    void update_battle_menu()
-    {
-        ((void(*)())ff7_externals.battle_menu_update_6CE8B3)();
-        if(*ff7_externals.g_do_render_menu)
-            (*ff7_externals.battle_menu_animation_idx)++;
-    }
-
-    void display_tifa_slots_handler()
-    {
-        if(*ff7_externals.g_do_render_menu)
-            ff7_externals.display_tifa_slots_handler_6E3135();
-    }
-
-    void display_cait_sith_slots_handler()
-    {
-        if(*ff7_externals.g_do_render_menu)
-            ff7_externals.display_cait_sith_slots_handler_6E2170();
-    }
-
-    void display_battle_arena_menu_handler()
-    {
-        if(*ff7_externals.g_do_render_menu)
-            ff7_externals.display_battle_arena_menu_handler_6E384F();
-    }
-
-    void display_battle_char_status_menu_handler()
-    {
-        if(*ff7_externals.g_do_render_menu)
-            ff7_externals.display_battle_char_status_menu_6E1308();
-    }
-
     void delay_battle_target_pointer_animation_type()
     {
         if(frame_counter % battle_frame_multiplier == 0)

--- a/src/ff7/battle/menu.h
+++ b/src/ff7/battle/menu.h
@@ -25,11 +25,6 @@
 
 namespace ff7::battle
 {
-    void update_battle_menu();
-    void display_tifa_slots_handler();
-    void display_cait_sith_slots_handler();
-    void display_battle_arena_menu_handler();
-    void display_battle_char_status_menu_handler();
     void delay_battle_target_pointer_animation_type();
     void battle_depth_clear();
 }

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1111,23 +1111,16 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.global_game_engine_data = (ff7_game_engine_data**)get_absolute_value((uint32_t)ff7_externals.get_global_model_matrix_buffer_66100D, 0x4);
 
 	// Battle menu
-	ff7_externals.battle_menu_update_call = battle_main_loop + 0x368;
 	uint32_t battle_sub_6D83C8 = get_relative_call(ff7_externals.battle_menu_update_6CE8B3, 0x77);
 	uint32_t battle_sub_6D82EA = get_relative_call(battle_sub_6D83C8, 0xE0);
 	ff7_externals.display_battle_menu_6D797C = get_relative_call(battle_sub_6D82EA, 0x59);
-	ff7_externals.display_cait_sith_slots_handler_6E2170 = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1BB);
 	ff7_externals.display_tifa_slots_handler_6E3135 = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1C2);
-	ff7_externals.display_battle_arena_menu_handler_6E384F = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1C9);
-	ff7_externals.display_battle_char_status_menu_6E1308 = (void(*)())get_relative_call(ff7_externals.display_battle_menu_6D797C, 0x1AD);
 	ff7_externals.battle_draw_text_ui_graphics_objects_call = battle_main_loop + 0x289;
 	ff7_externals.battle_draw_box_ui_graphics_objects_call = battle_main_loop + 0x2CF;
 	ff7_externals.battle_draw_call_42908C = (void(*)(int, int))get_relative_call(battle_main_loop, 0x2CF);
 	ff7_externals.battle_set_do_render_menu_call = battle_main_loop + 0x32A;
 	ff7_externals.battle_set_do_render_menu = get_relative_call(battle_main_loop, 0x32A);
 	ff7_externals.g_do_render_menu = (int*)get_absolute_value(ff7_externals.battle_set_do_render_menu, 0x7);
-	ff7_externals.battle_menu_animation_idx = (int*)get_absolute_value(ff7_externals.battle_menu_update_6CE8B3, 0x144);
-	ff7_externals.set_battle_speed_4385CC = get_relative_call(ff7_externals.battle_sub_437DB0, 0x17C);
-	ff7_externals.battle_set_actor_timer_data_4339C2 = get_relative_call(ff7_externals.battle_sub_437DB0, 0x1C7);
 	uint32_t battle_sub_4297B9 = get_relative_call(ff7_externals.battle_sub_42D992, 0x59);
 	uint32_t battle_sub_42952E = get_relative_call(battle_sub_4297B9, 0x10);
 	ff7_externals.battle_sub_42F3E8 = get_relative_call(battle_sub_42952E, 0xCD);
@@ -1136,6 +1129,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.battle_handle_player_mark_5B9C8E = get_relative_call(battle_sub_5B9B30, 0x123);
 	ff7_externals.battle_update_targeting_info_6E6291 = get_relative_call(ff7_externals.battle_sub_6DB0EE, 0x1F9);
 	ff7_externals.targeting_actor_id_DC3C98 = (byte*)get_absolute_value(ff7_externals.battle_update_targeting_info_6E6291, 0x684);
+	ff7_externals.battle_menu_closing_window_box_6DAEF0 = get_relative_call(ff7_externals.battle_sub_6DB0EE, 0x1D8);
 
 	// 3D Battleground
 	ff7_externals.update_3d_battleground = get_relative_call(ff7_externals.battle_sub_42D992, 0x4);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -245,7 +245,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		{
 			battle_frame_multiplier = (ff7_fps_limiter == FF7_LIMITER_30FPS) ? 2 : 4;
 
-			patch_divide_code<byte>(ff7_externals.battle_fps_menu_multiplier, 2); // Works perfectly only in 30 FPS
+			patch_divide_code<byte>(ff7_externals.battle_fps_menu_multiplier, battle_frame_multiplier); // Works perfectly only in 30 FPS
 
 			ff7::battle::camera_hook_init();
 			ff7::battle::animations_hook_init();


### PR DESCRIPTION
## Summary

Related to https://github.com/julianxhokaxhiu/FFNx/pull/592 and https://github.com/julianxhokaxhiu/FFNx/pull/593. This refactoring of battle menu 60fps fix follows the approach used in 30fps. It requires less patches and it should give better results in compatibility and coherence. 

Also in the second commit I put a workaround for 30 fps + ESUI. I am not really a fan of it, but it does the job. 

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
