### PR TITLE
FF8: vibration option in main menu

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.18.1...master
 
+## FF8
+
+- Added vibration option in the config menu and the battle pause menu ( https://github.com/julianxhokaxhiu/FFNx/pull/658 )
+
 # 1.18.1
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.18.0...1.18.1

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -641,6 +641,27 @@ struct ff8_vibrate_struc
 	uint8_t field_23;
 };
 
+struct ff8_menu_config_input {
+	int16_t text_id_name;
+	uint16_t text_id_value1;
+	uint16_t text_id_value2;
+	uint16_t type;
+	uint16_t mask;
+	uint16_t value;
+	void(*callback_change_state)();
+};
+
+struct ff8_menu_config_input_keymap {
+	uint8_t field_0;
+	uint8_t field_1;
+	uint8_t field_2;
+	uint8_t field_3;
+	uint8_t text_id;
+	uint8_t padd_5;
+	uint8_t padd_6;
+	uint8_t padd_7;
+};
+
 struct ff8_draw_menu_sprite_texture_infos {
 	uint32_t field_0;
 	uint32_t field_4;
@@ -1090,8 +1111,13 @@ struct ff8_externals
 	uint32_t sub_4BDB30;
 	ff8_menu_callback *menu_callbacks;
 	uint32_t menu_config_controller;
+	uint32_t menu_config_render;
+	uint32_t menu_config_render_submenu;
+	ff8_menu_config_input *menu_config_input_desc;
+	ff8_menu_config_input_keymap *menu_config_input_desc_keymap;
 	uint32_t main_menu_render_sub_4E5550;
 	uint32_t main_menu_controller;
+	uint32_t sub_4C2FF0;
 	uint32_t menu_chocobo_world_controller;
 	uint32_t create_save_file_sub_4C6E50;
 	uint32_t create_save_chocobo_world_file_sub_4C6620;
@@ -1344,6 +1370,8 @@ struct ff8_externals
 	uint32_t draw_controller_or_keyboard_icons;
 	uint32_t get_vibration_capability;
 	uint32_t vibration_apply;
+	uint32_t vibration_set_is_enabled;
+	uint32_t vibration_get_is_enabled;
 	int(*get_keyon)(int, int);
 	uint32_t set_vibration;
 	ff8_gamepad_state *gamepad_states;
@@ -1435,6 +1463,16 @@ struct ff8_externals
 	uint32_t load_magic_data_sub_571B80;
 	uint32_t load_magic_data_sub_5718E0;
 	uint32_t load_magic_data_sub_571900;
+	uint32_t sub_47D890;
+	uint32_t sub_4A94D0;
+	uint32_t sub_4BCBE0;
+	uint32_t sub_4C8B10;
+	uint32_t battle_pause_sub_4CD140;
+	uint32_t *is_alternative_pause_menu;
+	uint32_t *pause_menu_option_state;
+	void *battle_menu_state;
+	uint32_t battle_pause_window_sub_4CD350;
+	uint32_t sub_4A7210;
 };
 
 void ff8gl_field_78(struct ff8_polygon_set *polygon_set, struct ff8_game_obj *game_object);

--- a/src/ff8/vibration.cpp
+++ b/src/ff8/vibration.cpp
@@ -29,11 +29,10 @@
 #include <xxhash.h>
 
 char vibrateName[32] = "";
+ff8_menu_config_input_keymap menu_options_keymap_desc[11];
 
 int ff8_vibrate_capability(int port)
 {
-	bool ret = false;
-
 	if (trace_all) ffnx_trace("%s port=%d\n", __func__, port);
 
 	return nxVibrationEngine.canRumble();
@@ -242,11 +241,78 @@ int ff8_set_vibration(const uint8_t *data, int set, int intensity)
 	return ret;
 }
 
