### PR TITLE
FF7: Fixed menu not working when using the buggy

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.18.0...master
 
+## FF7
+
+- Renderer: Fixed menu not working when using external worldmap mesh ( https://github.com/julianxhokaxhiu/FFNx/pull/657 )
+
 # 1.18.0
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.17.1...1.18.0

--- a/src/ff7/world/player.cpp
+++ b/src/ff7/world/player.cpp
@@ -408,7 +408,7 @@ namespace ff7::world {
             {
                 if(player_model_id == HIGHWIND)
                     ff7_externals.world_run_special_opcode_7640BC(6);
-                else if(ff7_externals.world_is_player_model_bitmask(CLOUD | TIFA | CID | BUGGY) && ff7_externals.world_get_player_walkmap_type() != 14)
+                else if(player_model_id & (CLOUD | TIFA | CID | BUGGY) && ff7_externals.world_get_player_walkmap_type() != 14)
                 {
                     ff7_externals.world_set_camera_fade_speed_755B97(16);
                     ff7_externals.world_set_world_control_lock_74D438(0, 1);


### PR DESCRIPTION
## Summary

Fixed menu not working when using the buggy and external worldmap. For some reason the world_is_player_model_bitmask function does not work so instead I made it check the model id values manually.

### Motivation

To return the original behavior where the player can use the menu while using the buggy.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
