### PR TITLE
FF8: Fix texture animation only partially animated

### DIFF
--- a/misc/FF8.reg
+++ b/misc/FF8.reg
@@ -38,3 +38,11 @@ Windows Registry Editor Version 5.00
 
 [HKEY_CURRENT_USER\Software\Classes\VirtualStore\MACHINE\SOFTWARE\Wow6432Node\Square Soft, Inc\FINAL FANTASY VIII\1.00]
 "Graphics"=dword:00100021
+
+# Disable compatibility flags
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags]
+"{e1af58c2-e896-4640-bb34-d9fa0b8260a3}"=dword:00000077
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\AppCompatFlags]
+"{e1af58c2-e896-4640-bb34-d9fa0b8260a3}"=dword:00000077

--- a/src/ff8/mod.cpp
+++ b/src/ff8/mod.cpp
@@ -287,11 +287,13 @@ void ModdedTexture::copyRect(
 	int sourceXBpp2, int sourceY, int sourceWBpp2, int sourceH, int targetXBpp2, int targetY)
 {
 	int sourceX = sourceXBpp2 * (4 >> int(depth)),
-		sourceW = sourceWBpp2 * (4 >> int(depth)),
+		sourceW = sourceWBpp2 * (4 >> int(depth)) * scale,
 		targetX = targetXBpp2 * (4 >> int(depth));
 
 	const uint32_t *source = sourceRgba + (sourceX + sourceY * sourceRgbaW) * scale;
 	uint32_t *target = targetRgba + (targetX + targetY * targetRgbaW) * scale;
+
+	sourceH *= scale;
 
 	for (int y = 0; y < sourceH; ++y)
 	{

--- a/src/ff8/texture_packer.h
+++ b/src/ff8/texture_packer.h
@@ -163,7 +163,7 @@ public:
 		int palIndex, uint8_t *outScale, uint32_t **outTarget
 	) const;
 
-	static void debugSaveTexture(int textureId, const uint32_t *source, int w, int h, bool removeAlpha, bool after, TextureTypes textureType);
+	static void debugSaveTexture(int textureId, const uint32_t *source, int w, int h, bool removeAlpha = true, bool after = false, TextureTypes textureType = NoTexture);
 private:
 	inline static ModdedTextureId makeTextureId(int xBpp2, int y, bool isPal = false) {
 		return (xBpp2 + y * VRAM_WIDTH) | (isPal << 31);


### PR DESCRIPTION
## Summary

- When the external texture is upscaled (which is the common case), texture copy is not scaled up to the full size of the copy
- Adding some rules in the .reg file to allow alt+tab and windows key press (FF8 2000 only). It will ask Windows to disable all compatibility patches, which are not needed anyway with FFNx

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
