### PR TITLE
FF8: Add option to display playstation icons

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,11 @@
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.17.1...master
 
+## FF8
+
+- Input: New option to show PlayStation gamepad icons when a gamepad is used ( https://github.com/julianxhokaxhiu/FFNx/pull/641 )
+- Input: Fix mapping of gamepad buttons when modified in the game ( https://github.com/julianxhokaxhiu/FFNx/pull/641 )
+
 # 1.17.1
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.17.0...1.17.1

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -705,6 +705,11 @@ ff8_fix_uv_coords_precision = true
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ff8_external_music_force_original_filenames = false
 
+# Use icon textures for gamepad buttons instead of "B1", "B2", etc...
+# By default the PS1 icons are used from the game data.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ff8_use_gamepad_icons = false
+
 ## GAME INSTALLATION OPTIONS
 
 #[APP PATH]

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -135,6 +135,7 @@ long external_audio_sample_rate;
 bool ff8_worldmap_internal_highres_textures;
 bool ff8_fix_uv_coords_precision;
 bool ff8_external_music_force_original_filenames;
+bool ff8_use_gamepad_icons;
 std::string app_path;
 std::string data_drive;
 bool enable_ntscj_gamut_mode;
@@ -292,6 +293,7 @@ void read_cfg()
 	ff8_worldmap_internal_highres_textures = config["ff8_worldmap_internal_highres_textures"].value_or(true);
 	ff8_fix_uv_coords_precision = config["ff8_fix_uv_coords_precision"].value_or(true);
 	ff8_external_music_force_original_filenames = config["ff8_external_music_force_original_filenames"].value_or(false);
+	ff8_use_gamepad_icons = config["ff8_use_gamepad_icons"].value_or(false);
 	app_path = config["app_path"].value_or("");
 	data_drive = config["data_drive"].value_or("");
 	enable_ntscj_gamut_mode = config["enable_ntscj_gamut_mode"].value_or(false);

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -152,6 +152,7 @@ extern long external_audio_sample_rate;
 extern bool ff8_worldmap_internal_highres_textures;
 extern bool ff8_fix_uv_coords_precision;
 extern bool ff8_external_music_force_original_filenames;
+extern bool ff8_use_gamepad_icons;
 extern std::string app_path;
 extern std::string data_drive;
 extern bool enable_ntscj_gamut_mode;

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -641,6 +641,16 @@ struct ff8_vibrate_struc
 	uint8_t field_23;
 };
 
+struct ff8_draw_menu_sprite_texture_infos {
+	uint32_t field_0;
+	uint32_t field_4;
+	uint32_t field_8;
+	uint16_t x_related;
+	uint16_t y_related;
+	uint32_t field_10;
+	uint32_t field_14;
+};
+
 struct ff8_audio_fmt
 {
 	uint32_t audio_data_length;
@@ -1031,6 +1041,8 @@ struct ff8_externals
 	uint32_t pubintro_init;
 	uint32_t sub_467C00;
 	uint32_t sub_468810;
+	uint32_t dinput_get_input_device_capabilities_number_of_buttons;
+	uint32_t get_command_key;
 	uint32_t sub_468BD0;
 	uint32_t pubintro_cleanup;
 	uint32_t pubintro_exit;
@@ -1068,6 +1080,7 @@ struct ff8_externals
 	uint32_t sub_4B3140;
 	uint32_t sub_4BDB30;
 	ff8_menu_callback *menu_callbacks;
+	uint32_t menu_config_controller;
 	uint32_t main_menu_render_sub_4E5550;
 	uint32_t get_text_data;
 	uint32_t sub_4BE4D0;
@@ -1284,6 +1297,7 @@ struct ff8_externals
 	FILE *(*_fsopen)(const char*, const char*, int);
 	uint32_t input_init;
 	uint32_t ff8input_cfg_read;
+	uint32_t ff8input_cfg_reset;
 	char *(*strcpy_with_malloc)(const char *);
 	uint32_t moriya_filesytem_open;
 	uint32_t moriya_filesytem_seek;
@@ -1300,8 +1314,12 @@ struct ff8_externals
 	uint32_t sub_4A0C00;
 	char(*show_dialog)(int32_t, uint32_t, int16_t);
 	int(*pause_menu_with_vibration)(int);
+	uint32_t draw_icon;
 	int(*pause_menu)(int);
 	uint32_t init_pause_menu;
+	uint32_t sub_49BB30;
+	uint32_t get_icon_sp1_data;
+	uint32_t draw_controller_or_keyboard_icons;
 	uint32_t get_vibration_capability;
 	uint32_t vibration_apply;
 	int(*get_keyon)(int, int);

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -64,6 +64,7 @@ void ff8_find_externals()
 	ff8_externals.input_init = get_relative_call(ff8_externals.pubintro_init, 0xBA);
 	ff8_externals.ff8input_cfg_read = get_relative_call(ff8_externals.input_init, 0x5);
 	ff8_externals.sub_468810 = get_relative_call(ff8_externals.sub_467C00, 0x59);
+	ff8_externals.dinput_get_input_device_capabilities_number_of_buttons = get_relative_call(ff8_externals.sub_467C00, 0xA8);
 	ff8_externals.sub_468BD0 = get_relative_call(ff8_externals.sub_468810, 0x5B);
 	common_externals.dinput_hack1 = ff8_externals.sub_468BD0 + 0x64;
 
@@ -220,6 +221,11 @@ void ff8_find_externals()
 	ff8_externals.pause_menu = (int(*)(int))get_relative_call(uint32_t(ff8_externals.check_game_is_paused), 0x88);
 	ff8_externals.init_pause_menu = get_relative_call(uint32_t(ff8_externals.check_game_is_paused), 0xE2);
 	ff8_externals.pause_menu_with_vibration = (int(*)(int))(ff8_externals.init_pause_menu - 0x290);
+	ff8_externals.draw_icon = get_relative_call(uint32_t(ff8_externals.pause_menu_with_vibration), 0x1CF);
+	ff8_externals.get_icon_sp1_data = get_relative_call(ff8_externals.draw_icon, 0x2);
+	ff8_externals.draw_controller_or_keyboard_icons = get_relative_call(ff8_externals.draw_icon, 0x40);
+	ff8_externals.get_command_key = get_relative_call(ff8_externals.draw_controller_or_keyboard_icons, 0x31);
+	ff8_externals.sub_49BB30 = get_relative_call(ff8_externals.draw_icon, 0xF6);
 	ff8_externals.vibration_apply = get_relative_call(uint32_t(ff8_externals.pause_menu_with_vibration), 0xB4);
 	ff8_externals.get_keyon = (int(*)(int, int))get_relative_call(uint32_t(ff8_externals.pause_menu_with_vibration), 0xC9);
 	ff8_externals.get_vibration_capability = get_relative_call(uint32_t(ff8_externals.pause_menu_with_vibration), 0xE3);
@@ -368,12 +374,14 @@ void ff8_find_externals()
 	ff8_externals.sub_4B3140 = get_relative_call(ff8_externals.sub_4B3310, 0xC8);
 	ff8_externals.sub_4BDB30 = get_relative_call(ff8_externals.sub_4B3140, 0x4);
 	ff8_externals.menu_callbacks = (ff8_menu_callback *)get_absolute_value(ff8_externals.sub_4BDB30, 0x11);
+	ff8_externals.menu_config_controller = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[8].func), 0x8);
 	ff8_externals.main_menu_render_sub_4E5550 = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[16].func), 0x3);
 	ff8_externals.get_text_data = get_relative_call(ff8_externals.main_menu_render_sub_4E5550, 0x203);
 	ff8_externals.sub_4BE4D0 = get_relative_call(ff8_externals.sub_4B3410, 0x68);
 	ff8_externals.sub_4BECC0 = get_relative_call(ff8_externals.sub_4BE4D0, 0x39);
 	ff8_externals.menu_draw_text = get_relative_call(ff8_externals.sub_4BECC0, 0x127);
 	ff8_externals.get_character_width = (uint32_t (*)(uint32_t))get_relative_call(ff8_externals.menu_draw_text, JP_VERSION ? 0x1E1 : 0x1D0);
