### PR TITLE
FF8: Enable 360 analog input

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,8 @@
 ## FF8
 
 - Hext: `fix_uv_coords` hext files are not needed anymore ( https://github.com/julianxhokaxhiu/FFNx/pull/619 )
+- Input: Enable support for 360° analog movement ( https://github.com/julianxhokaxhiu/FFNx/pull/632 )
+- Input: Enable support dual-stick vehicle control ( https://github.com/julianxhokaxhiu/FFNx/pull/632 )
 - Graphics: Fix blue color on some attacks in battle ( https://github.com/julianxhokaxhiu/FFNx/pull/619 )
 - Graphics: Fix crash when using external texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/588 )
 - Graphics: Fix texture glitches using external texture replacement ( https://github.com/julianxhokaxhiu/FFNx/pull/591 )

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -365,42 +365,42 @@ external_movie_audio_ext = "ogg"
 ###########################
 
 #[ANALOGUE CONTROLS]
-# This flag will enable analogue joystick input for controlling the player in fields and the camera in battles.
+# FF7: This flag will enable analogue joystick input for controlling the player in fields and the camera in battles.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 enable_analogue_controls = false
 
 #[INVERT VERTICAL CAMERA CONTROLS]
-# This flag will enable inverted camera vertical movement when controlling the camera in battles.
+# FF7: This flag will enable inverted camera vertical movement when controlling the camera in battles.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 enable_inverted_vertical_camera_controls = false
 
 #[INVERT HORIZONTAL CAMERA CONTROLS]
-# This flag will enable inverted camera horizontal movement when controlling the camera in battles.
+# FF7: This flag will enable inverted camera horizontal movement when controlling the camera in battles.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 enable_inverted_horizontal_camera_controls = false
 
 #[LEFT ANALOG STICK DEADZONE]
-# Sets the deadzone for the left analog stick. Values are from 0 to 1.
+# FF7: Sets the deadzone for the left analog stick. Values are from 0 to 1.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 left_analog_stick_deadzone = 0.1
 
 #[RIGHT ANALOG STICK DEADZONE]
-# Sets the deadzone for the right analog stick. Values are from 0 to 1.
+# FF7: Sets the deadzone for the right analog stick. Values are from 0 to 1.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 right_analog_stick_deadzone = 0.1
 
 #[LEFT ANALOG TRIGGER DEADZONE]
-# Sets the deadzone for the left analog trigger. Values are from 0 to 1.
+# FF7: Sets the deadzone for the left analog trigger. Values are from 0 to 1.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 left_analog_trigger_deadzone = 0.1
 
 #[RIGHT ANALOG TRIGGER DEADZONE]
-# Sets the deadzone for the right analog trigger. Values are from 0 to 1.
+# FF7: Sets the deadzone for the right analog trigger. Values are from 0 to 1.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 right_analog_trigger_deadzone = 0.1
 
 #[AUTO RUN]
-# This flag enables mode to walk or run depending on how much the left analog stick is tilt.
+# FF7: This flag enables mode to walk or run depending on how much the left analog stick is tilt.
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 enable_auto_run = false
 

--- a/src/common.h
+++ b/src/common.h
@@ -88,6 +88,7 @@ enum game_modes
 	MODE_CARDGAME,
 	MODE_UNKNOWN,
 	MODE_AFTER_BATTLE,
+	MODE_MAIN_MENU,
 };
 
 enum AspectRatioMode

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -36,12 +36,13 @@ enum ff8_game_modes
 	FF8_MODE_5,
 	FF8_MODE_MENU,
 	FF8_MODE_7,
-	FF8_MODE_CARDGAME,
+	FF8_MODE_CARDGAME, // And battle
 	FF8_MODE_9,
 	FF8_MODE_TUTO,
 	FF8_MODE_11,
 	FF8_MODE_INTRO,
 	FF8_MODE_100 = 100,
+	FF8_MODE_MAIN_MENU = 200,
 	FF8_MODE_BATTLE = 999
 };
 
@@ -565,16 +566,19 @@ struct ff8_win_obj
 };
 
 struct ff8_gamepad_vibration_state_entry {
-	int16_t field_0;
+	uint8_t analog_disabled;
+	uint8_t analog_flags;
 	int16_t keyscan;
-	int16_t field_4;
-	int16_t field_6;
+	uint8_t analog_rx;
+	uint8_t analog_ry;
+	uint8_t analog_lx;
+	uint8_t analog_ly;
 	int16_t field_8;
 	int16_t field_A;
 	int16_t field_C;
 	int16_t field_E;
 	int16_t keyon;
-	int16_t field_12;
+	int16_t keyscan_invert;
 };
 
 struct ff8_gamepad_vibration_state {
@@ -599,8 +603,21 @@ struct ff8_gamepad_vibration_state {
 	ff8_gamepad_vibration_state_entry entries[8];
 	uint32_t field_BC;
 	uint16_t field_C0;
-	uint8_t sound_volume; // Analog level in PSX version
-	uint8_t gamepad_options; // is_enabled | u40 | u20 | u10 | u8 | u4 | u2 | u1
+	uint8_t port_id;
+	uint8_t gamepad_options; // is_enabled (1-bit) | u40 | u20 | u10 | u8 | analog sensitivity (1 to 4, 3-bits)
+};
+
+struct ff8_driver_input_state {
+	ff8_gamepad_vibration_state_entry entry;
+	uint32_t field_14;
+	uint32_t field_18;
+	uint32_t field_1C;
+	uint32_t field_20;
+};
+
+struct ff8_gamepad_state {
+	ff8_gamepad_vibration_state state_by_port[2];
+	ff8_driver_input_state driver_state_by_port[2];
 };
 
 struct ff8_vibrate_motor_struc
@@ -1014,10 +1031,10 @@ struct ff8_externals
 	uint32_t pubintro_exit;
 	uint32_t pubintro_main_loop;
 	uint32_t credits_main_loop;
+	uint32_t go_to_main_menu_main_loop;
+	uint32_t main_menu_main_loop;
 	DWORD* credits_loop_state;
 	DWORD* credits_counter;
-	uint32_t sub_470520;
-	uint32_t sub_4A24B0;
 	uint32_t sub_470630;
 	uint32_t dd_d3d_start;
 	uint32_t create_d3d_gfx_driver;
@@ -1150,7 +1167,7 @@ struct ff8_externals
 	uint32_t sub_54E9B0;
 	uint32_t sub_550070;
 	int (*sub_541C80)(int);
-	uint32_t sub_559240;
+	uint32_t worldmap_input_update_sub_559240;
 	uint32_t sub_554940;
 	uint32_t sub_554940_call_130;
 	uint32_t sub_541AE0;
@@ -1276,7 +1293,7 @@ struct ff8_externals
 	uint32_t vibration_apply;
 	int(*get_keyon)(int, int);
 	uint32_t set_vibration;
-	ff8_gamepad_vibration_state *gamepad_vibration_states;
+	ff8_gamepad_state *gamepad_states;
 	ff8_vibrate_struc *vibration_objects;
 	uint32_t vibration_clear_intensity;
 	uint8_t *vibrate_data_world;

--- a/src/ff8/battle/stage.cpp
+++ b/src/ff8/battle/stage.cpp
@@ -27,7 +27,7 @@
 #include "../../log.h"
 
 #include <set>
-#include <unordered_set>
+#include <unordered_map>
 
 const uint8_t *ff8_battle_stage_search_model(const uint8_t *stage_data, size_t stage_data_size, std::list<uint32_t> &model_offsets)
 {

--- a/src/ff8/field/background.cpp
+++ b/src/ff8/field/background.cpp
@@ -26,6 +26,8 @@
 #include "../../saveload.h"
 #include "../../log.h"
 
+#include <unordered_map>
+
 bool ff8_background_tiles_looks_alike(const Tile &tile, const Tile &other)
 {
 	return tile.texID == other.texID

--- a/src/ff8/vibration.cpp
+++ b/src/ff8/vibration.cpp
@@ -64,9 +64,9 @@ void vibrate(int left, int right)
 {
 	const int port = 0;
 
-	if (trace_all || trace_gamepad) ffnx_trace("%s left=%d right=%d vibrate_option_enabled=%d\n", __func__, left, right, ff8_externals.gamepad_vibration_states[port].vibrate_option_enabled);
+	if (trace_all || trace_gamepad) ffnx_trace("%s left=%d right=%d vibrate_option_enabled=%d\n", __func__, left, right, ff8_externals.gamepad_states->state_by_port[port].vibrate_option_enabled);
 
-	if (ff8_externals.gamepad_vibration_states[port].vibrate_option_enabled == 255)
+	if (ff8_externals.gamepad_states->state_by_port[port].vibrate_option_enabled == 255)
 	{
 		nxVibrationEngine.setLeftMotorValue(left);
 		nxVibrationEngine.setRightMotorValue(right);
@@ -76,7 +76,7 @@ void vibrate(int left, int right)
 
 void apply_vibrate_calc(char port, int left, int right)
 {
-	ff8_gamepad_vibration_state *gamepad_state = ff8_externals.gamepad_vibration_states;
+	ff8_gamepad_vibration_state *gamepad_state = ff8_externals.gamepad_states->state_by_port;
 	if (left < 0) left = 0;
 	if (right < 0) right = 0;
 

--- a/src/ff8/world/wmset.cpp
+++ b/src/ff8/world/wmset.cpp
@@ -139,8 +139,6 @@ std::unordered_map<uint32_t, WmsetSection41Texture> ff8_world_wmset_palette_anim
 			texture.palettePositions.push_back((const uint16_t *)(wmset_section41_data + pos + 12 + toc[j] + 20));
 		}
 
-		ffnx_info("%s: height=%d src=(%d, %d) pos=(%d, %d)\n", __func__, texture.height, texture.srcX, texture.srcY, texture.x, texture.y);
-
 		textures[uint32_t(texture.srcX) | (uint32_t(texture.srcY) << 16)] = texture;
 	}
 

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -70,8 +70,11 @@ void ff8_find_externals()
 	ff8_externals.pubintro_exit = get_absolute_value(ff8_externals.main_entry, 0x176);
 	ff8_externals.pubintro_main_loop = get_absolute_value(ff8_externals.main_entry, 0x180);
 	ff8_externals.credits_main_loop = get_absolute_value(ff8_externals.pubintro_main_loop, 0x6D);
+	ff8_externals.go_to_main_menu_main_loop = get_absolute_value(ff8_externals.credits_main_loop, 0xE2);
+	ff8_externals.main_menu_main_loop = get_absolute_value(ff8_externals.go_to_main_menu_main_loop, 0x2B);
 
 	ff8_set_main_loop(MODE_CREDITS, ff8_externals.credits_main_loop);
+	ff8_set_main_loop(MODE_MAIN_MENU, ff8_externals.main_menu_main_loop);
 
 	ff8_externals.config_worldmap_fog_disabled = (uint8_t *)get_absolute_value(ff8_externals.main_entry, 0x1C1);
 	ff8_externals.config_worldmap_color_anim_disabled = (uint8_t *)get_absolute_value(ff8_externals.main_entry, 0x1C7);
@@ -84,9 +87,7 @@ void ff8_find_externals()
 	ff8_externals.input_get_keyscan = (int(*)(int,int))get_relative_call(ff8_externals.sub_52FE80, 0xD1);
 	ff8_externals.credits_loop_state = (DWORD*)get_absolute_value(ff8_externals.load_credits_image, 0x7);
 	ff8_externals.credits_counter = (DWORD *)get_absolute_value(ff8_externals.load_credits_image, 0x59);
-	ff8_externals.sub_470520 = get_absolute_value(ff8_externals.credits_main_loop, 0xE2);
-	ff8_externals.sub_4A24B0 = get_absolute_value(ff8_externals.sub_470520, 0x2B);
-	ff8_externals.sub_470630 = get_absolute_value(ff8_externals.sub_4A24B0, 0xE4);
+	ff8_externals.sub_470630 = get_absolute_value(ff8_externals.main_menu_main_loop, 0xE4);
 	ff8_externals.main_loop = get_absolute_value(ff8_externals.sub_470630, 0x24);
 
 	ff8_externals.reg_get_data_drive = (uint32_t(*)(char*, DWORD))get_relative_call(ff8_externals.init_config, 0x21);
@@ -222,7 +223,7 @@ void ff8_find_externals()
 	ff8_externals.get_vibration_capability = get_relative_call(uint32_t(ff8_externals.pause_menu_with_vibration), 0xE3);
 	ff8_externals.vibrate_data_main = (uint8_t **)get_absolute_value(uint32_t(ff8_externals.pause_menu_with_vibration), 0x261);
 	ff8_externals.set_vibration = get_relative_call(uint32_t(ff8_externals.pause_menu_with_vibration), 0x26A);
-	ff8_externals.gamepad_vibration_states = (ff8_gamepad_vibration_state *)(get_absolute_value(ff8_externals.get_vibration_capability, 0xE + 3) - 0xB);
+	ff8_externals.gamepad_states = (ff8_gamepad_state *)(get_absolute_value(ff8_externals.get_vibration_capability, 0xE + 3) - 0xB);
 	ff8_externals.vibration_objects = (ff8_vibrate_struc *)get_absolute_value(ff8_externals.set_vibration, 0x2 + 1);
 	ff8_externals.vibration_clear_intensity = get_relative_call(ff8_externals.sub_471F70, 0x276);
 	ff8_externals.open_battle_vibrate_vib = get_relative_call(ff8_externals.pubintro_exit, 0x18);
@@ -359,7 +360,7 @@ void ff8_find_externals()
 
 	ff8_externals.menu_viewport = (sprite_viewport *)(get_absolute_value(ff8_externals.sub_4972A0, 0x12) - 0x20);
 
-	ff8_externals.sub_497380 = get_relative_call(ff8_externals.sub_4A24B0, 0xAA);
+	ff8_externals.sub_497380 = get_relative_call(ff8_externals.main_menu_main_loop, 0xAA);
 	ff8_externals.sub_4B3410 = get_relative_call(ff8_externals.sub_497380, 0xAC);
 	ff8_externals.sub_4BE4D0 = get_relative_call(ff8_externals.sub_4B3410, 0x68);
 	ff8_externals.sub_4BECC0 = get_relative_call(ff8_externals.sub_4BE4D0, 0x39);
@@ -547,11 +548,11 @@ void ff8_find_externals()
 		ff8_externals.show_vram_window = (void (*)())get_relative_call(ff8_externals.worldmap_main_loop, 0xA0);
 		ff8_externals.refresh_vram_window = (void (*)())get_relative_call(ff8_externals.worldmap_main_loop, 0xA5);
 		ff8_externals.worldmap_with_fog_sub_53FAC0 = get_relative_call(ff8_externals.worldmap_main_loop, 0x134);
-		ff8_externals.sub_559240 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x1E);
-		ff8_externals.sub_554940 = get_relative_call(ff8_externals.sub_559240, 0x23D);
+		ff8_externals.worldmap_input_update_sub_559240 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x1E);
+		ff8_externals.sub_554940 = get_relative_call(ff8_externals.worldmap_input_update_sub_559240, 0x23D);
 		ff8_externals.sub_554940_call_130 = ff8_externals.sub_554940 + 0x130;
 		ff8_externals.sub_541AE0 = get_relative_call(ff8_externals.sub_554940, 0x130);
-		ff8_externals.sub_554BC0 = get_relative_call(ff8_externals.sub_559240, 0x25B);
+		ff8_externals.sub_554BC0 = get_relative_call(ff8_externals.worldmap_input_update_sub_559240, 0x25B);
 		ff8_externals.sub_54B460 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x5D7);
 
 		ff8_externals.sub_549E80 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x1D5);
@@ -619,11 +620,11 @@ void ff8_find_externals()
 		ff8_externals.show_vram_window = (void (*)())get_relative_call(ff8_externals.worldmap_main_loop, 0xA3);
 		ff8_externals.refresh_vram_window = (void (*)())get_relative_call(ff8_externals.worldmap_main_loop, 0xA8);
 		ff8_externals.worldmap_with_fog_sub_53FAC0 = get_relative_call(ff8_externals.worldmap_main_loop, 0x137);
-		ff8_externals.sub_559240 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x1C);
-		ff8_externals.sub_554940 = get_relative_call(ff8_externals.sub_559240, 0x23A);
+		ff8_externals.worldmap_input_update_sub_559240 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x1C);
+		ff8_externals.sub_554940 = get_relative_call(ff8_externals.worldmap_input_update_sub_559240, 0x23A);
 		ff8_externals.sub_554940_call_130 = ff8_externals.sub_554940 + 0x13C;
 		ff8_externals.sub_541AE0 = get_relative_call(ff8_externals.sub_554940, 0x13C);
