### PR TITLE
FF8: Various enhancements and fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ find_package(VGMSTREAM REQUIRED)
 find_package(STACKWALKER REQUIRED)
 find_package(pugixml CONFIG REQUIRED)
 find_package(libpng CONFIG REQUIRED)
+find_package(directxtex CONFIG REQUIRED)
 find_package(mimalloc CONFIG REQUIRED)
 find_package(imgui CONFIG REQUIRED)
 find_package(SOLOUD REQUIRED)
@@ -134,6 +135,7 @@ target_link_libraries(
   strmiids
   ZLIB::ZLIB
   png_static
+  Microsoft::DirectXTex
   mimalloc-static
   imgui::imgui
   pugixml::pugixml

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,9 @@
 
 - Graphics: Add external textures replacement for magic.fs textures ( https://github.com/julianxhokaxhiu/FFNx/pull/646 )
 - Graphics: Fix white textures in battle ( https://github.com/julianxhokaxhiu/FFNx/pull/646 )
-- Input: New option to show PlayStation gamepad icons when a gamepad is used ( https://github.com/julianxhokaxhiu/FFNx/pull/641 )
+- Graphics: Opimize PNG and DDS loading time ( https://github.com/julianxhokaxhiu/FFNx/pull/650 )
+- Graphics: Minimize RAM usage of external textures and prevent crashes with big textures ( https://github.com/julianxhokaxhiu/FFNx/pull/650 )
+- Input: New option to show PlayStation gamepad icons when a gamepad is used ( https://github.com/julianxhokaxhiu/FFNx/pull/641 https://github.com/julianxhokaxhiu/FFNx/pull/650 )
 - Input: Fix mapping of gamepad buttons when modified in the game ( https://github.com/julianxhokaxhiu/FFNx/pull/641 )
 - Input: Fix inverted analog up/down direction for non-XInput controllers ( https://github.com/julianxhokaxhiu/FFNx/pull/647 )
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 - Graphics: Fix white textures in battle ( https://github.com/julianxhokaxhiu/FFNx/pull/646 )
 - Graphics: Opimize PNG and DDS loading time ( https://github.com/julianxhokaxhiu/FFNx/pull/650 )
 - Graphics: Minimize RAM usage of external textures and prevent crashes with big textures ( https://github.com/julianxhokaxhiu/FFNx/pull/650 )
+- Graphics: Fix Tonberry compatibility layer for field background -again- ( https://github.com/julianxhokaxhiu/FFNx/pull/650 )
 - Input: New option to show PlayStation gamepad icons when a gamepad is used ( https://github.com/julianxhokaxhiu/FFNx/pull/641 https://github.com/julianxhokaxhiu/FFNx/pull/650 )
 - Input: Fix mapping of gamepad buttons when modified in the game ( https://github.com/julianxhokaxhiu/FFNx/pull/641 )
 - Input: Fix inverted analog up/down direction for non-XInput controllers ( https://github.com/julianxhokaxhiu/FFNx/pull/647 )

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1481,22 +1481,38 @@ uint32_t load_external_texture(void* image_data, uint32_t dataSize, struct textu
 			&scale, &image_data_scaled
 		);
 
-		if (save_textures && textureType != TexturePacker::InternalTexture) return false;
+		if (save_textures && textureType != TexturePacker::InternalTexture) {
+			if (image_data_scaled != nullptr && image_data_scaled != image_data) {
+				driver_free(image_data_scaled);
+			}
+
+			return false;
+		}
 
 		if (textureType == TexturePacker::NoTexture)
 		{
+			if (image_data_scaled != nullptr && image_data_scaled != image_data) {
+				driver_free(image_data_scaled);
+			}
+
 			if(VREF(texture_set, ogl.external)) stats.external_textures--;
 			VRASS(texture_set, ogl.external, false);
 		}
 		else if (textureType == TexturePacker::RemoveTexture)
 		{
+			if (image_data_scaled != nullptr && image_data_scaled != image_data) {
+				driver_free(image_data_scaled);
+			}
+
 			return true;
 		}
 		else
 		{
 			VREF(texture_set, ogl.width) = originalWidth * scale;
 			VREF(texture_set, ogl.height) = originalHeight * scale;
-			texture = newRenderer.createTexture(reinterpret_cast<uint8_t *>(image_data_scaled), VREF(texture_set, ogl.width), VREF(texture_set, ogl.height));
+			// Data is passed to bgfx, not need to free it here
+			bool copyData = image_data_scaled == image_data;
+			texture = newRenderer.createTexture(reinterpret_cast<uint8_t *>(image_data_scaled), VREF(texture_set, ogl.width), VREF(texture_set, ogl.height), 0, RendererTextureType::BGRA, true, copyData);
 		}
 
 		if (textureType == TexturePacker::InternalTexture)

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -651,6 +651,15 @@ struct ff8_draw_menu_sprite_texture_infos {
 	uint32_t field_14;
 };
 
+struct ff8_draw_menu_sprite_texture_infos_short {
+	uint32_t field_0;
+	uint32_t field_4;
+	uint16_t x_related;
+	uint16_t y_related;
+	uint32_t field_C;
+	uint32_t field_10;
+};
+
 struct ff8_audio_fmt
 {
 	uint32_t audio_data_length;
@@ -1326,6 +1335,7 @@ struct ff8_externals
 	int(*pause_menu)(int);
 	uint32_t init_pause_menu;
 	uint32_t sub_49BB30;
+	uint32_t sub_49FE60;
 	uint32_t get_icon_sp1_data;
 	uint32_t draw_controller_or_keyboard_icons;
 	uint32_t get_vibration_capability;

--- a/src/ff8/mod.cpp
+++ b/src/ff8/mod.cpp
@@ -549,14 +549,18 @@ TexturePacker::TextureTypes TextureBackground::drawToImage(
 		const int realOffsetX = (_vramPageId * TEXTURE_WIDTH_BPP16 - offsetX) / (4 >> uint16_t(targetBpp));
 		const int vramPageIdTarget = realOffsetX / TEXTURE_WIDTH_BPP16;
 
-		drawImage(
-			imgData, imgWidth, imgScale,
-			targetRgba, targetW, targetScale,
-			0, 0, vramPageIdTarget == _vramPageId ? imgWidth : std::max<int>(imgWidth - 128, 0), imgHeight,
-			vramPageIdTarget == _vramPageId ? 0 : 128, 0
-		);
+		if (vramPageIdTarget == _vramPageId) {
+			drawImage(
+				imgData, imgWidth, imgScale,
+				targetRgba, targetW, targetScale,
+				0, 0, imgWidth, imgHeight,
+				0, 0
+			);
 
-		return TexturePacker::ExternalTexture;
+			return TexturePacker::ExternalTexture;
+		}
+
+		return TexturePacker::NoTexture;
 	}
 
 	const uint8_t cols = targetW / TILE_SIZE, rows = targetH / TILE_SIZE;

--- a/src/ff8/mod.cpp
+++ b/src/ff8/mod.cpp
@@ -43,14 +43,43 @@ bool TextureImage::createImage(const char *filename, int originalTexturePixelWid
 		destroyImage();
 	}
 
-	_image = loadImageContainer(&defaultAllocator, filename, bimg::TextureFormat::BGRA8);
+	bimg::TextureFormat::Enum targetFormat = bimg::TextureFormat::BGRA8;
+
+	const char *extension = strrchr(filename, '.');
+	if (extension != nullptr && stricmp(extension + 1, "png") == 0) {
+		// Load PNG using libPNG
+		bimg::ImageMip mip;
+		if (loadPng(filename, mip, targetFormat) && Renderer::doesItFitInMemory(mip.m_size + 1))
+		{
+			_image = bimg::imageAlloc(&defaultAllocator, mip.m_format, mip.m_width, mip.m_height, mip.m_depth, 1, false, false, mip.m_data);
+			setLod(0);
+
+			driver_free((void *)mip.m_data);
+		}
+	} else if (extension != nullptr && stricmp(extension + 1, "dds") == 0) {
+		// Load DDS using DirectXTex
+		DirectX::TexMetadata metadata;
+		DirectX::ScratchImage image;
+		if (parseDds(filename, image, metadata)) {
+			int lod = computeLod(originalTexturePixelWidth, metadata.width, metadata.mipLevels, internalLodScale, filename);
+			// Convert only the relevant lod to improve performance
+			_image = convertDds(&defaultAllocator, image, metadata, targetFormat, lod);
+			image.Release();
+			setLod(0);
+		}
+	} else {
+		_image = loadImageContainer(&defaultAllocator, filename, bimg::TextureFormat::BGRA8);
+
+		if (_image != nullptr)
+		{
+			setLod(computeLod(originalTexturePixelWidth, _image->m_width, _image->m_numMips, internalLodScale, filename));
+		}
+	}
 
 	if (_image == nullptr)
 	{
 		return false;
 	}
-
-	setLod(computeLod(originalTexturePixelWidth, internalLodScale));
 
 	uint8_t scale = computeScale(originalTexturePixelWidth, originalTextureHeight);
 
@@ -97,25 +126,24 @@ int TextureImage::computeMaxScale()
 	return std::max(resWidth, FF8_BASE_RESOLUTION_X) / baseResW;
 }
 
-uint8_t TextureImage::computeLod(int originalTexturePixelWidth, int internalScale) const
+uint8_t TextureImage::computeLod(int originalTexturePixelWidth, int imageWidth, int numMips, int internalScale, const char *filename) const
 {
-	if (_image == nullptr || _image->m_numMips <= 1)
+	if (numMips <= 1)
 	{
 		return 0;
 	}
 
 	int maxScale = computeMaxScale(),
-		maxWidth = originalTexturePixelWidth * maxScale * internalScale,
-		imageWidth = _image->m_width;
+		maxWidth = originalTexturePixelWidth * maxScale * internalScale;
 
 	if (trace_all || trace_vram)
 	{
-		ffnx_info("ModdedTexture::%s: maxScale=%d maxWidth=%d imageWidth=%d\n", __func__, maxScale, maxWidth, imageWidth);
+		ffnx_info("TextureImage::%s: maxScale=%d maxWidth=%d imageWidth=%d\n", __func__, maxScale, maxWidth, imageWidth);
 	}
 
-	for (uint8_t lod = 0; lod < _image->m_numMips; ++lod)
+	for (uint8_t lod = 0; lod < numMips; ++lod)
 	{
-		if (imageWidth == maxWidth)
+		if (imageWidth <= maxWidth)
 		{
 			return lod;
 		}
@@ -123,7 +151,7 @@ uint8_t TextureImage::computeLod(int originalTexturePixelWidth, int internalScal
 		imageWidth /= 2;
 	}
 
-	ffnx_warning("ModdedTexture::%s: Cannot detect the LOD of the texture\n", __func__);
+	ffnx_warning("TextureImage::%s: Cannot detect the LOD of the texture %s\n", __func__, filename);
 
 	return 0;
 }
@@ -170,7 +198,7 @@ bool ModdedTexture::findExternalTexture(const char *name, char *filename, uint8_
 {
 	char langPath[16] = "/";
 
-	if(trace_all || trace_loaders) ffnx_trace("texture file name (VRAM): %s palette_index=%d hasPal=%d\n", name, palette_index, hasPal);
+	if(trace_all || trace_loaders) ffnx_trace("Texture file name (VRAM): %s palette_index=%d hasPal=%d\n", name, palette_index, hasPal);
 
 	if(save_textures) return false;
 

--- a/src/ff8/mod.h
+++ b/src/ff8/mod.h
@@ -51,7 +51,7 @@ public:
 	static int computeMaxScale();
 private:
 	void setLod(uint8_t lod);
-	uint8_t computeLod(int originalTexturePixelWidth, int internalScale = 1) const;
+	uint8_t computeLod(int originalTexturePixelWidth, int imageWidth, int numMips, int internalScale = 1, const char *filename = "") const;
 	uint8_t computeScale(int originalTexturePixelWidth, int originalTextureHeight) const;
 	bimg::ImageContainer *_image;
 	bimg::ImageMip _mip;

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -704,8 +704,9 @@ void ff8_find_externals()
 	ff8_externals.dword_1D2B808 = (uint32_t *)get_absolute_value(ff8_externals.ff8_draw_icon_or_key2, 0x41);
 	ff8_externals.ff8_draw_icon_or_key3 = ff8_externals.ff8_draw_icon_or_key2 + 0x110;
 	ff8_externals.ff8_draw_icon_or_key4 = ff8_externals.ff8_draw_icon_or_key3 + 0xF0;
-	ff8_externals.ff8_draw_icon_or_key5 = ff8_externals.ff8_draw_icon_or_key2 + 0x120;
-	ff8_externals.ff8_draw_icon_or_key6 = ff8_externals.ff8_draw_icon_or_key2 + 0x110;
+	ff8_externals.ff8_draw_icon_or_key5 = ff8_externals.ff8_draw_icon_or_key4 + 0x120;
+	ff8_externals.ff8_draw_icon_or_key6 = ff8_externals.ff8_draw_icon_or_key5 + 0x110;
+	ff8_externals.sub_49FE60 = get_relative_call(ff8_externals.ff8_draw_icon_or_key6, 0xC9);
 	ff8_externals.sub_4A0C00 = get_absolute_value(ff8_externals.sub_4A0880, 0x33);
 	ff8_externals.show_dialog = (char(*)(int32_t, uint32_t, int16_t))get_relative_call(ff8_externals.sub_4A0C00, 0x5F);
 

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -646,6 +646,38 @@ ff8_draw_menu_sprite_texture_infos *ff8_draw_icon_or_key5(int a1, ff8_draw_menu_
 	return ff8_draw_icon_or_key(a1, draw_infos, icon_id, x, y, a6, a7, true);
 }
 
+ff8_draw_menu_sprite_texture_infos_short *ff8_draw_icon_or_key6(int a1, ff8_draw_menu_sprite_texture_infos_short *draw_infos, int icon_id, uint16_t x, uint16_t y, int a6, int a7) {
+	// We should not cast like this, but that's what the game does
+	icon_id = ff8_draw_gamepad_icon_or_keyboard_key(a1, reinterpret_cast<ff8_draw_menu_sprite_texture_infos *>(draw_infos), icon_id, x, y);
+	if (icon_id < 0)
+	{
+		return draw_infos;
+	}
+
+	int states_count = 0;
+	unsigned int *sp1_section_data = ff8_draw_icon_get_icon_sp1_infos(icon_id, states_count);
+
+	if (sp1_section_data == nullptr)
+	{
+		return draw_infos;
+	}
+
+	for (int i = states_count; i > 0; --i)
+	{
+		draw_infos->field_0 = 0x4000000;
+		draw_infos->field_C = (sp1_section_data[0] & 0x7CFFFFF) + ((0x3810 + a7) << 16);
+		draw_infos->field_4 = a6 | (((sp1_section_data[0] >> 26) & 2) << 24);
+		draw_infos->field_10 = sp1_section_data[1] & 0xFF00FF;
+		draw_infos->x_related = x + (int16_t(sp1_section_data[1]) >> 8);
+		draw_infos->y_related = y + (sp1_section_data[1] >> 24);
+		((void(*)(int, ff8_draw_menu_sprite_texture_infos_short*))ff8_externals.sub_49FE60)(a1, draw_infos);
+		draw_infos += 1;
+		sp1_section_data += 2;
+	}
+
+	return draw_infos;
+}
+
 int ff8_is_window_active()
 {
 	if (gameHwnd == GetActiveWindow())
@@ -1053,6 +1085,7 @@ void ff8_init_hooks(struct game_obj *_game_object)
 		replace_function(ff8_externals.ff8_draw_icon_or_key3, ff8_draw_icon_or_key3);
 		replace_function(ff8_externals.ff8_draw_icon_or_key4, ff8_draw_icon_or_key4);
 		replace_function(ff8_externals.ff8_draw_icon_or_key5, ff8_draw_icon_or_key5);
+		replace_function(ff8_externals.ff8_draw_icon_or_key6, ff8_draw_icon_or_key6);
 	}
 }
 

--- a/src/image/image.cpp
+++ b/src/image/image.cpp
@@ -20,6 +20,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include "image.h"
 #include "../common.h"
 #include "../renderer.h"
 #include <stdio.h>
@@ -35,7 +36,7 @@ static void LibPngWarningCb(png_structp png_ptr, const char* warning)
     ffnx_info("libpng warning: %s\n", warning);
 }
 
-bool loadPng(const char *filename, bimg::ImageMip &mip)
+bool loadPng(const char *filename, bimg::ImageMip &mip, bimg::TextureFormat::Enum targetFormat)
 {
     FILE* file = fopen(filename, "rb");
 
@@ -102,7 +103,15 @@ bool loadPng(const char *filename, bimg::ImageMip &mip)
         return false;
     }
 
-    png_read_png(png_ptr, info_ptr, PNG_TRANSFORM_EXPAND, NULL);
+    int transforms = PNG_TRANSFORM_EXPAND;
+
+    if (targetFormat == bimg::TextureFormat::BGRA8) {
+        transforms |= PNG_TRANSFORM_STRIP_16 | PNG_TRANSFORM_GRAY_TO_RGB | PNG_TRANSFORM_BGR;
+    } else if (targetFormat == bimg::TextureFormat::RGBA8) {
+        transforms |= PNG_TRANSFORM_STRIP_16 | PNG_TRANSFORM_GRAY_TO_RGB;
+    }
+
+    png_read_png(png_ptr, info_ptr, transforms, NULL);
 
     color_type = png_get_color_type(png_ptr, info_ptr);
     bit_depth = png_get_bit_depth(png_ptr, info_ptr);
@@ -202,28 +211,86 @@ bool loadPng(const char *filename, bimg::ImageMip &mip)
     return false;
 }
 
-bimg::ImageContainer *loadImageContainer(bx::AllocatorI *allocator, const char *filename, bimg::TextureFormat::Enum targetFormat, bool isPng)
+bool parseDds(const char *filename, DirectX::ScratchImage &image, DirectX::TexMetadata &metadata)
 {
-    bimg::ImageContainer* img = nullptr;
+    wchar_t filenameW[MAX_PATH];
 
-    if (isPng)
+    mbstowcs(filenameW, filename, MAX_PATH);
+
+    HRESULT hr = DirectX::LoadFromDDSFile(
+        filenameW,
+        DirectX::DDS_FLAGS_NONE, &metadata, image
+    );
+    if (FAILED(hr) || image.GetImageCount() == 0)
     {
-        bimg::ImageMip mip;
-        if (loadPng(filename, mip))
-        {
-            img = bimg::imageAlloc(allocator, mip.m_format, mip.m_width, mip.m_height, mip.m_depth, 1, false, false, mip.m_data);
+        ffnx_error("%s: Load DDS from file error (%d)\n", __func__, HRESULT_CODE(hr));
 
-            driver_free((void *)mip.m_data);
-
-            return img;
-        }
+        return false;
     }
 
+    return true;
+}
+
+bimg::ImageContainer *convertDds(bx::AllocatorI *allocator, DirectX::ScratchImage &image, const DirectX::TexMetadata &metadata, bimg::TextureFormat::Enum targetFormat, int lod)
+{
+    if (lod >= image.GetImageCount())
+    {
+        lod = image.GetImageCount() - 1;
+    }
+
+    const DirectX::Image &mainImage = image.GetImages()[lod];
+    DXGI_FORMAT format = DXGI_FORMAT_R8G8B8A8_UNORM;
+
+    if (targetFormat == bimg::TextureFormat::BGRA8) {
+        format = DXGI_FORMAT_B8G8R8A8_UNORM;
+    } else {
+        targetFormat = bimg::TextureFormat::RGBA8;
+    }
+
+    DirectX::ScratchImage out;
+    HRESULT hr;
+    if (DirectX::IsCompressed(image.GetMetadata().format))
+    {
+        hr = DirectX::Decompress(mainImage, format, out);
+        image.Release();
+    }
+    else if (image.GetMetadata().format != format)
+    {
+        hr = DirectX::Convert(mainImage, format, DirectX::TEX_FILTER_DEFAULT, DirectX::TEX_THRESHOLD_DEFAULT, out);
+        image.Release();
+    }
+    else
+    {
+        if (!Renderer::doesItFitInMemory(mainImage.rowPitch * mainImage.height + 1)) {
+            return nullptr;
+        }
+
+        return bimg::imageAlloc(allocator, targetFormat, mainImage.width, mainImage.height, 0, 1, false, false, mainImage.pixels);
+    }
+
+    if (FAILED(hr) || out.GetImageCount() == 0)
+    {
+        ffnx_error("%s: Convert DDS error (%d)\n", __func__, HRESULT_CODE(hr));
+
+        return nullptr;
+    }
+
+    const DirectX::Image &mainImage2 = out.GetImages()[0];
+
+    if (!Renderer::doesItFitInMemory(mainImage2.rowPitch * mainImage2.height + 1)) {
+        return nullptr;
+    }
+
+    return bimg::imageAlloc(allocator, targetFormat, mainImage2.width, mainImage2.height, 0, 1, false, false, mainImage2.pixels);
+}
+
+bimg::ImageContainer *loadImageContainer(bx::AllocatorI *allocator, const char *filename, bimg::TextureFormat::Enum targetFormat)
+{
     FILE* file = fopen(filename, "rb");
 
     if (!file)
     {
-        return img;
+        return nullptr;
     }
 
     size_t filesize = 0;
@@ -241,12 +308,14 @@ bimg::ImageContainer *loadImageContainer(bx::AllocatorI *allocator, const char *
 
     fclose(file);
 
-    if (buffer != nullptr)
+    if (buffer == nullptr)
     {
-        img = bimg::imageParse(allocator, buffer, filesize + 1, targetFormat);
-
-        driver_free(buffer);
+        return nullptr;
     }
+
+    bimg::ImageContainer* img = bimg::imageParse(allocator, buffer, filesize + 1, targetFormat);
+
+    driver_free(buffer);
 
     return img;
 }

--- a/src/image/image.h
+++ b/src/image/image.h
@@ -24,7 +24,11 @@
 
 #include <stdint.h>
 #include <bimg/bimg.h>
+#include <DirectXTex.h>
 
-bimg::ImageContainer *loadImageContainer(bx::AllocatorI *allocator, const char *filename, bimg::TextureFormat::Enum targetFormat = bimg::TextureFormat::Count, bool isPng = false);
+bimg::ImageContainer *loadImageContainer(bx::AllocatorI *allocator, const char *filename, bimg::TextureFormat::Enum targetFormat = bimg::TextureFormat::Count);
 // Fast PNG opening, you need to deallocate mip.m_data yourself
-bool loadPng(const char *filename, bimg::ImageMip &mip);
+bool loadPng(const char *filename, bimg::ImageMip &mip, bimg::TextureFormat::Enum targetFormat = bimg::TextureFormat::Count);
+// Fast DDS opening
+bool parseDds(const char *filename, DirectX::ScratchImage &image, DirectX::TexMetadata &metadata);
+bimg::ImageContainer *convertDds(bx::AllocatorI *allocator, DirectX::ScratchImage &image, const DirectX::TexMetadata &metadata, bimg::TextureFormat::Enum targetFormat, int lod);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -476,7 +476,7 @@ public:
 
     void bindVertexBuffer(struct nvertex* inVertex, vector3<float>* normals, uint32_t inCount);
     void bindIndexBuffer(WORD* inIndex, uint32_t inCount);
-    
+
     bgfx::UniformHandle setUniform(RendererUniform uniform, const void* uniformValue);
     void setCommonUniforms();
     void setLightingUniforms();
@@ -486,7 +486,7 @@ public:
     void setClearFlags(bool doClearColor = false, bool doClearDepth = false);
     void setBackgroundColor(float r = 0.0f, float g = 0.0f, float b = 0.0f, float a = 0.0f);
 
-    uint32_t createTexture(uint8_t* data, size_t width, size_t height, int stride = 0, RendererTextureType type = RendererTextureType::BGRA, bool isSrgb = true);
+    uint32_t createTexture(uint8_t* data, size_t width, size_t height, int stride = 0, RendererTextureType type = RendererTextureType::BGRA, bool isSrgb = true, bool copyData = true);
     uint32_t createTexture(char* filename, uint32_t* width, uint32_t* height, uint32_t* mipCount, bool isSrgb = true);
     bimg::ImageContainer* createImageContainer(const char* filename, bimg::TextureFormat::Enum targetFormat = bimg::TextureFormat::Enum::Count);
     bimg::ImageContainer* createImageContainer(cmrc::file* file, bimg::TextureFormat::Enum targetFormat = bimg::TextureFormat::Enum::Count);
@@ -565,7 +565,7 @@ public:
     void setSphericalWorldRate(float value = 0.0f);
     void setFogEnabled(bool flag = false);
     bool isFogEnabled();
-    
+
     // Game lighting
     void setGameLightData(light_data* lightdata = nullptr);
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,7 +35,11 @@
     },
     "imgui",
     "libpng",
-    "directxtex",
+    {
+      "name": "directxtex",
+      "default-features": false,
+      "features": []
+    },
     {
       "name": "mimalloc",
       "default-features": false,
@@ -82,6 +86,11 @@
       "name": "libpng",
       "version": "1.6.40",
       "port-version": 1
+    },
+    {
+      "name": "directxtex",
+      "version": "2023-10-28",
+      "port-version": 0
     },
     {
       "name": "mimalloc",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,6 +35,7 @@
     },
     "imgui",
     "libpng",
+    "directxtex",
     {
       "name": "mimalloc",
       "default-features": false,


### PR DESCRIPTION
## Summary

- Fix gamepad icons not displayed
- Use libPNG to decode PNGs, instead of bimg
- Use DirectXTex to decode DDS and decompress only the relevant lod for faster loading
- Minimize memory allocations with external textures to allow bigger textures and prevent game crashes (the game is limited to 2GB if not patched, and 4GB if patched, due to its x86 nature)

### Motivation

Fix things

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
