### PR TITLE
FF8: Update metadata file when a save file is created

### DIFF
--- a/.github/workflows/build.ps1
+++ b/.github/workflows/build.ps1
@@ -57,7 +57,7 @@ Write-Output "_CHANGELOG_VERSION=${env:_CHANGELOG_VERSION}" >> ${env:GITHUB_ENV}
 
 # Install CMake
 Write-Output "Installing cmake v${env:_WINGET_CMAKE}..."
-winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --uninstall-previous
+winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --uninstall-previous --no-upgrade
 cmake --version
 
 # Install Powershell

--- a/.github/workflows/build.ps1
+++ b/.github/workflows/build.ps1
@@ -57,7 +57,7 @@ Write-Output "_CHANGELOG_VERSION=${env:_CHANGELOG_VERSION}" >> ${env:GITHUB_ENV}
 
 # Install CMake
 Write-Output "Installing cmake v${env:_WINGET_CMAKE}..."
-winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity | out-null
+winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity
 cmake --version
 
 # Install Powershell

--- a/.github/workflows/build.ps1
+++ b/.github/workflows/build.ps1
@@ -57,7 +57,7 @@ Write-Output "_CHANGELOG_VERSION=${env:_CHANGELOG_VERSION}" >> ${env:GITHUB_ENV}
 
 # Install CMake
 Write-Output "Installing cmake v${env:_WINGET_CMAKE}..."
-winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --uninstall-previous | out-null
+winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --uninstall-previous
 cmake --version
 
 # Install Powershell

--- a/.github/workflows/build.ps1
+++ b/.github/workflows/build.ps1
@@ -56,8 +56,9 @@ Write-Output "_IS_GITHUB_RELEASE=${env:_IS_GITHUB_RELEASE}" >> ${env:GITHUB_ENV}
 Write-Output "_CHANGELOG_VERSION=${env:_CHANGELOG_VERSION}" >> ${env:GITHUB_ENV}
 
 # Install CMake
+Get-Command cmake
 Write-Output "Installing cmake v${env:_WINGET_CMAKE}..."
-winget upgrade Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity
+winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity | out-null
 cmake --version
 
 # Install Powershell

