### PR TITLE
FF7: Fix a softlock when trying to change in-game Controller setting to "Normal"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,10 @@
 - Widescreen: Fix Pandora Box white background position
 - Voice: Fix auto-text sometimes not working on certain fields after long gameplay sessions
 
+## FF7 Steam
+
+- Common: Fix a softlock when trying to change in-game Controller setting to "Normal" (by disabling this option)
+
 ## FF8
 
 - Hext: `fix_uv_coords` hext files are not needed anymore ( https://github.com/julianxhokaxhiu/FFNx/pull/619 )
@@ -44,10 +48,6 @@
 - Voice: Enable battle dialogs voice acting
 - Voice: Enable worldmap voice acting
 - Voice: Enable tutorial voice acting
-
-## FF7 Steam
-
-- Common: Fix a softlock when trying to change in-game Controller setting to "Normal" (by disabling this option)
 
 # 1.16.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 
 - 60FPS: Refactor 60FPS battle menu fix and fix ESUI compatibility ( https://github.com/julianxhokaxhiu/FFNx/pull/597 )
 - Ambient: Allow ambient effects to playback in fields that use movies as background
+- Common: Fix a softlock when trying to change in-game Controller setting to "Normal" (by disabling this option)
 - Core: Add additional main models eye-to-model mapping
 - DevTools: Add Game Moment in Field Debug
 - Lighting: Fix [`config.toml`](https://github.com/julianxhokaxhiu/FFNx/blob/master/misc/FFNx.lighting.toml) load/save logic

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
 - Lighting: Fixed minor shadow visual glitches occurring in some fields
 - Music: Fix overlapping external music tracks when `external_music_resume = false`
 - Renderer: Fix black color in some field maps (`spipe2` for example) ( https://github.com/julianxhokaxhiu/FFNx/pull/587 )
+- Sound: Fix loading music volume value from ff7sound.cfg
 - Voice: Enable tutorial voice acting
 - Widescreen: Added experimental support for 16:10 aspect ratio
 - Widescreen: Fix Pollensalta attack (only when also using 30/60FPS mode since it is a temporary fix) and Bahamut Zero summon background

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,6 @@
 
 - 60FPS: Refactor 60FPS battle menu fix and fix ESUI compatibility ( https://github.com/julianxhokaxhiu/FFNx/pull/597 )
 - Ambient: Allow ambient effects to playback in fields that use movies as background
-- Common: Fix a softlock when trying to change in-game Controller setting to "Normal" (by disabling this option)
 - Core: Add additional main models eye-to-model mapping
 - DevTools: Add Game Moment in Field Debug
 - Lighting: Fix [`config.toml`](https://github.com/julianxhokaxhiu/FFNx/blob/master/misc/FFNx.lighting.toml) load/save logic
@@ -45,6 +44,10 @@
 - Voice: Enable battle dialogs voice acting
 - Voice: Enable worldmap voice acting
 - Voice: Enable tutorial voice acting
+
+## FF7 Steam
+
+- Common: Fix a softlock when trying to change in-game Controller setting to "Normal" (by disabling this option)
 
 # 1.16.0
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2825,7 +2825,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 					if (ff7sound)
 					{
 						if (external_sfx_volume > -1) fread(&external_sfx_volume, sizeof(DWORD), 1, ff7sound);
-						if (external_sfx_volume > -1) fread(&external_music_volume, sizeof(DWORD), 1, ff7sound);
+						if (external_music_volume > -1) fread(&external_music_volume, sizeof(DWORD), 1, ff7sound);
 						fclose(ff7sound);
 					}
 				}

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2793,7 +2793,7 @@ struct ff7_externals
 	uint32_t field_map_infos;
 	uint32_t sound_operation;
 	struct ff7_field_sfx_state* sound_states;
-	uint32_t menu_sound_slider_loop;
+	uint32_t config_menu_sub;
 	uint32_t call_menu_sound_slider_loop_sfx_up;
 	uint32_t call_menu_sound_slider_loop_sfx_down;
 	uint32_t menu_start;

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -285,7 +285,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.menu_tutorial_sub_6C49FD = (int (*)())get_relative_call(ff7_externals.menu_sub_6CB56A, 0x2B7);
 	ff7_externals.timer_menu_sub = ff7_externals.menu_subs_call_table[0];
 	ff7_externals.status_menu_sub = ff7_externals.menu_subs_call_table[5];
-	ff7_externals.menu_sound_slider_loop = ff7_externals.menu_subs_call_table[8];
+	ff7_externals.config_menu_sub = ff7_externals.menu_subs_call_table[8];
 	ff7_externals.menu_sub_6FEDB0 = ff7_externals.menu_subs_call_table[10];
 
 	ff7_externals.menu_tutorial_window_state = (BYTE*)get_absolute_value((uint32_t)ff7_externals.menu_tutorial_sub_6C49FD, 0x9);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -84,9 +84,6 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	// Allow mouse cursor to be shown
 	replace_function(ff7_externals.dinput_createdevice_mouse, noop);
 
-  // Disable "Normal" setting in Controller section of the Config menu (it softlocks on Steam)
-  memset_code(ff7_externals.config_menu_sub + 0x8AC, 0x90, 0xE6);
-
 	// TODO: Comment this if Chocobo's not visible in race
 	// replace_function(ff7_externals.draw_3d_model, draw_3d_model);
 
@@ -368,9 +365,9 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		memset_code(ff7_externals.field_apply_kawai_op_64A070 + 0x23C, 0x90, 5);
 	}
 
-	//#############################
-	// steam save game preservation
-	//#############################
+	//#############################################
+	// steam save game preservation and other fixes
+	//#############################################
 	if (steam_edition)
 	{
 		switch(version)
@@ -386,6 +383,9 @@ void ff7_init_hooks(struct game_obj *_game_object)
 				replace_call_function(ff7_externals.menu_sub_6FEDB0 + 0x10FE, ff7_write_save_file);
 				break;
 		}
+
+		// Disable "Normal" setting in Controller section of the Config menu (it softlocks on Steam)
+		memset_code(ff7_externals.config_menu_sub + 0x8AC, 0x90, 0xE6);    
 	}
 
 	//###############################

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -84,6 +84,9 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	// Allow mouse cursor to be shown
 	replace_function(ff7_externals.dinput_createdevice_mouse, noop);
 
+  // Disable "Normal" setting in Controller section of the Config menu (it softlocks on Steam)
+  memset_code(ff7_externals.config_menu_sub + 0x8AC, 0x90, 0xE6);
+
 	// TODO: Comment this if Chocobo's not visible in race
 	// replace_function(ff7_externals.draw_3d_model, draw_3d_model);
 

--- a/src/sfx.cpp
+++ b/src/sfx.cpp
@@ -551,7 +551,7 @@ void sfx_update_volume(int modifier)
 	if (trace_all || trace_sfx) ffnx_info("%s: Update SFX volumes %d\n", __func__, modifier);
 
 	// Set master sfx volume
-	BYTE** sfx_tmp_volume = (BYTE**)(ff7_externals.menu_sound_slider_loop + ff7_externals.call_menu_sound_slider_loop_sfx_down + 0xA);
+	BYTE** sfx_tmp_volume = (BYTE**)(ff7_externals.config_menu_sub + ff7_externals.call_menu_sound_slider_loop_sfx_down + 0xA);
 
 	*common_externals.master_sfx_volume = **sfx_tmp_volume + modifier;
 
@@ -749,8 +749,8 @@ void sfx_init()
 		// On volume change in main menu initialization
 		replace_call(ff7_externals.menu_start + 0x17, sfx_menu_force_channel_5_volume);
 		// On SFX volume change in config menu
-		replace_call(ff7_externals.menu_sound_slider_loop + ff7_externals.call_menu_sound_slider_loop_sfx_down, sfx_menu_play_sound_down);
-		replace_call(ff7_externals.menu_sound_slider_loop + ff7_externals.call_menu_sound_slider_loop_sfx_up, sfx_menu_play_sound_up);
+		replace_call(ff7_externals.config_menu_sub + ff7_externals.call_menu_sound_slider_loop_sfx_down, sfx_menu_play_sound_down);
+		replace_call(ff7_externals.config_menu_sub + ff7_externals.call_menu_sound_slider_loop_sfx_up, sfx_menu_play_sound_up);
 		// Fix escape sound not played more than once
 		replace_function(ff7_externals.battle_clear_sound_flags, sfx_clear_sound_locks);
 		// On stop sound in battle swirl


### PR DESCRIPTION
## Summary

Fixes issue #623 by disabling the ability to change the Controller setting to "Normal". This is what Aali driver originally did and this change apparently wasn't ported to FFNx. 

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
