### PR TITLE
FF7: Fix Widescreen glitches for Bahamut Zero and Pollensalta

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@
 - Renderer: Fix black color in some field maps (`spipe2` for example) ( https://github.com/julianxhokaxhiu/FFNx/pull/587 )
 - Voice: Enable tutorial voice acting
 - Widescreen: Added experimental support for 16:10 aspect ratio
+- Widescreen: Fix Pollensalta attack (only when also using 30/60FPS mode) and Bahamut Zero summon background
 
 ## FF8
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,7 +20,7 @@
 - Renderer: Fix black color in some field maps (`spipe2` for example) ( https://github.com/julianxhokaxhiu/FFNx/pull/587 )
 - Voice: Enable tutorial voice acting
 - Widescreen: Added experimental support for 16:10 aspect ratio
-- Widescreen: Fix Pollensalta attack (only when also using 30/60FPS mode) and Bahamut Zero summon background
+- Widescreen: Fix Pollensalta attack (only when also using 30/60FPS mode since it is a temporary fix) and Bahamut Zero summon background
 
 ## FF8
 

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -3240,6 +3240,14 @@ struct ff7_externals
 	vector3<int>** ifrit_vector3_int_ptr_BCC6A8;
 	vector3<short>* battle_ifrit_model_position;
 	rotation_matrix* ifrit_rot_matrix_BCC768;
+	uint32_t pollensalta_cold_breath_atk_enter_sub_5474F0;
+	uint32_t pollensalta_cold_breath_atk_main_loop_5476B0;
+	uint32_t pollensalta_cold_breath_atk_draw_bg_effect_547B94;
+	uint32_t pollensalta_cold_breath_atk_white_dot_effect_547D56;
+	void (*pollensalta_cold_breath_atk_draw_white_dots_547E75)(short);
+	std::span<vector4<short>> pollensalta_cold_breath_white_dots_pos;
+	short* pollensalta_cold_breath_white_dot_rgb_scalar;
+	uint32_t pollensalta_cold_breath_bg_texture_ctx;
 
 	// battle menu
 	uint32_t display_battle_menu_6D797C;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -3166,6 +3166,8 @@ struct ff7_externals
 	uint32_t run_bahamut_zero_main_loop_484A16;
 	uint32_t run_bahamut_zero_movement_48BBFC;
 	uint32_t run_bahamut_zero_camera_483866;
+	uint32_t bahamut_zero_draw_bg_effect_sub_4859AA;
+	uint32_t bahamut_zero_bg_star_graphics_data_7F6748;
 	uint32_t run_summon_kotr_sub_476857;
 	uint32_t run_summon_kotr_main_loop_478031;
 	std::array<uint32_t, 13> run_summon_kotr_knight_script;

--- a/src/ff7/battle/animations.cpp
+++ b/src/ff7/battle/animations.cpp
@@ -1068,7 +1068,8 @@ namespace ff7::battle
                             v_bottom = v_top_1 + v_top_2;
                         }
 
-                        // Pollensalta cold breath bg widescreen fix
+                        // Temporary fix for Pollensalta cold breath bg widescreen fix 
+                        // (The correct solution should be to edit the file `magic/ff7/data/battle/special/hubuki/kemu.s` to edit the texture page)
                         if(widescreen_enabled && (uint32_t)texture_ctx == ff7_externals.pollensalta_cold_breath_bg_texture_ctx)
                         {
                             float widescreen_multiplier = ((float)wide_viewport_width / (float)wide_viewport_height) / (4 / 3.f);

--- a/src/ff7/battle/animations.cpp
+++ b/src/ff7/battle/animations.cpp
@@ -34,6 +34,7 @@
 #include "defs.h"
 #include "effect.h"
 #include "menu.h"
+#include "../widescreen.h"
 
 namespace ff7::battle
 {
@@ -1066,6 +1067,15 @@ namespace ff7::battle
                             v_top = page_spt_ptr->vScale * drawable->v_offset + drawable->v_offset / 2.0;
                             v_bottom = v_top_1 + v_top_2;
                         }
+
+                        // Pollensalta cold breath bg widescreen fix
+                        if(widescreen_enabled && (uint32_t)texture_ctx == ff7_externals.pollensalta_cold_breath_bg_texture_ctx)
+                        {
+                            float widescreen_multiplier = ((float)wide_viewport_width / (float)wide_viewport_height) / (4 / 3.f);
+                            quad_width *= widescreen_multiplier;
+                            quad_height *= widescreen_multiplier;
+                        }
+
                         drawable_state->vertices[0].x = x_left;
                         drawable_state->vertices[0].y = y_top;
                         drawable_state->vertices[0].z = 0.0;

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -123,7 +123,7 @@ void pollensalta_cold_breath_atk_white_dot_effect()
             ff7_externals.pollensalta_cold_breath_white_dots_pos[i].y = (offset + ff7_externals.pollensalta_cold_breath_white_dots_pos[i].y) % wide_viewport_height;
         }
 
-        if(effect_data->field_2 < 8)
+        if (effect_data->field_2 < 8)
             *ff7_externals.pollensalta_cold_breath_white_dot_rgb_scalar += 1;
         if (effect_data->field_2 > 42)
             *ff7_externals.pollensalta_cold_breath_white_dot_rgb_scalar -= 1;

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -198,6 +198,15 @@ void ff7_widescreen_hook_init() {
     patch_code_dword(ff7_externals.barret_limit_3_1_sub_4700F7 + 0x36, (uint32_t)&wide_viewport_width);
     patch_code_dword(ff7_externals.fat_chocobo_sub_5096F3 + 0x4A, (uint32_t)&wide_viewport_x);
     patch_code_dword(ff7_externals.fat_chocobo_sub_5096F3 + 0x5F, (uint32_t)&wide_viewport_width);
+    // Makes bahamut small stars background to 512x512 quad size and a different positioning of the 6 image patches
+    patch_code_short(ff7_externals.bahamut_zero_draw_bg_effect_sub_4859AA + 0x20F, -512);
+    patch_code_short(ff7_externals.bahamut_zero_draw_bg_effect_sub_4859AA + 0x23F, 1024);
+    patch_code_short(ff7_externals.bahamut_zero_draw_bg_effect_sub_4859AA + 0x26F, 512);
+    patch_code_short(ff7_externals.bahamut_zero_draw_bg_effect_sub_4859AA + 0x29E, 512);
+    patch_code_short(ff7_externals.bahamut_zero_draw_bg_effect_sub_4859AA + 0x2CE, 512);
+    patch_code_short(ff7_externals.bahamut_zero_bg_star_graphics_data_7F6748 + 0x8, 512);
+    patch_code_short(ff7_externals.bahamut_zero_bg_star_graphics_data_7F6748 + 0xA, 512);
+
     // Battle fading animation fix
     patch_code_short(ff7_externals.battle_sub_5BCF9D + 0x3A, 30);
     patch_code_byte(ff7_externals.battle_sub_5BCF9D + 0x69, 120);

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -105,6 +105,34 @@ void ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E(int wave_data_poin
     ff7_externals.engine_draw_sub_66A47E(wave_data_pointer);
 }
 
+void pollensalta_cold_breath_atk_white_dot_effect() 
+{
+    effect100_data* effect_data = &ff7_externals.effect100_array_data[*ff7_externals.effect100_array_idx];
+    ff7_externals.pollensalta_cold_breath_atk_draw_white_dots_547E75(*ff7_externals.pollensalta_cold_breath_white_dot_rgb_scalar);
+    if (!*ff7_externals.g_is_battle_paused) 
+    {
+        for (int i = 0; i < 400; i++)
+        {
+            short offset = 2 * (i % 2) + 2;
+            ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x = (offset + ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x);
+            if (ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x < wide_viewport_x) 
+                ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x = ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x + wide_viewport_width;
+            if (ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x > wide_viewport_width + wide_viewport_x)
+                ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x = ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x - wide_viewport_width;
+
+            ff7_externals.pollensalta_cold_breath_white_dots_pos[i].y = (offset + ff7_externals.pollensalta_cold_breath_white_dots_pos[i].y) % wide_viewport_height;
+        }
+
+        if(effect_data->field_2 < 8)
+            *ff7_externals.pollensalta_cold_breath_white_dot_rgb_scalar += 1;
+        if (effect_data->field_2 > 42)
+            *ff7_externals.pollensalta_cold_breath_white_dot_rgb_scalar -= 1;
+        if (++effect_data->field_2 == 50)
+            effect_data->field_0 = 0xFFFF;
+        
+    }
+}
+
 void ff7_widescreen_fix_chocobo_submit_quad_graphics_object(int x, int y, int width, int height, int color, int unknown, float z_value, DWORD* pointer)
 {
 	if(width == 640) // Replace only quad related to water effect
@@ -166,6 +194,11 @@ void ff7_widescreen_hook_init() {
     patch_code_dword(ff7_externals.display_battle_damage_5BB410 + 0x24C, (uint32_t)&wide_viewport_x);
     patch_code_int(ff7_externals.shadow_flare_draw_white_bg_57747E + 0x18, wide_viewport_x);
     patch_code_int(ff7_externals.shadow_flare_draw_white_bg_57747E + 0x1F, wide_viewport_width / 2);
+    patch_code_int(ff7_externals.pollensalta_cold_breath_atk_enter_sub_5474F0 + 0x83, wide_viewport_width);
+    patch_code_int(ff7_externals.pollensalta_cold_breath_atk_enter_sub_5474F0 + 0x8D, wide_viewport_height);
+    patch_code_short(ff7_externals.pollensalta_cold_breath_atk_main_loop_5476B0 + 0x191, wide_viewport_x - 200);
+    patch_code_dword(ff7_externals.pollensalta_cold_breath_atk_main_loop_5476B0 + 0x39, (uint32_t)&pollensalta_cold_breath_atk_white_dot_effect);
+
     // Battle summon fix
     replace_call_function(ff7_externals.ifrit_sub_595A05 + 0x930, ifrit_first_wave_effect_widescreen_fix_sub_66A47E);
     replace_call_function(ff7_externals.ifrit_sub_595A05 + 0xAEC, ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1102,6 +1102,16 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	uint32_t enemy_atk_sub_457B4C = get_relative_call(enemy_atk_sub_457B20, 0x22);
 	uint32_t enemy_atk_sub_457C20 = get_relative_call(enemy_atk_sub_457B4C, 0xB4);
 	ff7_externals.enemy_atk_camera_sub_457C60 = get_absolute_value(enemy_atk_sub_457C20, 0x5);
+	ff7_externals.pollensalta_cold_breath_atk_enter_sub_5474F0 = ff7_externals.enemy_atk_effects_fn_table[59];
+	uint32_t pollensalta_cold_breath_atk_main_sub_547595 = get_relative_call(ff7_externals.pollensalta_cold_breath_atk_enter_sub_5474F0, 0x99);
+	uint32_t pollensalta_cold_breath_atk_callback_sub_5455E7 = get_absolute_value(pollensalta_cold_breath_atk_main_sub_547595, 0x4);
+	ff7_externals.pollensalta_cold_breath_atk_main_loop_5476B0 = get_absolute_value(pollensalta_cold_breath_atk_callback_sub_5455E7, 0x7);
+	ff7_externals.pollensalta_cold_breath_atk_draw_bg_effect_547B94 = get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_main_loop_5476B0, 0x16F);
+	ff7_externals.pollensalta_cold_breath_atk_white_dot_effect_547D56 = get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_main_loop_5476B0, 0x39);
+	ff7_externals.pollensalta_cold_breath_atk_draw_white_dots_547E75 = (void(*)(short))get_relative_call(ff7_externals.pollensalta_cold_breath_atk_white_dot_effect_547D56, 0x20);
+	ff7_externals.pollensalta_cold_breath_white_dots_pos = std::span((vector4<short>*) get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_white_dot_effect_547D56, 0x79), 400);
+	ff7_externals.pollensalta_cold_breath_white_dot_rgb_scalar = (short*) get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_white_dot_effect_547D56, 0x1B);
+	ff7_externals.pollensalta_cold_breath_bg_texture_ctx = get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_draw_bg_effect_547B94, 0x2A);	
 
 	// Texture/Material animation
 	uint32_t battle_leviathan_sub_5B2F18 = get_absolute_value(ff7_externals.battle_summon_leviathan_loop, 0x50E);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1023,6 +1023,8 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.run_bahamut_zero_main_loop_484A16 = get_absolute_value(run_bahamut_zero_sub_483762, 0x5F);
 	ff7_externals.run_bahamut_zero_movement_48BBFC = get_absolute_value(run_bahamut_zero_sub_483762, 0x6C);
 	ff7_externals.run_bahamut_zero_camera_483866 = get_absolute_value(run_bahamut_zero_camera_handler_483826, 0x5);
