### PR TITLE
FF8: World chara.one textures replacement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@
 - Graphics: Fix crash when using external texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/588 )
 - Graphics: Fix texture glitches using external texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/591 )
 - Graphics: Fix external texture blending ( https://github.com/julianxhokaxhiu/FFNx/pull/598 https://github.com/julianxhokaxhiu/FFNx/pull/601 )
+- Graphics: Add chara.one worldmap texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/615 )
 - Graphics: Increase max texture size to 16384 for external textures ( https://github.com/julianxhokaxhiu/FFNx/pull/601 )
 - Music: Add `ff8_external_music_force_original_filenames` option to use original music names (eg 018s-julia.ogg) instead of just the main identifier in external music ( https://github.com/julianxhokaxhiu/FFNx/pull/594 )
 - Voice: Enable battle dialogs voice acting

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1059,6 +1059,8 @@ struct ff8_externals
 	uint32_t load_field_models;
 	uint32_t chara_one_read_file;
 	uint32_t chara_one_seek_file;
+	uint32_t chara_one_set_data_start;
+	uint8_t **chara_one_data_start;
 	uint32_t chara_one_upload_texture;
 	uint32_t worldmap_main_loop;
 	uint32_t worldmap_enter_main;
@@ -1071,6 +1073,8 @@ struct ff8_externals
 	uint32_t worldmap_sub_541970_upload_tim;
 	uint32_t worldmap_sub_548020;
 	uint32_t worldmap_sub_5531F0;
+	uint32_t worldmap_sub_545E20;
+	uint32_t worldmap_chara_one;
 	int32_t (*open_file_world)(const char*, int32_t, uint32_t, void *);
 	uint32_t open_file_world_sub_52D670_texl_call1;
 	uint32_t open_file_world_sub_52D670_texl_call2;

--- a/src/ff8/field/chara_one.cpp
+++ b/src/ff8/field/chara_one.cpp
@@ -61,7 +61,7 @@ std::unordered_map<uint32_t, CharaOneModel> ff8_chara_one_parse_models(const uin
 		CharaOneModel model = CharaOneModel();
 
 		if (flag >> 24 != 0xd0) { // NPCs (not main characters)
-			uint32_t timOffset;
+			uint32_t tim_offset;
 
 			if (trace_all) ffnx_info("%s: %d %d %d\n", __func__, i, int(cur - chara_one_data), size);
 
@@ -70,14 +70,14 @@ std::unordered_map<uint32_t, CharaOneModel> ff8_chara_one_parse_models(const uin
 			}
 
 			while (cur - chara_one_data < size) {
-				memcpy(&timOffset, cur, 4);
+				memcpy(&tim_offset, cur, 4);
 				cur += 4;
 
-				if (timOffset == 0xFFFFFFFF) {
+				if (tim_offset == 0xFFFFFFFF) {
 					break;
 				}
 
-				model.texturesData.push_back(timOffset & 0xFFFFFF);
+				model.texturesData.push_back(tim_offset & 0xFFFFFF);
 			}
 		} else {
 			model.isMch = true;

--- a/src/ff8/world/chara_one.cpp
+++ b/src/ff8/world/chara_one.cpp
@@ -1,0 +1,85 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//    Copyright (C) 2020 John Pritchard                                     //
+//    Copyright (C) 2023 myst6re                                            //
+//    Copyright (C) 2023 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2023 Cosmos                                             //
+//    Copyright (C) 2023 Tang-Tang Zhou                                     //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#include "chara_one.h"
+#include "../../image/tim.h"
+#include "../../saveload.h"
+#include "../../log.h"
+
+std::vector<CharaOneModelTextures> ff8_world_chara_one_parse_models(const uint8_t *chara_one_data, size_t size)
+{
+	std::vector<CharaOneModelTextures> models;
+
+	const uint8_t *cur = chara_one_data + size, *min_cur = chara_one_data + 4;
+
+	// The header is at the end of the file
+	uint32_t count;
+	cur -= 4;
+	memcpy(&count, cur, 4);
+
+	for (uint32_t i = 0; i < count && cur >= min_cur; ++i) {
+		CharaOneModelTextures textures;
+
+		uint32_t tim_offset;
+
+		while (cur >= min_cur) {
+			cur -= 4;
+			memcpy(&tim_offset, cur, 4);
+
+			if (tim_offset == 0xFFFFFFFF) {
+				break;
+			}
+
+			textures.push_back(tim_offset & 0xFFFFFFF);
+		}
+
+		models.push_back(textures);
+
+		cur -= 4; // Skipping offset to the model data
+	}
+
+	return models;
+}
+
+bool ff8_world_chara_one_model_save_textures(const std::vector<CharaOneModelTextures> &models, const uint8_t *chara_one_model_data, const char *dirname)
+{
+	if (trace_all || trace_vram) ffnx_trace("%s: %s\n", __func__, dirname);
+
+	int model_id = 0;
+	for (const CharaOneModelTextures &textures: models) {
+		int texture_id = 0;
+		for (uint32_t texture_pointer: textures) {
+			char name[MAX_PATH] = {};
+			snprintf(name, sizeof(name), "%s/model%d-%d", dirname, model_id, texture_id);
+			Tim tim = Tim::fromTimData(chara_one_model_data + texture_pointer);
+
+			if (!tim.save(name, 0, 0, true)) {
+				return false;
+			}
+			++texture_id;
+		}
+		++model_id;
+	}
+
+	return true;
+}

--- a/src/ff8/world/chara_one.h
+++ b/src/ff8/world/chara_one.h
@@ -1,0 +1,33 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//    Copyright (C) 2020 John Pritchard                                     //
+//    Copyright (C) 2023 myst6re                                            //
+//    Copyright (C) 2023 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2023 Cosmos                                             //
+//    Copyright (C) 2023 Tang-Tang Zhou                                     //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#pragma once
+
+#include "../../common.h"
+
+#include <vector>
+
+typedef std::vector<uint32_t> CharaOneModelTextures;
+
+std::vector<CharaOneModelTextures> ff8_world_chara_one_parse_models(const uint8_t *chara_one_data, size_t size);
+bool ff8_world_chara_one_model_save_textures(const std::vector<CharaOneModelTextures> &models, const uint8_t *chara_one_model_data, const char *dirname);

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -377,6 +377,8 @@ void ff8_find_externals()
 	ff8_externals.load_field_models = get_relative_call(ff8_externals.read_field_data, JP_VERSION ? 0xFA2 : 0xF0F);
 	ff8_externals.chara_one_read_file = get_relative_call(ff8_externals.load_field_models, 0x15F);
 	ff8_externals.chara_one_seek_file = get_relative_call(ff8_externals.load_field_models, 0x582);
+	ff8_externals.chara_one_set_data_start = get_relative_call(ff8_externals.load_field_models, 0xAFF);
+	ff8_externals.chara_one_data_start = (uint8_t **)get_absolute_value(ff8_externals.chara_one_set_data_start, 0x5);
 	ff8_externals.chara_one_upload_texture = get_relative_call(ff8_externals.load_field_models, 0xB72);
 
 	ff8_externals.worldmap_sub_53F310 = get_relative_call(ff8_externals.worldmap_enter_main, 0xA7);
@@ -516,6 +518,8 @@ void ff8_find_externals()
 		ff8_externals.worldmap_sub_53F310_call_366 = ff8_externals.worldmap_sub_53F310 + 0x366;
 		ff8_externals.worldmap_sub_53F310_loc_53F7EE = ff8_externals.worldmap_sub_53F310 + 0x4DE;
 		ff8_externals.worldmap_sub_541970_upload_tim = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x330);
+		ff8_externals.worldmap_sub_545E20 = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x60C);
+		ff8_externals.worldmap_chara_one = get_relative_call(ff8_externals.worldmap_sub_545E20, 0x68);
 		ff8_externals.worldmap_sub_5531F0 = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x614);
 		ff8_externals.open_file_world = (int32_t(*)(const char*, int32_t, uint32_t, void *))get_relative_call(ff8_externals.worldmap_sub_5531F0, 0x395);
 		ff8_externals.open_file_world_sub_52D670_texl_call1 = ff8_externals.worldmap_sub_5531F0 + 0x395;
@@ -572,6 +576,8 @@ void ff8_find_externals()
 		ff8_externals.worldmap_sub_53F310_call_366 = ff8_externals.worldmap_sub_53F310 + 0x382;
 		ff8_externals.worldmap_sub_53F310_loc_53F7EE = ff8_externals.worldmap_sub_53F310 + 0x507;
 		ff8_externals.worldmap_sub_541970_upload_tim = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x34C);
+		ff8_externals.worldmap_sub_545E20 = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x635);
+		ff8_externals.worldmap_chara_one = get_relative_call(ff8_externals.worldmap_sub_545E20, 0x6B);
 		ff8_externals.worldmap_sub_5531F0 = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x63D);
 		ff8_externals.open_file_world = (int32_t(*)(const char*, int32_t, uint32_t, void *))get_relative_call(ff8_externals.worldmap_sub_5531F0, 0x38F);
 		ff8_externals.open_file_world_sub_52D670_texl_call1 = ff8_externals.worldmap_sub_5531F0 + 0x38F;


### PR DESCRIPTION
## Summary

Add worldmap texture replacement for Squall, Zell, Selphie (?), Ragnarok and Chocobo

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