+ff8_draw_menu_sprite_texture_infos *alternate_pause_battle(int a1, ff8_draw_menu_sprite_texture_infos *draw_infos)
+{
+	if (nxVibrationEngine.canRumble())
+	{
+		uint16_t keyon = *(uint16_t *)(*(int *)ff8_externals.battle_menu_state + 0x14);
+		uint8_t port = 0;
+		int vibrate_state = ((int(*)(uint8_t))ff8_externals.vibration_get_is_enabled)(port);
+
+		if ((keyon & 0xF060) != 0)
+		{
+			vibrate_state = uint8_t(-(vibrate_state != 255));
+			((void(*)(uint8_t,int))ff8_externals.vibration_set_is_enabled)(port, vibrate_state);
+		}
+
+		*ff8_externals.is_alternative_pause_menu = 1;
+		int previous_value = *ff8_externals.pause_menu_option_state;
+		*ff8_externals.pause_menu_option_state = vibrate_state;
+
+		ff8_draw_menu_sprite_texture_infos *ret = ((ff8_draw_menu_sprite_texture_infos*(*)(int,ff8_draw_menu_sprite_texture_infos*))ff8_externals.battle_pause_window_sub_4CD350)(a1, draw_infos);
+
+		// Reset values to prevent any issues outside the pause menu
+		*ff8_externals.is_alternative_pause_menu = 0;
+		*ff8_externals.pause_menu_option_state = previous_value;
+
+		return ret;
+	}
+
+	return ((ff8_draw_menu_sprite_texture_infos*(*)(int,ff8_draw_menu_sprite_texture_infos*))ff8_externals.battle_pause_window_sub_4CD350)(a1, draw_infos);
+}
+
+ff8_draw_menu_sprite_texture_infos *battle_pause_show_quit_game_text(int a1, ff8_draw_menu_sprite_texture_infos *draw_infos, int x, int y, uint8_t *text_data, int a6)
+{
+	// Replace to "Vibration"
+	return ((ff8_draw_menu_sprite_texture_infos*(*)(int,ff8_draw_menu_sprite_texture_infos*,int,int))ff8_externals.sub_4A7210)(a1, draw_infos, x, y);
+}
+
 void vibration_init()
 {
-	replace_call(uint32_t(ff8_externals.check_game_is_paused) + 0x88, ff8_game_is_paused);
 	replace_function(ff8_externals.get_vibration_capability, ff8_vibrate_capability);
 	replace_function(ff8_externals.vibration_apply, apply_vibrate_calc);
 	replace_function(ff8_externals.vibration_clear_intensity, noop_a1);
 	ff8_set_vibration_replace_id = replace_function(ff8_externals.set_vibration, ff8_set_vibration);
+
+	// Replace pause menus
+	replace_call(uint32_t(ff8_externals.check_game_is_paused) + 0x88, ff8_game_is_paused);
+	replace_call(ff8_externals.battle_pause_sub_4CD140 + (JP_VERSION ? 0x1F1 : 0x225), alternate_pause_battle);
+	replace_call(ff8_externals.battle_pause_window_sub_4CD350 + 0x8D, battle_pause_show_quit_game_text);
+
+	// Relocate menu_options_keymap_desc to make room for a new input line in menu_options_desc which is located right before
+	memcpy(menu_options_keymap_desc, ff8_externals.menu_config_input_desc_keymap, sizeof(menu_options_keymap_desc));
+	patch_code_dword(uint32_t(ff8_externals.menu_callbacks[8].func) + 0x110, DWORD(menu_options_keymap_desc));
+	patch_code_dword(uint32_t(ff8_externals.menu_callbacks[8].func) + 0x12E, DWORD(menu_options_keymap_desc));
+	patch_code_dword(ff8_externals.menu_config_controller + 0x84, DWORD(menu_options_keymap_desc));
+	patch_code_dword(ff8_externals.menu_config_controller + 0x92, DWORD(menu_options_keymap_desc));
+	patch_code_dword(ff8_externals.menu_config_controller + 0xD7, DWORD(menu_options_keymap_desc) + 4);
+	patch_code_dword(ff8_externals.menu_config_controller + 0x109, DWORD(menu_options_keymap_desc) + 3);
+	patch_code_dword(ff8_externals.menu_config_controller + 0x155, DWORD(menu_options_keymap_desc) + 1);
+	patch_code_dword(ff8_externals.menu_config_controller + 0x53A, DWORD(menu_options_keymap_desc) + 3);
+	patch_code_dword(ff8_externals.menu_config_controller + 0x5B1, DWORD(menu_options_keymap_desc) + 3);
+	patch_code_dword(ff8_externals.menu_config_controller + 0x67B, DWORD(menu_options_keymap_desc));
+	patch_code_dword(ff8_externals.menu_config_controller + 0x7A0, DWORD(menu_options_keymap_desc) + 3);
+	patch_code_dword(ff8_externals.menu_config_render_submenu + 0x13, DWORD(menu_options_keymap_desc));
+
+	// Add Vibration configuration line in main menu
+	ff8_externals.menu_config_input_desc[9].text_id_name = 0x0; // "Vibration"
+	ff8_externals.menu_config_input_desc[9].text_id_value1 = 0x2; // "OFF"
+	ff8_externals.menu_config_input_desc[9].text_id_value2 = 0x1; // "ON"
+	ff8_externals.menu_config_input_desc[9].type = 2; // Toggle switch (Vibration option specific)
+	ff8_externals.menu_config_input_desc[9].mask = 0x40; // Bit mask in the savemap entry
+	ff8_externals.menu_config_input_desc[9].value = 0; // Always initialized to zero, will change at runtime
+	ff8_externals.menu_config_input_desc[9].callback_change_state = (void(*)())ff8_externals.sub_4C2FF0; // Update structures
+	// End of configuration lines
+	ff8_externals.menu_config_input_desc[10] = ff8_menu_config_input();
+	ff8_externals.menu_config_input_desc[10].text_id_name = -1;
 }

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -185,6 +185,17 @@ void ff8_find_externals()
 	ff8_externals.battle_open_file = get_relative_call(ff8_externals.battle_open_file_wrapper, 0x14);
 	ff8_externals.battle_filenames = (char **)get_absolute_value(ff8_externals.battle_open_file, 0x11);
 
