### PR TITLE
FF7: Preserve world camera state when changing game modes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ## FF7
 
 - Renderer: Fixed fog being incorrectly applied to Emerald Weapon battle ( https://github.com/julianxhokaxhiu/FFNx/pull/648 )
+- Renderer: Preserve world camera state when changing game modes ( https://github.com/julianxhokaxhiu/FFNx/pull/651 )
 
 ## FF8
 

--- a/src/ff7/world/camera.cpp
+++ b/src/ff7/world/camera.cpp
@@ -166,16 +166,20 @@ namespace ff7::world
         float targetRotationX = -ff7_externals.world_get_camera_rotation_x_74F916() * 360.0f / 4096.0f;
         //ff7_externals.world_get_camera_rotation_x_74F916();
 
-        static float zoomTarget = 10000.0f;        
+        static float zoomTarget = 10000.0f;
+        static int cameraStatusCounter = 0;
         float maxZoomDist = camera.getMaxZoomDist();
         
-        if(world_map_type != SNOWSTORM &&
-           *ff7_externals.world_is_control_enabled_DE6B5C &&
-            ff7_externals.world_get_unknown_flag_75335C())
+        if(world_map_type != SNOWSTORM && ff7_externals.world_get_unknown_flag_75335C())
         {
             targetRotationX = camera.targetRotation.x;
             zoomTarget = std::min(maxZoomDist, std::max(camera.minZoomDist, zoomTarget - camera.getZoomSpeed()));            
-        } else zoomTarget = 10000.0f;
+            cameraStatusCounter = 0;
+        } else 
+        {
+            if (cameraStatusCounter > 0) zoomTarget = 10000.0f;            
+            cameraStatusCounter++;
+        }
 
         const float t = 0.1f * movement_multiplier;     
         camera.rotationOffset.x = (1.0f - t) * camera.rotationOffset.x + t * targetRotationX;


### PR DESCRIPTION
## Summary

Preserve world camera state when changing game modes to prevent resetting after every battle, when entering menus or coming back from a field.

### Motivation

Because resetting every time was very annoying.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