+	ff7_externals.bahamut_zero_draw_bg_effect_sub_4859AA = get_absolute_value(ff7_externals.run_bahamut_zero_main_loop_484A16, 0x2E8);
+	ff7_externals.bahamut_zero_bg_star_graphics_data_7F6748 = get_absolute_value(ff7_externals.bahamut_zero_draw_bg_effect_sub_4859AA, 0x1BC);
 	uint32_t run_summon_kotr_main_476842 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x43A);
 	ff7_externals.run_summon_kotr_sub_476857 = get_relative_call(run_summon_kotr_main_476842, 0xB);
 	ff7_externals.run_summon_kotr_main_loop_478031 = get_absolute_value(ff7_externals.run_summon_kotr_sub_476857, 0x1AC);

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -66,6 +66,15 @@ struct vector3
 	T z;
 };
 
+template <typename T>
+struct vector4
+{
+	T x;
+	T y;
+	T z;
+	T w;
+};
+
 struct point4d
 {
 	float x;


### PR DESCRIPTION
## Summary

Fix widescreen glitches (related to #474) for:
 - Bahamut Zero stars background positioning and size
 - Pollensalta cold breath attack: moving background and moving white dots 

Regarding Pollensalta fix for the moving background size: this only works when in 30/60fps mode because I used a function hooked only when in 60 fps mode. I don't think there is other way to do it, but I think the correct solution should be to fix the texture page which I suppose it is inside files with `.s` as extension (in this case, `special/hubuki/kemu.s`). So I left the solution for 30/60fps just as a temporary fix.

### Motivation

I don't know why either

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
