### PR TITLE
FF8: Fix main menu texts on new game

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -57,6 +57,7 @@
 - Voice: Enable worldmap voice acting
 - Voice: Enable tutorial voice acting
 - SFX: Fix Quezacotl sounds ( https://github.com/julianxhokaxhiu/FFNx/pull/633 )
+- Menu: Fix main menu texts when selecting "new game" option (European versions only) ( https://github.com/julianxhokaxhiu/FFNx/pull/636 )
 
 # 1.16.0
 

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -977,6 +977,11 @@ struct ff8_field_state_background {
 	uint8_t field_1b3;
 };
 
+struct ff8_menu_callback {
+	void (*func)(int);
+	uint32_t field_4;
+};
+
 // --------------- end of FF8 imports ---------------
 
 // memory addresses and function pointers from FF8.exe
@@ -1059,6 +1064,12 @@ struct ff8_externals
 	uint32_t sub_559F30;
 	uint32_t sub_497380;
 	uint32_t sub_4B3410;
+	uint32_t sub_4B3310;
+	uint32_t sub_4B3140;
+	uint32_t sub_4BDB30;
+	ff8_menu_callback *menu_callbacks;
+	uint32_t main_menu_render_sub_4E5550;
+	uint32_t get_text_data;
 	uint32_t sub_4BE4D0;
 	uint32_t sub_4BECC0;
 	uint32_t menu_draw_text;

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -364,6 +364,12 @@ void ff8_find_externals()
 
 	ff8_externals.sub_497380 = get_relative_call(ff8_externals.main_menu_main_loop, 0xAA);
 	ff8_externals.sub_4B3410 = get_relative_call(ff8_externals.sub_497380, 0xAC);
+	ff8_externals.sub_4B3310 = get_relative_call(ff8_externals.sub_497380, 0xD3);
+	ff8_externals.sub_4B3140 = get_relative_call(ff8_externals.sub_4B3310, 0xC8);
+	ff8_externals.sub_4BDB30 = get_relative_call(ff8_externals.sub_4B3140, 0x4);
+	ff8_externals.menu_callbacks = (ff8_menu_callback *)get_absolute_value(ff8_externals.sub_4BDB30, 0x11);
+	ff8_externals.main_menu_render_sub_4E5550 = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[16].func), 0x3);
+	ff8_externals.get_text_data = get_relative_call(ff8_externals.main_menu_render_sub_4E5550, 0x203);
 	ff8_externals.sub_4BE4D0 = get_relative_call(ff8_externals.sub_4B3410, 0x68);
 	ff8_externals.sub_4BECC0 = get_relative_call(ff8_externals.sub_4BE4D0, 0x39);
 	ff8_externals.menu_draw_text = get_relative_call(ff8_externals.sub_4BECC0, 0x127);

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -668,6 +668,28 @@ int credits_controller_input_call()
 	return ((int(*)())ff8_externals.sub_52FE80)();
 }
 
+char new_game_text_cache[64] = "";
+char load_game_text_cache[64] = "";
+
+char *ff8_get_text_cached(int pool_id, int cat_id, int text_id, int a4, char *cache)
+{
+	if (*cache == '\0') {
+		memcpy(cache, ((char*(*)(int,int,int,int))ff8_externals.get_text_data)(pool_id, cat_id, text_id, a4), sizeof(new_game_text_cache));
+	}
+
+	return cache;
+}
+
+char *ff8_get_text_cached_new_game(int pool_id, int cat_id, int text_id, int a4)
+{
+	return ff8_get_text_cached(pool_id, cat_id, text_id, a4, new_game_text_cache);
+}
+
+char *ff8_get_text_cached_load_game(int pool_id, int cat_id, int text_id, int a4)
+{
+	return ff8_get_text_cached(pool_id, cat_id, text_id, a4, load_game_text_cache);
+}
+
 void ff8_init_hooks(struct game_obj *_game_object)
 {
 	struct ff8_game_obj *game_object = (struct ff8_game_obj *)_game_object;
@@ -852,6 +874,12 @@ void ff8_init_hooks(struct game_obj *_game_object)
 	patch_code_dword(int(ff8_externals.vibrate_data_summon_quezacotl) - 12, 240033); // 240033 - 240000 + 370 = ID 403
 	patch_code_dword(int(ff8_externals.vibrate_data_summon_quezacotl) - 8, 240036); // 240036 - 240000 + 370 = ID 406
 	patch_code_dword(int(ff8_externals.vibrate_data_summon_quezacotl) - 4, 240039); // 240039 - 240000 + 370 = ID 409
+
+	if (!FF8_US_VERSION && !JP_VERSION) {
+		// Fix "New Game" and "Load Game" texts converted to "Doomtrain" and "Alexander" when starting a new game
+		replace_call(ff8_externals.main_menu_render_sub_4E5550 + 0x203, ff8_get_text_cached_new_game);
+		replace_call(ff8_externals.main_menu_render_sub_4E5550 + 0x222, ff8_get_text_cached_load_game);
+	}
 }
 
 struct ff8_gfx_driver *ff8_load_driver(void* _game_object)


### PR DESCRIPTION
## Summary

![new-game-load-credits](https://github.com/julianxhokaxhiu/FFNx/assets/8015696/d37c17f4-8814-430a-9074-60d1aa56cce3)

![cerberus-alexander-credits](https://github.com/julianxhokaxhiu/FFNx/assets/8015696/f73b5e83-ec26-447d-95c1-06fc8dc2d260)

### Motivation

As a french player, the first thing I see when I start the game is a bug. Enough is enough, let's restore the reputation of FF8 once and for all!

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
