### PR TITLE
FF7: Fix field shadows not displaying during FMV movies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 - Core: Add additional main models eye-to-model mapping
 - Lighting: Fix [`config.toml`](https://github.com/julianxhokaxhiu/FFNx/blob/master/misc/FFNx.lighting.toml) load/save logic
 - Lighting: Fix Bahamut Zero and Supernova not displaying correctly when lighting enabled
+- Lighting: Fix field shadows not displaying during FMV movies
 - Renderer: Fix black color in some field maps (`spipe2` for example) ( https://github.com/julianxhokaxhiu/FFNx/pull/587 )
 
 ## FF8

--- a/src/gl/deferred.cpp
+++ b/src/gl/deferred.cpp
@@ -530,7 +530,7 @@ void gl_draw_deferred(draw_field_shadow_callback shadow_callback)
 
 		if (shadow_callback != nullptr && !isFieldShadowDrawn && deferred_draws[i].vertextype != TLVERTEX)
 		{
-			newRenderer.setD3DProjection(&current_state.d3dprojection_matrix);
+			newRenderer.setD3DProjection(&deferred_draws[i].state.d3dprojection_matrix);
 			newRenderer.setD3DViweport(&d3dviewport_matrix);
 
 			(*shadow_callback)();


### PR DESCRIPTION
## Summary

Fix for field shadows not displaying during FMV movies. Problem was the projection matrix was not being set correctly.

### Motivation

To clean Cosmos own mess.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
