### PR TITLE
FF8: External texture fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 
 - Graphics: Fix crash when using external texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/588 )
 - Graphics: Fix texture glitches using external texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/591 )
+- Graphics: Fix external texture blending ( https://github.com/julianxhokaxhiu/FFNx/pull/598 )
 - Music: Add `ff8_external_music_force_original_filenames` option to use original music names (eg 018s-julia.ogg) instead of just the main identifier in external music ( https://github.com/julianxhokaxhiu/FFNx/pull/594 )
 
 # 1.16.0

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1468,10 +1468,10 @@ uint32_t load_external_texture(void* image_data, uint32_t dataSize, struct textu
 	struct gl_texture_set *gl_set = VREF(texture_set, ogl.gl_set);
 	struct texture_format* tex_format = VREFP(tex_header, tex_format);
 
-	if(save_textures) return false;
-
 	if((uint32_t)VREF(tex_header, file.pc_name) > 32)
 	{
+		if(save_textures) return false;
+
 		if(trace_all || trace_loaders) ffnx_trace("texture file name: %s\n", VREF(tex_header, file.pc_name));
 
 		texture = load_texture(image_data, dataSize, VREF(tex_header, file.pc_name), VREF(tex_header, palette_index), VREFP(texture_set, ogl.width), VREFP(texture_set, ogl.height), gl_set);
@@ -1532,6 +1532,8 @@ uint32_t load_external_texture(void* image_data, uint32_t dataSize, struct textu
 		{
 			textureType = texturePacker.drawTextures(VREF(tex_header, image_data), tex_format, (uint32_t *)image_data_scaled, (uint32_t *)image_data, originalWidth, originalHeight, scale, VREF(tex_header, palette_index));
 		}
+
+		if(save_textures && textureType != TexturePacker::InternalTexture) return false;
 
 		if (textureType != TexturePacker::NoTexture)
 		{

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -990,6 +990,7 @@ struct ff8_externals
 	uint32_t field_main_loop;
 	uint32_t field_main_exit;
 	uint32_t psxvram_texture_pages_free;
+	uint32_t engine_set_init_time;
 	uint32_t sub_4672C0;
 	uint32_t sub_471F70;
 	uint32_t sub_4767B0;
@@ -1147,6 +1148,7 @@ struct ff8_externals
 	uint32_t restart_music_and_sfx;
 	uint32_t directsound_create_secondary_buffer;
 	uint32_t start;
+	uint32_t battle_enter;
 	uint32_t battle_main_loop;
 	void (*show_vram_window)();
 	void (*refresh_vram_window)();

--- a/src/ff8/texture_packer.h
+++ b/src/ff8/texture_packer.h
@@ -107,6 +107,7 @@ public:
 	bool setTextureBackground(const char *name, int x, int y, int w, int h, const std::vector<Tile> &mapTiles, int bgTexId = -1, const char *extension = nullptr, char *found_extension = nullptr);
 	// Override a part of the VRAM from another part of the VRAM, typically with biggest textures (Worldmap)
 	bool setTextureRedirection(const TextureInfos &oldTexture, const TextureInfos &newTexture, uint32_t *imageData);
+	void clearTiledTexs();
 	void clearTextures();
 	uint8_t getMaxScale(const uint8_t *texData) const;
 	void getTextureNames(const uint8_t *texData, std::list<std::string> &names) const;

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -745,14 +745,21 @@ void ff8_battle_upload_texture_palette(int16_t *pos_and_size, uint8_t *texture_b
 		if (StrStrIA(battle_texture_name, ".X") != nullptr) {
 			ff8_battle_state_save_texture(stage, tim, next_texture_name);
 		} else {
-			tim.save(next_texture_name, 0, 0, false);
+			tim.save(next_texture_name, 0, 0, true);
 		}
 	}
 }
 
-void clean_psxvram_pages()
+void engine_set_init_time(double fps_adjust)
 {
 	texturePacker.clearTextures();
+
+	((void(*)(double))ff8_externals.engine_set_init_time)(fps_adjust);
+}
+
+void clean_psxvram_pages()
+{
+	texturePacker.clearTiledTexs();
 
 	((void(*)())ff8_externals.sub_4672C0)();
 }
@@ -797,6 +804,8 @@ void vram_init()
 	replace_call(ff8_externals.battle_open_file + 0x1A2, ff8_battle_read_file);
 	replace_call(ff8_externals.battle_upload_texture_to_vram + 0x45, ff8_battle_upload_texture_palette);
 
+	// Fix missing textures in battle module by clearing custom textures
+	replace_call(ff8_externals.battle_enter + 0x35, engine_set_init_time);
 	// Clear texture_packer on every module exits
 	replace_call(ff8_externals.psxvram_texture_pages_free + 0x5A, clean_psxvram_pages);
 

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -102,6 +102,7 @@ void ff8_find_externals()
 		common_externals.current_field_id = (WORD*)get_absolute_value(ff8_externals.main_loop, 0x21F + 6);
 		ff8_externals.worldmap_enter_main = get_absolute_value(ff8_externals.main_loop, 0x2C0 + 4);
 		ff8_externals.worldmap_main_loop = get_absolute_value(ff8_externals.main_loop, 0x2D0 + 4);
+		ff8_externals.battle_enter = get_absolute_value(ff8_externals.main_loop, 0x330 + 4);
 		ff8_externals.battle_main_loop = get_absolute_value(ff8_externals.main_loop, 0x340 + 4);
 		// Search battle sound function to find play/stop midi related methods
 		ff8_externals.sm_battle_sound = get_relative_call(ff8_externals.main_loop, 0x487 + 5);
@@ -118,6 +119,7 @@ void ff8_find_externals()
 		common_externals.current_field_id = (WORD*)get_absolute_value(ff8_externals.main_loop, 0x21F);
 		ff8_externals.worldmap_enter_main = get_absolute_value(ff8_externals.main_loop, 0x2C0);
 		ff8_externals.worldmap_main_loop = get_absolute_value(ff8_externals.main_loop, 0x2D0);
+		ff8_externals.battle_enter = get_absolute_value(ff8_externals.main_loop, 0x330);
 		ff8_externals.battle_main_loop = get_absolute_value(ff8_externals.main_loop, 0x340);
 		// Search battle sound function to find play/stop midi related methods
 		ff8_externals.sm_battle_sound = get_relative_call(ff8_externals.main_loop, 0x487);
@@ -127,6 +129,7 @@ void ff8_find_externals()
 
 	ff8_externals.psxvram_texture_pages_free = get_relative_call(ff8_externals.field_main_exit, 0x58);
 	ff8_externals.sub_4672C0 = get_relative_call(ff8_externals.psxvram_texture_pages_free, 0x5A);
+	ff8_externals.engine_set_init_time = get_relative_call(ff8_externals.battle_enter, 0x35);
 
 	common_externals.debug_print2 = get_relative_call(uint32_t(ff8_externals.sm_pc_read), 0x16);
 	ff8_externals.moriya_filesytem_open = get_relative_call(uint32_t(ff8_externals.sm_pc_read), 0x21);


### PR DESCRIPTION
## Summary

- Fix texture blending when using mods
- Fix mods removed after showing menu.
- Continue to use high-res WM when save_textures is enabled
- Fix alpha in dumped monster textures.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
