### PR TITLE
FF7: Fixed not being able to place the flags during snowstorm

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,9 +9,9 @@
 ## FF7
 
 - Input: Fixed auto-run not working sometimes on diagonals ( https://github.com/julianxhokaxhiu/FFNx/pull/666 )
+- Input: Fixed not being able to place the flags during snowstorm ( https://github.com/julianxhokaxhiu/FFNx/pull/667 )
 - Renderer: Fixed menu not working when using external worldmap mesh ( https://github.com/julianxhokaxhiu/FFNx/pull/657 )
 - Widescreen: Fixed scripted camera clipping when widescreen enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/664 )
-- Input: Fixed not being able to place the flags during snowstorm ( https://github.com/julianxhokaxhiu/FFNx/pull/667 )
 
 ## FF8 Steam
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Input: Fixed auto-run not working sometimes on diagonals ( https://github.com/julianxhokaxhiu/FFNx/pull/666 )
 - Renderer: Fixed menu not working when using external worldmap mesh ( https://github.com/julianxhokaxhiu/FFNx/pull/657 )
 - Widescreen: Fixed scripted camera clipping when widescreen enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/664 )
+- Input: Fixed not being able to place the flags during snowstorm ( https://github.com/julianxhokaxhiu/FFNx/pull/667 )
 
 ## FF8 Steam
 

--- a/src/ff7/world/camera.cpp
+++ b/src/ff7/world/camera.cpp
@@ -43,7 +43,7 @@ namespace ff7::world
         {
             auto flag = current_key_input & ANY_DIRECTIONAL_KEY;
             int delta_camera_step = ff7_externals.world_snowstorm_get_camera_movement_758B12(flag,
-                                    !is_key_released(current_key_input, prev_key_input, CIRCLE));
+                                    !((current_key_input & CIRCLE) == 0 || (prev_key_input & CIRCLE) != 0));
             *ff7_externals.world_camera_front_DFC484 += delta_camera_step;
         }
         else
@@ -131,7 +131,7 @@ namespace ff7::world
                 camera.rotationOffset.y += 360;
             else if (diff < - 180)  camera.rotationOffset.y -= 360;
 
-            const float t = 0.1f * movement_multiplier;
+            const float t = 0.05f * movement_multiplier;
             camera.rotationOffset.y = (1.0f - t) * camera.rotationOffset.y + t * targetRotationY;
 
             *ff7_externals.world_camera_rotation_y_DFC474 = camera.rotationOffset.y * 4096.0f / 360.0f;
@@ -181,7 +181,7 @@ namespace ff7::world
             cameraStatusCounter++;
         }
 
-        const float t = 0.1f * movement_multiplier;     
+        const float t = 0.05f * movement_multiplier;     
         camera.rotationOffset.x = (1.0f - t) * camera.rotationOffset.x + t * targetRotationX;
 
         bx::Vec3 up = { 0, 1, 0 };

--- a/src/ff7/world/player.cpp
+++ b/src/ff7/world/player.cpp
@@ -188,7 +188,7 @@ namespace ff7::world {
                     }
                     else
                     {
-                        const float rotSpeedXMax = worldmap_type == UNDERWATER || player_model_id == SUBMARINE ? 24.0f : 32.0f;
+                        const float rotSpeedXMax = worldmap_type == UNDERWATER || player_model_id == SUBMARINE ? 24.0f : player_model_id == BUGGY ? 64.0f : 32.0f;
                         float rotSpeedX = 0.0f;
                         if (std::abs(joyDir.x) > 0.0)
                             rotSpeedX = rotSpeedXMax * joyDir.x / common_frame_multiplier;

--- a/src/ff7/world/world.cpp
+++ b/src/ff7/world/world.cpp
@@ -250,6 +250,7 @@ namespace ff7::world
             //if (enable_lighting)
             {
                 replace_call_function((uint32_t)ff7_externals.world_wm0_overworld_draw_all_74C179 + 0x13B, ff7::world::draw_shadow);
+                replace_call_function((uint32_t)ff7_externals.world_wm3_snowstorm_draw_all_74C589 + 0xB8, ff7::world::draw_shadow);
             }
         }
     }    


### PR DESCRIPTION
## Summary

Fixed not being able to place the flags during snowstorm. PR also includes some minor adjustments to worldmap controls and disables unintended shadow rendering in snowstorm map.

### Motivation

Because that part of the game is annoying enough already.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