+	ff8_externals.sub_47D890 = get_relative_call(ff8_externals.sub_506CF0, 0x59);
+	ff8_externals.sub_4A94D0 = get_relative_call(ff8_externals.sub_47D890, 0x9);
+	ff8_externals.sub_4BCBE0 = get_relative_call(ff8_externals.sub_4A94D0, 0x1E0);
+	ff8_externals.sub_4C8B10 = get_relative_call(ff8_externals.sub_4BCBE0, 0x8E);
+	ff8_externals.battle_pause_sub_4CD140 = get_absolute_value(ff8_externals.sub_4C8B10, 0x3);
+	ff8_externals.battle_pause_window_sub_4CD350 = get_relative_call(ff8_externals.battle_pause_sub_4CD140, JP_VERSION ? 0x1F1 : 0x225);
+	ff8_externals.is_alternative_pause_menu = (uint32_t *)get_absolute_value(ff8_externals.battle_pause_window_sub_4CD350, 0x6B);
+	ff8_externals.pause_menu_option_state = (uint32_t *)get_absolute_value(ff8_externals.battle_pause_window_sub_4CD350, 0x9C);
+	ff8_externals.battle_menu_state = (void *)get_absolute_value(ff8_externals.battle_pause_window_sub_4CD350, 0x29);
+	ff8_externals.sub_4A7210 = get_relative_call(ff8_externals.battle_pause_window_sub_4CD350, 0xC3);
+
 	ff8_externals.battle_load_textures_sub_500900 = get_relative_call(ff8_externals.sub_47CCB0, 0x98D);
 	ff8_externals.loc_5005A0 = ff8_externals.battle_load_textures_sub_500900 + 0x9D + 0x4 + *((int32_t *)(ff8_externals.battle_load_textures_sub_500900 + 0x9D));
 	ff8_externals.battle_upload_texture_to_vram = get_relative_call(ff8_externals.loc_5005A0, 0xD1);
