### PR TITLE
FF8: Fix intro credits unsync

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -51,6 +51,7 @@
 - Graphics: Minimize texture uploads when the palette is not set yet ( https://github.com/julianxhokaxhiu/FFNx/pull/617 https://github.com/julianxhokaxhiu/FFNx/pull/628 )
 - Graphics: Increase max texture size to 16384 for external textures ( https://github.com/julianxhokaxhiu/FFNx/pull/601 )
 - Music: Add `ff8_external_music_force_original_filenames` option to use original music names (eg 018s-julia.ogg) instead of just the main identifier in external music ( https://github.com/julianxhokaxhiu/FFNx/pull/594 )
+- Music: Fix intro credits unsync ( https://github.com/julianxhokaxhiu/FFNx/pull/634 )
 - Voice: Enable battle dialogs voice acting
 - Voice: Enable worldmap voice acting
 - Voice: Enable tutorial voice acting

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -91,3 +91,10 @@ This cheat will allow you to toggle the voice auto text feature while playing th
 Shortcuts:
 
 - Keyboard Shortcut: `CTRL + T`
+
+### Quit Game ( FF8 only! )
+
+Shortcuts:
+
+- Keyboard Shortcut: `CTRL + Q` (For Qwerty keyboards)
+- Keyboard Shortcut: `CTRL + A` (For Azerty keyboards)

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1035,6 +1035,8 @@ struct ff8_externals
 	uint32_t main_menu_main_loop;
 	DWORD* credits_loop_state;
 	DWORD* credits_counter;
+	DWORD* credits_current_image_global_counter_start;
+	DWORD* credits_current_step_image;
 	uint32_t sub_470630;
 	uint32_t dd_d3d_start;
 	uint32_t create_d3d_gfx_driver;

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -87,6 +87,8 @@ void ff8_find_externals()
 	ff8_externals.input_get_keyscan = (int(*)(int,int))get_relative_call(ff8_externals.sub_52FE80, 0xD1);
 	ff8_externals.credits_loop_state = (DWORD*)get_absolute_value(ff8_externals.load_credits_image, 0x7);
 	ff8_externals.credits_counter = (DWORD *)get_absolute_value(ff8_externals.load_credits_image, 0x59);
+	ff8_externals.credits_current_image_global_counter_start = (DWORD *)get_absolute_value(ff8_externals.load_credits_image, 0x1CB);
+	ff8_externals.credits_current_step_image = (DWORD *)get_absolute_value(ff8_externals.load_credits_image, 0x1BC);
 	ff8_externals.sub_470630 = get_absolute_value(ff8_externals.main_menu_main_loop, 0xE4);
 	ff8_externals.main_loop = get_absolute_value(ff8_externals.sub_470630, 0x24);
 


### PR DESCRIPTION
## Summary

The intro credits (before the main menu) is not synchronized with the background music.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
