### PR TITLE
FF7: Fix character naming screen not working correctly when Steam Input is enabled

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
 - Lighting: Fixed minor shadow visual glitches occurring in some fields
 - Music: Fix overlapping external music tracks when `external_music_resume = false`
 - Renderer: Fix black color in some field maps (`spipe2` for example) ( https://github.com/julianxhokaxhiu/FFNx/pull/587 )
+- Sound: Fix loading music volume value from ff7sound.cfg
 - Voice: Enable tutorial voice acting
 - Widescreen: Added experimental support for 16:10 aspect ratio
 - Widescreen: Fix Pollensalta attack (only when also using 30/60FPS mode since it is a temporary fix) and Bahamut Zero summon background

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 - Ambient: Allow ambient effects to playback in fields that use movies as background
 - Core: Add additional main models eye-to-model mapping
 - DevTools: Add Game Moment in Field Debug
+- Input: Fix character naming screen not working correctly when Steam Input is enabled
 - Lighting: Fix [`config.toml`](https://github.com/julianxhokaxhiu/FFNx/blob/master/misc/FFNx.lighting.toml) load/save logic
 - Lighting: Fix Bahamut Zero and Supernova not displaying correctly when lighting enabled
 - Lighting: Fix field shadows not displaying during FMV movies

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,6 @@
 - Ambient: Allow ambient effects to playback in fields that use movies as background
 - Core: Add additional main models eye-to-model mapping
 - DevTools: Add Game Moment in Field Debug
-- Input: Fix character naming screen not working correctly when Steam Input is enabled
 - Lighting: Fix [`config.toml`](https://github.com/julianxhokaxhiu/FFNx/blob/master/misc/FFNx.lighting.toml) load/save logic
 - Lighting: Fix Bahamut Zero and Supernova not displaying correctly when lighting enabled
 - Lighting: Fix field shadows not displaying during FMV movies
@@ -32,6 +31,7 @@
 ## FF7 Steam
 
 - Common: Fix a softlock when trying to change in-game Controller setting to "Normal" (by disabling this option)
+- Input: Fix character naming screen not working correctly when Steam Input is enabled
 
 ## FF8
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2825,7 +2825,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 					if (ff7sound)
 					{
 						if (external_sfx_volume > -1) fread(&external_sfx_volume, sizeof(DWORD), 1, ff7sound);
-						if (external_sfx_volume > -1) fread(&external_music_volume, sizeof(DWORD), 1, ff7sound);
+						if (external_music_volume > -1) fread(&external_music_volume, sizeof(DWORD), 1, ff7sound);
 						fclose(ff7sound);
 					}
 				}

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -77,12 +77,6 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	// Load Models atoi function
 	replace_call_function(ff7_externals.field_load_models_atoi, ff7_field_load_models_atoi);
 
-  // Restore Steam release behavior on character name screen when using gamepads in Steam Input mode
-  // Aali driver used to patch out these three functions to fix this issue
-  replace_function(ff7_externals.set_default_input_settings_save, noop);
-  replace_function(ff7_externals.keyboard_name_input, noop);
-  replace_function(ff7_externals.restore_input_settings, noop);
-
 	// DirectInput hack, try to reacquire on any error
 	memset_code(ff7_externals.dinput_getdata2 + 0x65, 0x90, 9);
 	memset_code((uint32_t)common_externals.dinput_acquire_keyboard + 0x31, 0x90, 5);
@@ -391,7 +385,13 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		}
 
 		// Disable "Normal" setting in Controller section of the Config menu (it softlocks on Steam)
-		memset_code(ff7_externals.config_menu_sub + 0x8AC, 0x90, 0xE6);    
+		memset_code(ff7_externals.config_menu_sub + 0x8AC, 0x90, 0xE6);
+
+		// Restore Steam release behavior on character name screen when using gamepads in Steam Input mode
+		// Aali driver used to patch out these three functions to fix this issue
+		replace_function(ff7_externals.set_default_input_settings_save, noop);
+		replace_function(ff7_externals.keyboard_name_input, noop);
+		replace_function(ff7_externals.restore_input_settings, noop);
 	}
 
 	//###############################

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -77,6 +77,12 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	// Load Models atoi function
 	replace_call_function(ff7_externals.field_load_models_atoi, ff7_field_load_models_atoi);
 
+  // Restore Steam release behavior on character name screen when using gamepads in Steam Input mode
+  // Aali driver used to patch out these three functions to fix this issue
+  replace_function(ff7_externals.set_default_input_settings_save, noop);
+  replace_function(ff7_externals.keyboard_name_input, noop);
+  replace_function(ff7_externals.restore_input_settings, noop);
+
 	// DirectInput hack, try to reacquire on any error
 	memset_code(ff7_externals.dinput_getdata2 + 0x65, 0x90, 9);
 	memset_code((uint32_t)common_externals.dinput_acquire_keyboard + 0x31, 0x90, 5);


### PR DESCRIPTION
## Summary

Fixes issue #622 by patching out functions that enable direct keyboard input on character naming screens. This is what Aali driver originally did and this change apparently wasn't ported to FFNx. See linked issue for more details.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
