### PR TITLE
FF8: Increase max texture size to 16384 for external textures + Minor fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,7 +19,8 @@
 
 - Graphics: Fix crash when using external texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/588 )
 - Graphics: Fix texture glitches using external texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/591 )
-- Graphics: Fix external texture blending ( https://github.com/julianxhokaxhiu/FFNx/pull/598 )
+- Graphics: Fix external texture blending ( https://github.com/julianxhokaxhiu/FFNx/pull/598 https://github.com/julianxhokaxhiu/FFNx/pull/601 )
+- Graphics: Increase max texture size to 16384 for external textures ( https://github.com/julianxhokaxhiu/FFNx/pull/601 )
 - Music: Add `ff8_external_music_force_original_filenames` option to use original music names (eg 018s-julia.ogg) instead of just the main identifier in external music ( https://github.com/julianxhokaxhiu/FFNx/pull/594 )
 - Voice: Enable battle dialogs voice acting
 - Voice: Enable worldmap voice acting

--- a/src/common.h
+++ b/src/common.h
@@ -51,6 +51,7 @@
 
 #define NV_VERSION (!(version & 1))
 #define JP_VERSION (version == VERSION_FF8_12_JP || version == VERSION_FF8_12_JP_NV)
+#define FF8_US_VERSION (version == VERSION_FF8_12_US || version == VERSION_FF8_12_US_NV || version == VERSION_FF8_12_US_EIDOS || version == VERSION_FF8_12_US_EIDOS_NV)
 
 // FF8 does not support BLUE text!
 enum

--- a/src/ff8/field/chara_one.cpp
+++ b/src/ff8/field/chara_one.cpp
@@ -139,7 +139,7 @@ bool ff8_chara_one_model_save_textures(const CharaOneModel &model, const uint8_t
 		snprintf(name, sizeof(name), "%s/%s-%d", dirname, model.name, texture_id);
 		Tim tim = Tim::fromTimData(chara_one_model_data + texture_pointer);
 
-		if (!tim.save(name)) {
+		if (!tim.save(name, 0, 0, true)) {
 			return false;
 		}
 		++texture_id;

--- a/src/ff8/texture_packer.h
+++ b/src/ff8/texture_packer.h
@@ -38,7 +38,7 @@ constexpr int VRAM_WIDTH = 1024;
 constexpr int VRAM_HEIGHT = 512;
 constexpr int VRAM_DEPTH = 2;
 constexpr ModdedTextureId INVALID_TEXTURE = ModdedTextureId(0xFFFFFFFF);
-constexpr int MAX_SCALE = 10;
+constexpr int MAX_SCALE = 128;
 
 class TexturePacker {
 public:

--- a/src/ff8/uv_patch.cpp
+++ b/src/ff8/uv_patch.cpp
@@ -157,7 +157,7 @@ void uv_patch_init()
 	 * - And when the game uses the UVs from the SSIGPU instruction, we alter
 	 *   the computation of U and V using the forgotten bits.
 	 */
-	bool isUs = version == VERSION_FF8_12_US || version == VERSION_FF8_12_US_NV || version == VERSION_FF8_12_US_EIDOS || version == VERSION_FF8_12_US_EIDOS_NV;
+	bool isUs = version == FF8_US_VERSION;
 
 	// Worldmap with Fog enabled
 	replace_call(ff8_externals.sub_53BB90 + (isUs ? 0x42D : 0x43B), worldmap_fog_filter_polygons_in_block_1);

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -539,10 +539,15 @@ void ff8_find_externals()
 		ff8_externals.sub_45E3A0 = get_relative_call(ff8_externals.worldmap_fog_filter_polygons_in_block_1, 0x4A4);
 		ff8_externals.worldmap_fog_filter_polygons_in_block_2 = get_relative_call(ff8_externals.sub_53BB90, 0x442);
 		ff8_externals.sub_53C750 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x2DB);
+		ff8_externals.sub_54E9B0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x369);
 		ff8_externals.sub_54FDA0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x375);
 		ff8_externals.sub_54D7E0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x3C2);
+		ff8_externals.world_dialog_assign_text_sub_543790 = (int (*)(int,int,char*))get_relative_call(ff8_externals.sub_54D7E0, 0x72);
 		ff8_externals.sub_544630 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x3D2);
 		ff8_externals.sub_545EA0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x4BF);
+		ff8_externals.sub_5484B0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x5C9);
+		ff8_externals.sub_54A230 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x5CF);
+		ff8_externals.sub_543CB0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0xA55);
 
 		ff8_externals.sub_545F10 = get_relative_call(ff8_externals.sub_545EA0, 0x20);
 
