### PR TITLE
FF8: Fix Quezacotl SFX

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -54,6 +54,7 @@
 - Voice: Enable battle dialogs voice acting
 - Voice: Enable worldmap voice acting
 - Voice: Enable tutorial voice acting
+- SFX: Fix Quezacotl sounds ( https://github.com/julianxhokaxhiu/FFNx/pull/633 )
 
 # 1.16.0
 

--- a/README.md
+++ b/README.md
@@ -82,13 +82,14 @@ We are always open for contributions via PRs, and in case you want to join the c
 
 #### FF8
 - Vibration support
+- Analog controls improved support
 - **Voice acting**! [Echo-S](https://www.tsunamods.com/echo-s-8/) was the first mod to take advantage of this!
 - Various graphical patches for worldmap included
 - Enable the VRAM debug window while playing in order to see how the engine uploads textures
 - Support for external SFX audio effects
 - Support for external movie audio files (allows multiple videos to share the same audio)
 - Support for external movie voice acting (dedicated audio layer only for voice acting on top of movies)
-- Support for external music audio
+- Support for external music audio with music resume after battle and improved volume transitions
 
 ### As a modder
 
@@ -276,7 +277,7 @@ These people are:
 - [LaZar00](https://github.com/LaZar00)
   - for the Snowboard TMD structures
 - [ChthonVII](https://github.com/ChthonVII)
-  - for the R&D needed to match modern display gamuts to the original PSX release 
+  - for the R&D needed to match modern display gamuts to the original PSX release
 
 I'm sure I forgot many others. In case you feel you're missing here, feel free to open a PR! I'll be happy to include you because you deserve this.
 

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1369,6 +1369,15 @@ struct ff8_externals
 	char* unk_1CF3E48;
 	DWORD* dword_1CF3EE0;
 	DWORD* battle_current_actor_talking;
+	uint32_t sub_502380;
+	uint32_t sub_50A790;
+	uint32_t sub_50A9A0;
+	uint32_t battle_read_effect_sub_50AF20;
+	DWORD* func_off_battle_effects_C81774;
+	uint32_t battle_effect_quezacotl_sub_6C3550;
+	uint32_t sub_6C3640;
+	uint32_t sub_6C3760;
+	uint8_t **vibrate_data_summon_quezacotl;
 };
 
 void ff8gl_field_78(struct ff8_polygon_set *polygon_set, struct ff8_game_obj *game_object);

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -717,6 +717,17 @@ void ff8_find_externals()
 
 	ff8_externals.battle_current_actor_talking = (DWORD*)get_absolute_value(ff8_externals.sub_485610, 0x36E);
 
+	ff8_externals.sub_502380 = get_relative_call(ff8_externals.sub_500CC0, 0x69);
+	ff8_externals.sub_50A790 = get_relative_call(ff8_externals.sub_502380, 0x51);
+	ff8_externals.sub_50A9A0 = get_absolute_value(ff8_externals.sub_50A790, 0x7C);
+	ff8_externals.battle_read_effect_sub_50AF20 = get_relative_call(ff8_externals.sub_50A9A0, 0xF4);
+	ff8_externals.func_off_battle_effects_C81774 = (DWORD*)get_absolute_value(ff8_externals.battle_read_effect_sub_50AF20, 0x2C);
+
+	ff8_externals.battle_effect_quezacotl_sub_6C3550 = ff8_externals.func_off_battle_effects_C81774[115];
+	ff8_externals.sub_6C3640 = get_relative_call(ff8_externals.battle_effect_quezacotl_sub_6C3550, 0x5);
+	ff8_externals.sub_6C3760 = get_absolute_value(ff8_externals.sub_6C3640, 0x8B);
+	ff8_externals.vibrate_data_summon_quezacotl = (uint8_t **)get_absolute_value(ff8_externals.sub_6C3760, 0xB0);
+
 	// Required by Steam edition
 	switch (version)
 	{

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -809,6 +809,12 @@ void ff8_init_hooks(struct game_obj *_game_object)
 		replace_call(ff8_externals.get_disk_number + 0x6E, ff8_retry_configured_drive);
 		replace_call(ff8_externals.cdcheck_sub_52F9E0 + 0x15E, ff8_retry_configured_drive);
 	}
+
+	// Force SFX IDs for Quezacotl
+	patch_code_dword(int(ff8_externals.vibrate_data_summon_quezacotl) - 16, 240030); // 240030 - 240000 + 370 = ID 400
+	patch_code_dword(int(ff8_externals.vibrate_data_summon_quezacotl) - 12, 240033); // 240033 - 240000 + 370 = ID 403
+	patch_code_dword(int(ff8_externals.vibrate_data_summon_quezacotl) - 8, 240036); // 240036 - 240000 + 370 = ID 406
+	patch_code_dword(int(ff8_externals.vibrate_data_summon_quezacotl) - 4, 240039); // 240039 - 240000 + 370 = ID 409
 }
 
 struct ff8_gfx_driver *ff8_load_driver(void* _game_object)


### PR DESCRIPTION
## Summary

In PC version (original and Steam), the SFX ids for Quezacotl are thoses used for Phoenix.
This patch fixes this

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