+	ff8_externals.ff8input_cfg_reset = get_relative_call(ff8_externals.menu_config_controller, 0x185);
 
 	ff8_externals.open_lzs_image = get_relative_call(ff8_externals.load_credits_image, 0x27);
 	ff8_externals.credits_open_file = (uint32_t (*)(char*,char*))get_relative_call(ff8_externals.open_lzs_image, 0x72);

--- a/src/joystick.cpp
+++ b/src/joystick.cpp
@@ -98,6 +98,11 @@ LPDIJOYSTATE2 Joystick::GetState()
   return &currentState;
 }
 
+LPDIDEVCAPS Joystick::GetCaps()
+{
+  return &caps;
+}
+
 bool Joystick::CheckConnection()
 {
   if (dev == nullptr)

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -50,6 +50,7 @@ private:
 
 public:
   LPDIJOYSTATE2 GetState();
+  LPDIDEVCAPS GetCaps();
   bool CheckConnection();
   bool Refresh();
   bool HasAnalogTriggers();


### PR DESCRIPTION
## Summary

![2024-01-18 00_25_46-Final Fantasy VIII](https://github.com/julianxhokaxhiu/FFNx/assets/8015696/ecc618c6-333c-45f6-8286-8e11bbeb702f)

### Motivation

![2024-01-18 00_29_25-Final Fantasy VIII](https://github.com/julianxhokaxhiu/FFNx/assets/8015696/b65b5800-1215-4356-b8ea-78f0e9bee9d6)


### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