@@ -594,10 +599,15 @@ void ff8_find_externals()
 			ff8_externals.sub_4023D0 = get_relative_call(ff8_externals.sub_4023D0, 0x0);
 		}
 		ff8_externals.sub_53C750 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x2DC);
+		ff8_externals.sub_54E9B0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x36A);
 		ff8_externals.sub_54FDA0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x376);
 		ff8_externals.sub_54D7E0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x3C4);
+		ff8_externals.world_dialog_assign_text_sub_543790 = (int (*)(int,int,char*))get_relative_call(ff8_externals.sub_54D7E0, 0x6F);
 		ff8_externals.sub_544630 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x3D5);
 		ff8_externals.sub_545EA0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x4C1);
+		ff8_externals.sub_5484B0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x5CB);
+		ff8_externals.sub_54A230 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x5D1);
+		ff8_externals.sub_543CB0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0xA47);
 
 		ff8_externals.sub_545F10 = get_relative_call(ff8_externals.sub_545EA0, 0x1C);
 
@@ -608,12 +618,7 @@ void ff8_find_externals()
 		ff8_externals.battle_trigger_worldmap = ff8_externals.worldmap_with_fog_sub_53FAC0 + 0x4EA;
 	}
 
-	ff8_externals.world_dialog_assign_text_sub_543790 = (int (*)(int,int,char*))get_relative_call(ff8_externals.sub_54D7E0, 0x72);
 	ff8_externals.worldmap_windows_idx_map = (char*)get_absolute_value((uint32_t)ff8_externals.world_dialog_assign_text_sub_543790, 0x3B);
-	ff8_externals.sub_543CB0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0xA55);
-	ff8_externals.sub_5484B0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x5C9);
-	ff8_externals.sub_54A230 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x5CF);
-	ff8_externals.sub_54E9B0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x369);
 
 	ff8_externals.sub_548080 = get_relative_call(ff8_externals.worldmap_sub_53F310_loc_53F7EE, 0x9B);
 	ff8_externals.sub_541C80 = (int (*)(int))get_relative_call(ff8_externals.battle_trigger_worldmap, 0);

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -499,7 +499,7 @@ void ff8_find_externals()
 	ff8_externals.ssigpu_init = get_relative_call(ff8_externals.sub_45B460, 0x26);
 	ff8_externals.d3dcaps = (uint32_t *)get_absolute_value(ff8_externals.ssigpu_init, 0x6C);
 
