### PR TITLE
FF7: Fix Widescreen Pandora Box white background position

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
 - Voice: Enable tutorial voice acting
 - Widescreen: Added experimental support for 16:10 aspect ratio
 - Widescreen: Fix Pollensalta attack (only when also using 30/60FPS mode since it is a temporary fix) and Bahamut Zero summon background
+- Widescreen: Fix Pandora Box white background position
 
 ## FF8
 

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -3248,6 +3248,7 @@ struct ff7_externals
 	std::span<vector4<short>> pollensalta_cold_breath_white_dots_pos;
 	short* pollensalta_cold_breath_white_dot_rgb_scalar;
 	uint32_t pollensalta_cold_breath_bg_texture_ctx;
+	uint32_t pandora_box_skill_draw_bg_flash_effect_568371;
 
 	// battle menu
 	uint32_t display_battle_menu_6D797C;

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -198,6 +198,7 @@ void ff7_widescreen_hook_init() {
     patch_code_int(ff7_externals.pollensalta_cold_breath_atk_enter_sub_5474F0 + 0x8D, wide_viewport_height);
     patch_code_short(ff7_externals.pollensalta_cold_breath_atk_main_loop_5476B0 + 0x191, wide_viewport_x - 200);
     patch_code_dword(ff7_externals.pollensalta_cold_breath_atk_main_loop_5476B0 + 0x39, (uint32_t)&pollensalta_cold_breath_atk_white_dot_effect);
+    patch_code_int(ff7_externals.pandora_box_skill_draw_bg_flash_effect_568371 + 0x3D, wide_viewport_x - 170);
 
     // Battle summon fix
     replace_call_function(ff7_externals.ifrit_sub_595A05 + 0x930, ifrit_first_wave_effect_widescreen_fix_sub_66A47E);

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1112,6 +1112,11 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.pollensalta_cold_breath_white_dots_pos = std::span((vector4<short>*) get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_white_dot_effect_547D56, 0x79), 400);
 	ff7_externals.pollensalta_cold_breath_white_dot_rgb_scalar = (short*) get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_white_dot_effect_547D56, 0x1B);
 	ff7_externals.pollensalta_cold_breath_bg_texture_ctx = get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_draw_bg_effect_547B94, 0x2A);	
+	uint32_t pandora_box_skill_enter_5667E1 = ff7_externals.enemy_skill_effects_fn_table[23];
+	uint32_t pandora_box_skill_main_566806 = get_relative_call(pandora_box_skill_enter_5667E1, 0x1A);
+	uint32_t pandora_box_skill_sub_566871 = get_absolute_value(pandora_box_skill_main_566806, 0x30);
+	uint32_t pandora_box_skill_main_loop_566E61 = get_absolute_value(pandora_box_skill_sub_566871, 0x1F);
+	ff7_externals.pandora_box_skill_draw_bg_flash_effect_568371 = get_absolute_value(pandora_box_skill_main_loop_566E61, 0x162);
 
 	// Texture/Material animation
 	uint32_t battle_leviathan_sub_5B2F18 = get_absolute_value(ff7_externals.battle_summon_leviathan_loop, 0x50E);


### PR DESCRIPTION
## Summary

Another widescreen fix on battle mode: Pandora Box white background position (related to #474)

### Motivation

Again...Sorry should have put this change into the previous PR

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
