### PR TITLE
Fix/ff8 black worldmap

### DIFF
--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -475,11 +475,6 @@ void ff8_wm_texl_palette_upload_vram(int16_t *pos_and_size, uint8_t *texture_buf
 			return;
 		}
 
-		for (int i = 0; i < newTexture.pixelW() * newTexture.h(); ++i)
-		{
-			image[i] = (image[i] & 0xFFFFFF) | ((image[i] & 0xFF000000) == 0 ? 0 : 0x7F000000); // Force alpha
-		}
-
 		if (! texturePacker.setTextureRedirection(oldTexture, newTexture, image))
 		{
 			if (trace_all || trace_vram) ffnx_warning("%s: invalid redirection\n");


### PR DESCRIPTION
## Summary

Revert a change from #598

### Motivation

This the change, unmodded worlmap is completely black

### ACKs

- N/A I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [ ] I did test my code on FF8