-	if(version == VERSION_FF8_12_US || version == VERSION_FF8_12_US_NV || version == VERSION_FF8_12_US_EIDOS || version == VERSION_FF8_12_US_EIDOS_NV)
+	if(version == FF8_US_VERSION)
 	{
 		ff8_externals.worldmap_section38_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x296);
 		ff8_externals.worldmap_section39_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x321);

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1834,7 +1834,7 @@ bimg::ImageContainer* Renderer::createImageContainer(cmrc::file* file, bimg::Tex
     {
         if (trace_all || trace_renderer) ffnx_trace("Renderer::%s: convert image to format %d\n", __func__, targetFormat);
 
-        bimg::ImageContainer* converted = bimg::imageConvert(&defaultAllocator, targetFormat, *img);
+        bimg::ImageContainer* converted = bimg::imageConvert(&defaultAllocator, targetFormat, *img, false);
 
         bimg::imageFree(img);
 

--- a/src/voice.cpp
+++ b/src/voice.cpp
@@ -1255,17 +1255,18 @@ void voice_init()
 		replace_function(ff8_externals.battle_get_actor_name_sub_47EAF0, ff8_battle_get_actor_name);
 
 		// == World Map ==
-		replace_call_function(ff8_externals.sub_543CB0 + 0x638, ff8_world_dialog_assign_text);
-		replace_call_function(ff8_externals.sub_5484B0 + 0x524, ff8_world_dialog_assign_text);
-		replace_call_function(ff8_externals.sub_54A230 + 0xF, ff8_world_dialog_assign_text);
-		replace_call_function(ff8_externals.sub_54D7E0 + 0x72, ff8_world_dialog_assign_text);
-		replace_call_function(ff8_externals.sub_54E9B0 + 0x206, ff8_world_dialog_assign_text);
-		replace_call_function(ff8_externals.sub_54E9B0 + 0x396, ff8_world_dialog_assign_text);
-		replace_call_function(ff8_externals.sub_54E9B0 + 0x3D2, ff8_world_dialog_assign_text);
-		replace_call_function(ff8_externals.sub_54E9B0 + 0x67D, ff8_world_dialog_assign_text);
-		replace_call_function(ff8_externals.sub_54E9B0 + 0x6A6, ff8_world_dialog_assign_text);
-		replace_call_function(ff8_externals.sub_54E9B0 + 0xEED, ff8_world_dialog_assign_text);
-		replace_call_function(ff8_externals.sub_54FDA0 + 0xAE, ff8_world_dialog_assign_text);
-		replace_call_function(ff8_externals.sub_54FDA0 + 0x178, ff8_world_dialog_assign_text);
+		bool isUs = version == FF8_US_VERSION;
+		replace_call_function(ff8_externals.sub_543CB0 + (isUs ? 0x638 : 0x605), ff8_world_dialog_assign_text);
+		replace_call_function(ff8_externals.sub_5484B0 + (isUs ? 0x524 : 0x4FD), ff8_world_dialog_assign_text);
+		replace_call_function(ff8_externals.sub_54A230 + (isUs ? 0xF : 0xD), ff8_world_dialog_assign_text);
+		replace_call_function(ff8_externals.sub_54D7E0 + (isUs ? 0x72 : 0x6F), ff8_world_dialog_assign_text);
+		replace_call_function(ff8_externals.sub_54E9B0 + (isUs ? 0x206 : 0x20C), ff8_world_dialog_assign_text);
+		replace_call_function(ff8_externals.sub_54E9B0 + (isUs ? 0x396 : 0x3A9), ff8_world_dialog_assign_text);
+		replace_call_function(ff8_externals.sub_54E9B0 + (isUs ? 0x3D2 : 0x3E5), ff8_world_dialog_assign_text);
+		replace_call_function(ff8_externals.sub_54E9B0 + (isUs ? 0x67D : 0x68F), ff8_world_dialog_assign_text);
+		replace_call_function(ff8_externals.sub_54E9B0 + (isUs ? 0x6A6 : 0x6BC), ff8_world_dialog_assign_text);
+		replace_call_function(ff8_externals.sub_54E9B0 + (isUs ? 0xEED : 0xF72), ff8_world_dialog_assign_text);
+		replace_call_function(ff8_externals.sub_54FDA0 + (isUs ? 0xAE : 0xAC), ff8_world_dialog_assign_text);
+		replace_call_function(ff8_externals.sub_54FDA0 + (isUs ? 0x178 : 0x175), ff8_world_dialog_assign_text);
 	}
 }

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -61,7 +61,7 @@ void world_init()
 		playerPosZ = playerPosX+1;
 		playerPosY = playerPosX+2;
 		BYTE *wm_struct;
-		if(version == VERSION_FF8_12_US || version == VERSION_FF8_12_US_NV || version == VERSION_FF8_12_US_EIDOS || version == VERSION_FF8_12_US_EIDOS_NV)
+		if(version == FF8_US_VERSION)
 		{
 			wm_struct = (BYTE*)get_absolute_value(ff8_externals.sub_53C750, 0x633);
 			bCollisionEnabled = (DWORD*)get_absolute_value(ff8_externals.sub_53E6B0, 0x4);


### PR DESCRIPTION
## Summary

- Non-us version does not use similar addresses in Worldmap.
- When an external texture contains an almost opaque alpha, like 254, the pixel is displayed black, force an opaque color to show the real color of the pixel instead
- texl textures (high res worldmap textures) can only be upscaled to 1024x1024, because source height is incorrect. But it should be incorrect as it replaces low res worldmap textures. So I decided to increase MAX_SCALE a lot. Now it is possible to upscale texl to 16384 (which is the max texture size on my machine).

### Motivation

Crash => no crash

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
