### PR TITLE
FF7: Fixed fog being incorrectly applied to Emerald Weapon battle

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
 
 ## FF7
 
+- Renderer: Fixed fog being incorrectly applied to Emerald Weapon battle
 - Renderer: Fixed fog rendering not working in underwater worldmap
 
 ## FF8

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -405,6 +405,7 @@ void Renderer::resetState()
 
     doMirrorTextureWrap();
     setSphericalWorldRate();
+    setFogEnabled();
 
     resetViewMatrixFlag();
 };


### PR DESCRIPTION
## Summary

Fixed fog being incorrectly applied to Emerald Weapon battle. The problem was that the fog flag was not being reset.

### Motivation

Because otherwise can't see shit.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