@@ -227,6 +238,8 @@ void ff8_find_externals()
 	ff8_externals.get_command_key = get_relative_call(ff8_externals.draw_controller_or_keyboard_icons, 0x31);
 	ff8_externals.sub_49BB30 = get_relative_call(ff8_externals.ff8_draw_icon_or_key1, 0xF6);
 	ff8_externals.vibration_apply = get_relative_call(uint32_t(ff8_externals.pause_menu_with_vibration), 0xB4);
+	ff8_externals.vibration_set_is_enabled = get_relative_call(uint32_t(ff8_externals.pause_menu_with_vibration), 0xF3);
+	ff8_externals.vibration_get_is_enabled = get_relative_call(uint32_t(ff8_externals.pause_menu_with_vibration), 0xA9);
 	ff8_externals.get_keyon = (int(*)(int, int))get_relative_call(uint32_t(ff8_externals.pause_menu_with_vibration), 0xC9);
 	ff8_externals.get_vibration_capability = get_relative_call(uint32_t(ff8_externals.pause_menu_with_vibration), 0xE3);
 	ff8_externals.vibrate_data_main = (uint8_t **)get_absolute_value(uint32_t(ff8_externals.pause_menu_with_vibration), 0x261);
@@ -374,9 +387,14 @@ void ff8_find_externals()
 	ff8_externals.sub_4B3140 = get_relative_call(ff8_externals.sub_4B3310, 0xC8);
 	ff8_externals.sub_4BDB30 = get_relative_call(ff8_externals.sub_4B3140, 0x4);
 	ff8_externals.menu_callbacks = (ff8_menu_callback *)get_absolute_value(ff8_externals.sub_4BDB30, 0x11);
+	ff8_externals.menu_config_render = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[8].func), 0x3);
+	ff8_externals.menu_config_render_submenu = get_relative_call(ff8_externals.menu_config_render, 0x101);
 	ff8_externals.menu_config_controller = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[8].func), 0x8);
+	ff8_externals.menu_config_input_desc = (ff8_menu_config_input *)get_absolute_value(uint32_t(ff8_externals.menu_callbacks[8].func), 0x39);
+	ff8_externals.menu_config_input_desc_keymap = (ff8_menu_config_input_keymap *)get_absolute_value(uint32_t(ff8_externals.menu_callbacks[8].func), 0x110);
 	ff8_externals.main_menu_render_sub_4E5550 = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[16].func), 0x3);
 	ff8_externals.main_menu_controller = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[16].func), 0x8);
+	ff8_externals.sub_4C2FF0 = get_relative_call(uint32_t(ff8_externals.menu_callbacks[16].func), 0x2B);
 	ff8_externals.menu_chocobo_world_controller = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[27].func), 0xB);
 	ff8_externals.create_save_file_sub_4C6E50 = get_relative_call(ff8_externals.main_menu_controller, JP_VERSION ? 0x1004 : 0xF8D);
 	ff8_externals.create_save_chocobo_world_file_sub_4C6620 = get_relative_call(ff8_externals.menu_chocobo_world_controller, 0x9F6);


### PR DESCRIPTION
## Summary

Bring back Vibration option in the main menu and the battle pause menu.

### Motivation

The vibration option was restored only in field and worldmap pause menus. Since it is common that user want to disable vibration in battle, it is great to restore the original pause menu in battle too.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8

## Images

_ePSXe french_
![ePSXe french](https://github.com/julianxhokaxhiu/FFNx/assets/8015696/46194511-3b70-4648-8c74-3288a041e1cb)
_FFNx french enabled_
![FFNx french enabled](https://github.com/julianxhokaxhiu/FFNx/assets/8015696/b2558710-8ddc-4643-8cba-a3514926d63d)
_FFNx french disabled (keyboard or gamepad without rumble capability)_
![FFNx french disabled](https://github.com/julianxhokaxhiu/FFNx/assets/8015696/b59be9d5-1f9f-4e52-bcb6-668f54ed0538)
