### PR TITLE
FF7: Fixed minor shadow visual glitches occurring in some fields

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@
 - Lighting: Fix Bahamut Zero and Supernova not displaying correctly when lighting enabled
 - Lighting: Fix field shadows not displaying during FMV movies
 - Lighting: Implemented GPU-based original game lighting that better matches PSX version
+- Lighting: Fixed minor shadow visual glitches occurring in some fields
 - Renderer: Fix black color in some field maps (`spipe2` for example) ( https://github.com/julianxhokaxhiu/FFNx/pull/587 )
 - Voice: Enable tutorial voice acting
 

--- a/misc/FFNx.lighting.toml
+++ b/misc/FFNx.lighting.toml
@@ -38,3 +38,139 @@ disable_lighting_textures = [
   "STAGE84_T03", "STAGE87_T01", "STAGE87_T02", "STAGE88_T01", "STAGE88_T02",
   "STAGE89_T01"
 ]
+
+[field_ancnt1]
+shadowmap_fade_start_distance = 200.0
+
+[field_anfrst_3]
+shadowmap_fade_start_distance = 200.0
+
+[field_blin66_5]
+shadowmap_fade_start_distance = 200.0
+
+[field_blin68_1]
+shadowmap_fade_start_distance = 100.0
+
+[field_blinst_1]
+shadowmap_fade_start_distance = 200.0
+
+[field_blinst_2]
+shadowmap_fade_start_distance = 200.0
+
+[field_blinst_3]
+shadowmap_fade_start_distance = 200.0
+
+[field_blue_1]
+shadowmap_area = 6000.0
+
+[field_convil_1]
+shadowmap_fade_start_distance = 200.0
+
+[field_cos_btm]
+shadowmap_fade_start_distance = 200.0
+
+[field_cos_top]
+shadowmap_fade_start_distance = 200.0
+
+[field_del1]
+shadowmap_area = 3500.0
+
+[field_del12]
+shadowmap_area = 3500.0
+
+[field_del2]
+shadowmap_fade_start_distance = 100.0
+
+[field_fship_4]
+shadowmap_fade_start_distance = 200.0
+
+[field_fship_42]
+shadowmap_fade_start_distance = 200.0
+
+[field_gaia_2]
+shadowmap_fade_start_distance = 200.0
+
+[field_gaiafoot]
+shadowmap_area = 3500.0
+
+[field_gaiin_1]
+shadowmap_fade_range = 100.0
+shadowmap_fade_start_distance = 100.0
+
+[field_gnmkf]
+shadowmap_area = 3800.0
+
+[field_holu_2]
+shadowmap_fade_start_distance = 100.0
+
+[field_junair]
+shadowmap_area = 3600.0
+
+[field_junonr1]
+shadowmap_area = 4000.0
+
+[field_las0_1]
+shadowmap_fade_start_distance = 200.0
+
+[field_las1_2]
+shadowmap_fade_start_distance = 200.0
+
+[field_losin1]
+shadowmap_fade_start_distance = 100.0
+
+[field_losin2]
+shadowmap_fade_start_distance = 200.0
+
+[field_losin3]
+shadowmap_fade_start_distance = 100.0
+
+[field_loslake1]
+shadowmap_fade_start_distance = 200.0
+
+[field_lost1]
+shadowmap_area = 3100.0
+
+[field_md8_32]
+shadowmap_fade_start_distance = 200.0
+
+[field_md8_b1]
+shadowmap_fade_start_distance = 200.0
+
+[field_md8_b2]
+shadowmap_fade_start_distance = 200.0
+
+[field_mds7st32]
+shadowmap_area = 3500.0
+
+[field_mtcrl_3]
+shadowmap_fade_start_distance = 200.0
+
+[field_mtcrl_9]
+shadowmap_area = 5100.0
+
+[field_rcktbas1]
+shadowmap_fade_start_distance = 200.0
+
+[field_sandun_1]
+shadowmap_fade_start_distance = 200.0
+
+[field_sango1]
+shadowmap_fade_start_distance = 100.0
+
+[field_sango2]
+shadowmap_area = 6000.0
+
+[field_sango3]
+shadowmap_fade_start_distance = 200.0
+
+[field_shpin_2]
+shadowmap_fade_start_distance = 200.0
+
+[field_shpin_22]
+shadowmap_fade_start_distance = 200.0
+
+[field_sinin3]
+shadowmap_fade_start_distance = 200.0
+
+[field_trnad_3]
+shadowmap_area = 3750.0

--- a/misc/FFNx.pcf.sh
+++ b/misc/FFNx.pcf.sh
@@ -34,6 +34,8 @@ float sampleShadowMap(vec2 base_uv, float u, float v, float shadowMapSizeInv, fl
     vec2 uv = base_uv + vec2(u, v) * shadowMapSizeInv;
 
     vec3 shadowUv = vec3(uv, lightDepth);
+    if(shadowUv.x < 0.0 || shadowUv.x > 1.0 || shadowUv.y < 0.0 || shadowUv.y > 1.0 || lightDepth < 0.0 || lightDepth > 1.0) return 1.0;
+
     float shadowFactor = shadow2D(tex_3, shadowUv);
 
 #ifdef FIELD_SHADOW

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -67,7 +67,7 @@ struct LightingState
     float materialData[4] = { 0.7, 0.5, 0.2, 0.0 };
     float materialScaleData[4] = { 1.0, 1.0, 1.0, 1.0 };
     float shadowData[4] = { 0.001, 0.0, 0.0, 2048.0 };
-    float fieldShadowData[4] = { 0.3, 200.0, 100.0, 0.0 };
+    float fieldShadowData[4] = { 0.3, 1000.0, 100.0, 0.0 };
     float iblData[4] = { 1.0, 0.0, 0.0, 0.0 };
 
     float lightingDebugData[4] = { 0.0, 0.0, 0.0, 0.0 };
@@ -105,7 +105,6 @@ private:
     std::vector<WORD> walkMeshIndices;
 
     auto getConfigEntry(char* key);
-    void setConfigEntry(const char* key, auto value);
 
     void loadConfig();
     void initParamsFromConfig();
@@ -131,6 +130,7 @@ public:
 
     // Config
     std::string getConfigGroup();
+    void setConfigEntry(const char* key, auto value);
 
     // Lighting
     void setPbrTextureEnabled(bool isEnabled);
@@ -205,6 +205,21 @@ public:
     void setDebugOutput(DebugOutput output);
     DebugOutput GetDebugOutput();
 };
+
+inline void Lighting::setConfigEntry(const char *key, auto value)
+{
+	std::string groupKey = getConfigGroup();
+
+	if (!groupKey.empty())
+	{
+		if (config.contains(groupKey))
+			config[groupKey].as_table()->insert_or_assign(key, value);
+		else
+			config.insert_or_assign(groupKey, toml::table{ {key, value} });
+	}
+	else
+		config.insert_or_assign(key, value);
+}
 
 void drawFieldShadow();
 

--- a/src/lighting_debug.cpp
+++ b/src/lighting_debug.cpp
@@ -75,17 +75,21 @@ void lighting_debug(bool* isOpen)
             lightRotation[0] = std::max(0.0f, std::min(180.0f, lightRotation[0]));
             lightRotation[1] = std::max(0.0f, std::min(360.0f, lightRotation[1]));
             lighting.setWorldLightDir(lightRotation[0], lightRotation[1], 0.0f);
+            lighting.setConfigEntry("light_rotation_vertical", lightRotation[0]);
+	        lighting.setConfigEntry("light_rotation_horizontal", lightRotation[1]);
         }
         float lightIntensity = lighting.getLightIntensity();
         if (ImGui::DragFloat("Intensity##0", &lightIntensity, 0.01f, 0.0f, 100.0f))
         {
-            lighting.setLightIntensity(lightIntensity);
+            lighting.setLightIntensity(lightIntensity);            
+            lighting.setConfigEntry("light_intensity", lightIntensity);
         }
         vector3<float> lightColorPoint3d = lighting.getLightColor();
         float lightColor[3] = { lightColorPoint3d.x, lightColorPoint3d.y, lightColorPoint3d.z };
         if (ImGui::ColorEdit3("Color##0", lightColor))
         {
             lighting.setLightColor(lightColor[0], lightColor[1], lightColor[2]);
+            lighting.setConfigEntry("light_color", toml::array(lightColor[0], lightColor[1], lightColor[2]));
         }
     }
     if (ImGui::CollapsingHeader("Indirect Lighting", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth))
