### PR TITLE
FF7: Fix Bahamut Zero and Supernova not displaying correctly with lighting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 - Core: Add additional main models eye-to-model mapping
 - Lighting: Fix [`config.toml`](https://github.com/julianxhokaxhiu/FFNx/blob/master/misc/FFNx.lighting.toml) load/save logic
 - Renderer: Fix black color in some field maps (`spipe2` for example) ( https://github.com/julianxhokaxhiu/FFNx/pull/587 )
+- Fixed Bahamut Zero and Supernova not displaying correctly when lighting enabled
 
 ## FF8
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,8 +13,8 @@
 - Ambient: Allow ambient effects to playback in fields that use movies as background
 - Core: Add additional main models eye-to-model mapping
 - Lighting: Fix [`config.toml`](https://github.com/julianxhokaxhiu/FFNx/blob/master/misc/FFNx.lighting.toml) load/save logic
+- Lighting: Fix Bahamut Zero and Supernova not displaying correctly when lighting enabled
 - Renderer: Fix black color in some field maps (`spipe2` for example) ( https://github.com/julianxhokaxhiu/FFNx/pull/587 )
-- Fixed Bahamut Zero and Supernova not displaying correctly when lighting enabled
 
 ## FF8
 

--- a/src/gl/gl.cpp
+++ b/src/gl/gl.cpp
@@ -304,7 +304,7 @@ void gl_draw_indexed_primitive(uint32_t primitivetype, uint32_t vertextype, stru
 	newRenderer.bindIndexBuffer(indices, count);
 	newRenderer.setPrimitiveType(RendererPrimitiveType(primitivetype));
 
-	if (!ff8 && enable_lighting && isLightingEnabledTexture) newRenderer.drawWithLighting(normals != nullptr);
+	if (!ff8 && enable_lighting && normals != nullptr && isLightingEnabledTexture) newRenderer.drawWithLighting(true);
 	else newRenderer.draw();
 
 	stats.vertex_count += count;


### PR DESCRIPTION
## Summary

Fixed Bahamut Zero and Supernova not displaying correctly when lighting enabled. The lighting shader assumes an input with valid normals. So for any model that has no valid normals I changed it to fallback to the standard shader.

### Motivation

Because it's time to have a bug-free lighting mode from start to finish :)

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