--- a/.github/workflows/build.ps1
+++ b/.github/workflows/build.ps1
@@ -82,8 +82,8 @@ Get-Content "$env:temp\vcvars.txt" | Foreach-Object {
 [Environment]::SetEnvironmentVariable('VCPKG_ROOT','')
 
 # Add Github Packages registry
-nuget sources add -Name github -Source "https://nuget.pkg.github.com/${env:GITHUB_REPOSITORY_OWNER}/index.json" -Username ${env:GITHUB_REPOSITORY_OWNER} -Password ${env:GITHUB_PACKAGES_PAT} -StorePasswordInClearText
-nuget setApiKey ${env:GITHUB_PACKAGES_PAT} -Source "https://nuget.pkg.github.com/${env:GITHUB_REPOSITORY_OWNER}/index.json"
+nuget sources add -Name github -Source "https://nuget.pkg.github.com/julianxhokaxhiu/index.json" -Username ${env:GITHUB_REPOSITORY_OWNER} -Password ${env:GITHUB_PACKAGES_PAT} -StorePasswordInClearText
+nuget setApiKey ${env:GITHUB_PACKAGES_PAT} -Source "https://nuget.pkg.github.com/julianxhokaxhiu/index.json"
 nuget sources list
 
 # Vcpkg setup

--- a/.github/workflows/build.ps1
+++ b/.github/workflows/build.ps1
@@ -57,7 +57,7 @@ Write-Output "_CHANGELOG_VERSION=${env:_CHANGELOG_VERSION}" >> ${env:GITHUB_ENV}
 
 # Install CMake
 Write-Output "Installing cmake v${env:_WINGET_CMAKE}..."
-winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity
+winget upgrade Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity
 cmake --version
 
 # Install Powershell

--- a/.github/workflows/build.ps1
+++ b/.github/workflows/build.ps1
@@ -56,19 +56,18 @@ Write-Output "_IS_GITHUB_RELEASE=${env:_IS_GITHUB_RELEASE}" >> ${env:GITHUB_ENV}
 Write-Output "_CHANGELOG_VERSION=${env:_CHANGELOG_VERSION}" >> ${env:GITHUB_ENV}
 
 # Install CMake
-Get-Command cmake
 Write-Output "Installing cmake v${env:_WINGET_CMAKE}..."
-winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity | out-null
+winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --scope machine | out-null
 cmake --version
 
 # Install Powershell
 Write-Output "Installing powershell v${env:_WINGET_POWERSHELL}..."
-winget install Microsoft.PowerShell --version ${env:_WINGET_POWERSHELL} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity | out-null
+winget install Microsoft.PowerShell --version ${env:_WINGET_POWERSHELL} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --scope machine | out-null
 pwsh --version
 
 # Install Visual Studio Enterprise
 Write-Output "Installing VisualStudio 2022 Enterprise v${env:_WINGET_VS2022}..."
-winget install Microsoft.VisualStudio.2022.Enterprise --version ${env:_WINGET_VS2022} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity | out-null
+winget install Microsoft.VisualStudio.2022.Enterprise --version ${env:_WINGET_VS2022} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --scope machine | out-null
 
 # Load vcvarsall environment for x86
 $vcvarspath = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease -latest -property InstallationPath

--- a/.github/workflows/build.ps1
+++ b/.github/workflows/build.ps1
@@ -57,17 +57,17 @@ Write-Output "_CHANGELOG_VERSION=${env:_CHANGELOG_VERSION}" >> ${env:GITHUB_ENV}
 
 # Install CMake
 Write-Output "Installing cmake v${env:_WINGET_CMAKE}..."
-winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --uninstall-previous --accept-source-agreements --accept-package-agreements --disable-interactivity --force
+winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --uninstall-previous --accept-source-agreements --accept-package-agreements --disable-interactivity --force | out-null
 cmake --version
 
 # Install Powershell
 Write-Output "Installing powershell v${env:_WINGET_POWERSHELL}..."
-winget install Microsoft.PowerShell --version ${env:_WINGET_POWERSHELL} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity | out-null
+winget install Microsoft.PowerShell --version ${env:_WINGET_POWERSHELL} --silent --uninstall-previous --accept-source-agreements --accept-package-agreements --disable-interactivity --force | out-null
 pwsh --version
 
 # Install Visual Studio Enterprise
 Write-Output "Installing VisualStudio 2022 Enterprise v${env:_WINGET_VS2022}..."
-winget install Microsoft.VisualStudio.2022.Enterprise --version ${env:_WINGET_VS2022} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity | out-null
+winget install Microsoft.VisualStudio.2022.Enterprise --version ${env:_WINGET_VS2022} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --force | out-null
 
 # Load vcvarsall environment for x86
 $vcvarspath = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease -latest -property InstallationPath

--- a/.github/workflows/build.ps1
+++ b/.github/workflows/build.ps1
@@ -57,17 +57,17 @@ Write-Output "_CHANGELOG_VERSION=${env:_CHANGELOG_VERSION}" >> ${env:GITHUB_ENV}
 
 # Install CMake
 Write-Output "Installing cmake v${env:_WINGET_CMAKE}..."
-winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --scope machine | out-null
+winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --uninstall-previous | out-null
 cmake --version
 
 # Install Powershell
 Write-Output "Installing powershell v${env:_WINGET_POWERSHELL}..."
-winget install Microsoft.PowerShell --version ${env:_WINGET_POWERSHELL} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --scope machine | out-null
+winget install Microsoft.PowerShell --version ${env:_WINGET_POWERSHELL} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity | out-null
 pwsh --version
 
 # Install Visual Studio Enterprise
 Write-Output "Installing VisualStudio 2022 Enterprise v${env:_WINGET_VS2022}..."
-winget install Microsoft.VisualStudio.2022.Enterprise --version ${env:_WINGET_VS2022} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --scope machine | out-null
+winget install Microsoft.VisualStudio.2022.Enterprise --version ${env:_WINGET_VS2022} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity | out-null
 
 # Load vcvarsall environment for x86
 $vcvarspath = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease -latest -property InstallationPath

--- a/.github/workflows/build.ps1
+++ b/.github/workflows/build.ps1
@@ -57,7 +57,7 @@ Write-Output "_CHANGELOG_VERSION=${env:_CHANGELOG_VERSION}" >> ${env:GITHUB_ENV}
 
 # Install CMake
 Write-Output "Installing cmake v${env:_WINGET_CMAKE}..."
-winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --accept-source-agreements --accept-package-agreements --disable-interactivity --uninstall-previous --no-upgrade
+winget install Kitware.CMake --version ${env:_WINGET_CMAKE} --silent --uninstall-previous --accept-source-agreements --accept-package-agreements --disable-interactivity --force
 cmake --version
 
 # Install Powershell

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,10 @@
 - Input: Fix mapping of gamepad buttons when modified in the game ( https://github.com/julianxhokaxhiu/FFNx/pull/641 )
 - Input: Fix inverted analog up/down direction for non-XInput controllers ( https://github.com/julianxhokaxhiu/FFNx/pull/647 )
 
+## FF8 Steam
+
+- Misc: Rewrite metadata file when a save file is created to prevent save file loss ( https://github.com/julianxhokaxhiu/FFNx/pull/655 )
+
 # 1.17.1
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.17.0...1.17.1

--- a/docs/ff8/mods/external_textures.md
+++ b/docs/ff8/mods/external_textures.md
@@ -158,10 +158,10 @@ Path: `{mod_path}\field\mapdata\{map name}\{map name}.png`
 
 Example: `mods\Textures\field\mapdata\bccent_1\bccent_1.png`
 
-#### Legacy support for Tomberry's mods
+#### Legacy support for Tonberry's mods
 
 There is an alternative way to override maps, but on some edge cases it can be buggy.
-This is compatible with mods made for [Tomberry](https://forums.qhimm.com/index.php?topic=15945.0).
+This is compatible with mods made for [Tonberry](https://forums.qhimm.com/index.php?topic=15945.0).
 
 Path: `{mod_path}\field\mapdata\{first two letters of map name}\{map name}\{map name}_{number}.png`
 

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -456,7 +456,7 @@ save_textures = false
 
 # Dump internal legacy textures to PNG files in the mod_path
 # FF7: There is currently no legacy format
-# FF8: Field backgrounds will be saved in Tomberry's format, instead of FFNx one
+# FF8: Field backgrounds will be saved in Tonberry's format, instead of FFNx one
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 save_textures_legacy = false
 

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1091,6 +1091,10 @@ struct ff8_externals
 	ff8_menu_callback *menu_callbacks;
 	uint32_t menu_config_controller;
 	uint32_t main_menu_render_sub_4E5550;
+	uint32_t main_menu_controller;
+	uint32_t menu_chocobo_world_controller;
+	uint32_t create_save_file_sub_4C6E50;
+	uint32_t create_save_chocobo_world_file_sub_4C6620;
 	uint32_t get_text_data;
 	uint32_t sub_4BE4D0;
 	uint32_t sub_4BECC0;

--- a/src/ff8/mod.cpp
+++ b/src/ff8/mod.cpp
@@ -544,7 +544,7 @@ TexturePacker::TextureTypes TextureBackground::drawToImage(
 	const uint8_t imgScale = _texture.scale();
 	const uint32_t imgWidth = mip.m_width / imgScale, imgHeight = mip.m_height / imgScale;
 
-	// Tomberry way
+	// Tonberry way
 	if (_vramPageId >= 0) {
 		const int realOffsetX = (_vramPageId * TEXTURE_WIDTH_BPP16 - offsetX) / (4 >> uint16_t(targetBpp));
 		const int vramPageIdTarget = realOffsetX / TEXTURE_WIDTH_BPP16;

--- a/src/ff8/texture_packer.h
+++ b/src/ff8/texture_packer.h
@@ -147,7 +147,7 @@ public:
 	bool setTexture(const char *name, const TextureInfos &texture, const TextureInfos &palette = TextureInfos(), int textureCount = -1, bool clearOldTexture = true);
 	bool setTextureBackground(const char *name, int x, int y, int w, int h, const std::vector<Tile> &mapTiles, int bgTexId = -1, const char *extension = nullptr, char *found_extension = nullptr);
 	// Override a part of the VRAM from another part of the VRAM, typically with biggest textures (Worldmap)
-	bool setTextureRedirection(const char *name, const TextureInfos &oldTexture, const TextureInfos &newTexture, uint32_t *imageData);
+	void setTextureRedirection(const char *name, const TextureInfos &oldTexture, const TextureInfos &newTexture, const Tim &tim);
 	void animateTextureByCopy(int sourceXBpp2, int y, int sourceWBpp2, int sourceH, int targetXBpp2, int targetY);
 	void forceCurrentPalette(int xBpp2, int y, int8_t paletteId);
 	void clearTiledTexs();

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -816,22 +816,7 @@ void ff8_wm_texl_palette_upload_vram(int16_t *pos_and_size, uint8_t *texture_buf
 	}
 
 	// Redirect internal texl textures
-	uint32_t image_data_size = newTexture.pixelW() * newTexture.h() * 4;
-	uint32_t *image = (uint32_t*)driver_malloc(image_data_size);
-
-	if (image)
-	{
-		if (! tim.toRGBA32MultiPaletteGrid(image, 4, 4, 0, 4, true))
-		{
-			driver_free(image);
-			return;
-		}
-
-		if (! texturePacker.setTextureRedirection(next_texture_name, oldTexture, newTexture, image))
-		{
-			driver_free(image);
-		}
-	}
+	texturePacker.setTextureRedirection(next_texture_name, oldTexture, newTexture, tim);
 
 	*next_texture_name = '\0';
 

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -376,6 +376,10 @@ void ff8_find_externals()
 	ff8_externals.menu_callbacks = (ff8_menu_callback *)get_absolute_value(ff8_externals.sub_4BDB30, 0x11);
 	ff8_externals.menu_config_controller = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[8].func), 0x8);
 	ff8_externals.main_menu_render_sub_4E5550 = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[16].func), 0x3);
+	ff8_externals.main_menu_controller = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[16].func), 0x8);
+	ff8_externals.menu_chocobo_world_controller = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[27].func), 0xB);
+	ff8_externals.create_save_file_sub_4C6E50 = get_relative_call(ff8_externals.main_menu_controller, 0xF8D);
+	ff8_externals.create_save_chocobo_world_file_sub_4C6620 = get_relative_call(ff8_externals.menu_chocobo_world_controller, 0x9F6);
 	ff8_externals.get_text_data = get_relative_call(ff8_externals.main_menu_render_sub_4E5550, 0x203);
 	ff8_externals.sub_4BE4D0 = get_relative_call(ff8_externals.sub_4B3410, 0x68);
 	ff8_externals.sub_4BECC0 = get_relative_call(ff8_externals.sub_4BE4D0, 0x39);


### PR DESCRIPTION
## Summary

Rewrite metadata file when a save file is created to prevent save file loss.

Currently the metadata file is updated when the game is closed. Some users experienced save file loss, maybe because the metadata file was not updated correctly and the ff8 launcher removed the save files which were detected as invalid.

### Motivation

Losing your save is very serious situation, I never finished the game Child Of Light because Ubisoft devs do not understand the concept of redundancy and do not let you create several saves. Crash, lost hours, cry a lot, bargain, accept.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