@@ -94,6 +98,7 @@ void lighting_debug(bool* isOpen)
         if (ImGui::DragFloat("Intensity##1", &ambientIntensity, 0.01f, 0.0f, 100.0f))
         {
             lighting.setAmbientIntensity(ambientIntensity);
+            lighting.setConfigEntry("ambient_light_intensity", ambientIntensity);
         }
 
         vector3<float> ambientLightColorPoint3d = lighting.getAmbientLightColor();
@@ -101,6 +106,7 @@ void lighting_debug(bool* isOpen)
         if (ImGui::ColorEdit3("Color##1", ambientLightColor))
         {
             lighting.setAmbientLightColor(ambientLightColor[0], ambientLightColor[1], ambientLightColor[2]);
+            lighting.setConfigEntry("ambient_light_color", toml::array(ambientLightColor[0], ambientLightColor[1], ambientLightColor[2]));
         }
     }
     if (ImGui::CollapsingHeader("Material", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth))
@@ -173,26 +179,31 @@ void lighting_debug(bool* isOpen)
         if (ImGui::DragFloat("Occlusion", &fieldShadowOcclusion, 0.01f, 0.0f, 1.0f))
         {
             lighting.setFieldShadowOcclusion(fieldShadowOcclusion);
+            lighting.setConfigEntry("shadowmap_occlusion", fieldShadowOcclusion);
         }
         float fieldShadowMapArea = lighting.getFieldShadowMapArea();
         if (ImGui::DragFloat("Area##1", &fieldShadowMapArea, 10.0f, 0.0f, 100000.0f))
         {
             lighting.setFieldShadowMapArea(fieldShadowMapArea);
+            lighting.setConfigEntry("shadowmap_area", fieldShadowMapArea);
         }
         float fieldShadowMapNearFarSize = lighting.getFieldShadowMapNearFarSize();
         if (ImGui::DragFloat("Near/far size##1", &fieldShadowMapNearFarSize, 10.0f, 0.0f, 100000.0f))
         {
             lighting.setFieldShadowMapNearFarSize(fieldShadowMapNearFarSize);
+            lighting.setConfigEntry("shadowmap_near_far_size", fieldShadowMapNearFarSize);
         }
         float fieldShadowDistance = lighting.getFieldShadowFadeStartDistance();
         if (ImGui::DragFloat("Fade Start Distance", &fieldShadowDistance, 1.0f, 0.0f, 1000.0f))
         {
             lighting.setFieldShadowFadeStartDistance(fieldShadowDistance);
+            lighting.setConfigEntry("shadowmap_fade_start_distance", fieldShadowDistance);
         }
         float fieldShadowFadeRange = lighting.getFieldShadowFadeRange();
         if (ImGui::DragFloat("Fade Range", &fieldShadowFadeRange, 1.0f, 0.0f, 1000.0f))
         {
             lighting.setFieldShadowFadeRange(fieldShadowFadeRange);
+            lighting.setConfigEntry("shadowmap_fade_range", fieldShadowDistance);
         }
         float walkMeshExtrudeSize = lighting.getWalkmeshExtrudeSize();
         if (ImGui::DragFloat("Walkmesh extrude size", &walkMeshExtrudeSize, 0.01f, 0.0f, 100.0f))


### PR DESCRIPTION
## Summary

Fixed minor shadow visual glitches occurring in some fields like shadow stretching or some unintended shadows appearing where they shouldn't. Changed also the lighting config save to only be done when a parameter has been modified (until now every field loaded was creating config entries).

### Motivation

To make people happy.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
