### PR TITLE
FF7: Fixed menu not working when using external worldmap mesh

### DIFF
--- a/src/ff7/world/player.cpp
+++ b/src/ff7/world/player.cpp
@@ -408,7 +408,7 @@ namespace ff7::world {
             {
                 if(player_model_id == HIGHWIND)
                     ff7_externals.world_run_special_opcode_7640BC(6);
-                else if(player_model_id & (CLOUD | TIFA | CID | BUGGY) && ff7_externals.world_get_player_walkmap_type() != 14)
+                else if((player_model_id ==  CLOUD || player_model_id ==  TIFA || player_model_id ==  CID || player_model_id == BUGGY) && ff7_externals.world_get_player_walkmap_type() != 14)
                 {
                     ff7_externals.world_set_camera_fade_speed_755B97(16);
                     ff7_externals.world_set_world_control_lock_74D438(0, 1);


### PR DESCRIPTION
## Summary

Fixed menu not working when using external worldmap mesh again because my previous fix was incorrect.

### Motivation

To fix my own mess

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
