### PR TITLE
Music: Add new relative_speed option in the config layer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.18.1...master
 
+## Common
+
+- Music: Add new [relative_speed](https://github.com/julianxhokaxhiu/FFNx/blob/master/misc/FFNx.music.toml#L29-L31) option in the config layer ( https://github.com/julianxhokaxhiu/FFNx/pull/672 )
+
 ## FF8
 
 - Graphics: Fix texture animations by copy only partially animated ( https://github.com/julianxhokaxhiu/FFNx/pull/670 )

--- a/misc/FFNx.music.toml
+++ b/misc/FFNx.music.toml
@@ -25,6 +25,10 @@
 # -----------------------------------------------------------------------------
 # disabled: Set this flag to true to never play this music and act like it was
 # never triggered by the game.
+# -----------------------------------------------------------------------------
+# relative_speed: Set the music relative speed, with 1.0 is the normal speed,
+# between 0.0 and 1.0 (not included) the music is slowed down, and above 1.0
+# the music is sped up.
 ###############################################################################
 
 # This entry will shuffle "battle" with "battle2", "bossbat1" and "bossbat2".

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -624,6 +624,7 @@ void NxAudioEngine::overloadPlayArgumentsFromConfig(char* name, uint32_t* id, Mu
 	std::optional<SoLoud::time> offset_seconds_opt = config[name]["offset_seconds"].value<SoLoud::time>();
 	std::optional<std::string> no_intro_track_opt = config[name]["no_intro_track"].value<std::string>();
 	std::optional<SoLoud::time> intro_seconds_opt = config[name]["intro_seconds"].value<SoLoud::time>();
+	std::optional<float> relative_speed_opt = config[name]["relative_speed"].value<float>();
 
 	if (offset_seconds_opt.has_value()) {
 		musicOptions->offsetSeconds = *offset_seconds_opt;
@@ -651,6 +652,10 @@ void NxAudioEngine::overloadPlayArgumentsFromConfig(char* name, uint32_t* id, Mu
 		else {
 			ffnx_info("%s: cannot play no intro track, please configure it in %s/config.toml\n", __func__, external_music_path.c_str());
 		}
+	}
+
+	if (relative_speed_opt.has_value() && *relative_speed_opt > 0.0f) {
+		musicOptions->relativeSpeed = *relative_speed_opt;
 	}
 
 	// Shuffle Music playback, if any entry found for the current music name
@@ -720,6 +725,10 @@ bool NxAudioEngine::playMusic(const char* name, uint32_t id, int channel, MusicO
 		}
 		else if (options.fadetime > 0.0) {
 			setMusicVolume(music.wantedMusicVolume, channel, options.fadetime);
+		}
+
+		if (options.relativeSpeed > 0.0f && options.relativeSpeed != 1.0f) {
+			setMusicSpeed(options.relativeSpeed, channel);
 		}
 
 		return true;

--- a/src/audio.h
+++ b/src/audio.h
@@ -44,19 +44,21 @@ public:
 	{
 		MusicOptions() :
 			offsetSeconds(0.0),
+			fadetime(0.0),
+			targetVolume(-1.0f),
+			relativeSpeed(1.0f),
+			format(""),
 			noIntro(false),
 			sync(false),
 			useNameAsFullPath(false),
-			suppressOpeningSilence(false),
-			fadetime(0.0),
-			targetVolume(-1.0f),
-			format("")
+			suppressOpeningSilence(false)
 		{}
 		SoLoud::time offsetSeconds;
-		bool noIntro, sync, useNameAsFullPath, suppressOpeningSilence;
 		SoLoud::time fadetime;
 		float targetVolume;
+		float relativeSpeed;
 		char format[12];
+		bool noIntro, sync, useNameAsFullPath, suppressOpeningSilence;
 	};
 
 	struct NxAudioEngineSFX


### PR DESCRIPTION
## Summary

External Music: ability to set music speed via config

### Motivation

Kurodo asked me if it was possible to sync "tb" music track (main theme alternative / Cloud's mind) with the scene, like in PS1
https://www.youtube.com/watch?v=ELt0-heDj0I&t=20020s

The PC version is faster than the PSX version, one solution would be speed up the music. That's increase the pitch a little, I'm not a big fan of this solution. But everyone seems fine with it, for example the modder Postscriptthree released a fix that just does just that, DLPB also did this in the past.

Since this patch is really light, and can be used by modders for whetever creative reasons (I enjoy listening to the slow version of costa del sol, for example), so let's do it!

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