-		ff8_externals.sub_554BC0 = get_relative_call(ff8_externals.sub_559240, 0x258);
+		ff8_externals.sub_554BC0 = get_relative_call(ff8_externals.worldmap_input_update_sub_559240, 0x258);
 		ff8_externals.sub_54B460 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x5D9);
 
 		ff8_externals.sub_549E80 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x1D6);

--- a/src/ff8_data.h
+++ b/src/ff8_data.h
@@ -40,7 +40,8 @@ static struct game_mode ff8_modes[] = {
 	{FF8_MODE_11,            "MODE_11",            MODE_UNKNOWN,       true },
 	{FF8_MODE_INTRO,         "MODE_INTRO",         MODE_INTRO,         true },
 	{FF8_MODE_100,           "MODE_100",           MODE_UNKNOWN,       true },
-	{FF8_MODE_BATTLE,        "MODE_BATTLE",        MODE_BATTLE,        true },
+	{FF8_MODE_MAIN_MENU,     "MODE_MAIN_MENU",     MODE_MAIN_MENU,     true },
+	{FF8_MODE_BATTLE,        "MODE_BATTLE",        MODE_BATTLE,        true }
 };
 
 void ff8_set_main_loop(uint32_t driver_mode, uint32_t main_loop);


### PR DESCRIPTION
## Summary

Send analog input to the core game. Per module, not globally, because analog already works well as a d-pad.

- Field module: send analog values for characters movements (it automatically overrides d-pad input sent by the driver)
- World module: send analog values for everything (left and right sticks), but override d-pad input only for characters movements

### Motivation

PlayStation version always supported analog input for character movements, not only 8 directions, but a range of 255*255 values.
The game also implements an auto walk/run feature depending of the strength of the analog input.
Finally in worldmap, vehicles can be driven using the right stick along with the left stick.

https://finalfantasy.fandom.com/wiki/Final_Fantasy_VIII_version_differences#Microsoft_Windows

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
