### PR TITLE
FF8: Allow more external texture replacement for battle effects

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 ## FF8
 
 - Graphics: Fix texture animations by copy only partially animated ( https://github.com/julianxhokaxhiu/FFNx/pull/670 )
+- Graphics: Allow more external texture replacement for battle effects ( https://github.com/julianxhokaxhiu/FFNx/pull/674 )
 - SFX: Fix some external SFX effects that were not stopping when they were looped in certain scenes
 - Vibration: Added vibration option in the config menu and the battle pause menu ( https://github.com/julianxhokaxhiu/FFNx/pull/658 )
 

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1455,8 +1455,9 @@ struct ff8_externals
 	uint32_t sub_50A9A0;
 	uint32_t battle_read_effect_sub_50AF20;
 	DWORD* func_off_battle_effects_C81774;
+	int* battle_magic_id;
+	uint32_t sub_571870;
 	DWORD* func_off_battle_effect_textures_50AF93;
-	uint32_t battle_effect_quezacotl_sub_6C3550;
 	uint32_t sub_6C3640;
 	uint32_t sub_6C3760;
 	uint8_t **vibrate_data_summon_quezacotl;
@@ -1464,6 +1465,7 @@ struct ff8_externals
 	uint32_t load_magic_data_sub_5718E0;
 	uint32_t load_magic_data_sub_571900;
 	uint32_t sub_47D890;
+	uint32_t sub_505DF0;
 	uint32_t sub_4A94D0;
 	uint32_t sub_4BCBE0;
 	uint32_t sub_4C8B10;
@@ -1473,6 +1475,18 @@ struct ff8_externals
 	void *battle_menu_state;
 	uint32_t battle_pause_window_sub_4CD350;
 	uint32_t sub_4A7210;
+	uint32_t sub_B586F0;
+	uint32_t sub_B64B80;
+	DWORD* leviathan_funcs_B64C3C;
+	uint32_t mag_data_palette_sub_B66560;
+	DWORD** effect_struct_27973EC;
+	uint8_t** mag_data_dword_2798A68;
+	DWORD** effect_struct_2797624;
+	uint32_t sub_B63230;
+	uint32_t mag_data_texture_sub_B66560;
+	BYTE** dword_27973E8;
+	uint32_t battle_set_action_upload_raw_palette_sub_B666F0;
+	uint32_t battle_set_action_upload_raw_palette_sub_B66400;
 };
 
 void ff8gl_field_78(struct ff8_polygon_set *polygon_set, struct ff8_game_obj *game_object);

--- a/src/ff8/battle/effects.h
+++ b/src/ff8/battle/effects.h
@@ -1,0 +1,38 @@
+/****************************************************************************/
+//    Copyright (C) 2009 Aali132                                            //
+//    Copyright (C) 2018 quantumpencil                                      //
+//    Copyright (C) 2018 Maxime Bacoux                                      //
+//    Copyright (C) 2020 Chris Rizzitello                                   //
+//    Copyright (C) 2020 John Pritchard                                     //
+//    Copyright (C) 2024 myst6re                                            //
+//    Copyright (C) 2024 Julian Xhokaxhiu                                   //
+//    Copyright (C) 2023 Cosmos                                             //
+//    Copyright (C) 2023 Tang-Tang Zhou                                     //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#pragma once
+
+namespace FF8BattleEffect {
+    enum Effect {
+        Leviathan = 5,
+        Quezacotl = 115
+    };
+}
+
+namespace FF8BattleEffectOpcode {
+    enum Opcode {
+        UploadTexture39 = 39,
+        UploadPalette75 = 75
+    };
+}

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -23,6 +23,7 @@
 #include "ff8_data.h"
 
 #include "patch.h"
+#include "ff8/battle/effects.h"
 
 void ff8_set_main_loop(uint32_t driver_mode, uint32_t main_loop)
 {
@@ -186,6 +187,7 @@ void ff8_find_externals()
 	ff8_externals.battle_filenames = (char **)get_absolute_value(ff8_externals.battle_open_file, 0x11);
 
 	ff8_externals.sub_47D890 = get_relative_call(ff8_externals.sub_506CF0, 0x59);
+	ff8_externals.sub_505DF0 = get_relative_call(ff8_externals.sub_506CF0, 0xAA);
 	ff8_externals.sub_4A94D0 = get_relative_call(ff8_externals.sub_47D890, 0x9);
 	ff8_externals.sub_4BCBE0 = get_relative_call(ff8_externals.sub_4A94D0, 0x1E0);
 	ff8_externals.sub_4C8B10 = get_relative_call(ff8_externals.sub_4BCBE0, 0x8E);
@@ -769,12 +771,27 @@ void ff8_find_externals()
 	ff8_externals.sub_50A9A0 = get_absolute_value(ff8_externals.sub_50A790, 0x7C);
 	ff8_externals.battle_read_effect_sub_50AF20 = get_relative_call(ff8_externals.sub_50A9A0, 0xF4);
 	ff8_externals.func_off_battle_effects_C81774 = (DWORD*)get_absolute_value(ff8_externals.battle_read_effect_sub_50AF20, 0x2C);
+	ff8_externals.battle_magic_id = (int*)get_absolute_value(ff8_externals.battle_read_effect_sub_50AF20, 0x3E);
+	ff8_externals.sub_571870 = get_relative_call(ff8_externals.battle_read_effect_sub_50AF20, 0x63);
 	ff8_externals.func_off_battle_effect_textures_50AF93 = (DWORD*)get_absolute_value(ff8_externals.battle_read_effect_sub_50AF20, 0x6B);
 
-	ff8_externals.battle_effect_quezacotl_sub_6C3550 = ff8_externals.func_off_battle_effects_C81774[115];
-	ff8_externals.sub_6C3640 = get_relative_call(ff8_externals.battle_effect_quezacotl_sub_6C3550, 0x5);
+	ff8_externals.sub_6C3640 = get_relative_call(ff8_externals.func_off_battle_effects_C81774[FF8BattleEffect::Quezacotl], 0x5);
 	ff8_externals.sub_6C3760 = get_absolute_value(ff8_externals.sub_6C3640, 0x8B);
 	ff8_externals.vibrate_data_summon_quezacotl = (uint8_t **)get_absolute_value(ff8_externals.sub_6C3760, 0xB0);
+
+	ff8_externals.sub_B586F0 = get_absolute_value(ff8_externals.func_off_battle_effects_C81774[FF8BattleEffect::Leviathan], 0x45);
+	ff8_externals.sub_B64B80 = get_relative_call(ff8_externals.sub_B586F0, 0x1B5);
+	ff8_externals.leviathan_funcs_B64C3C = (DWORD *)get_absolute_value(ff8_externals.sub_B64B80, 0xBF);
+	ff8_externals.mag_data_palette_sub_B66560 = get_relative_call(ff8_externals.leviathan_funcs_B64C3C[FF8BattleEffectOpcode::UploadPalette75], 0x13);
+	ff8_externals.effect_struct_27973EC = (DWORD **)get_absolute_value(ff8_externals.mag_data_palette_sub_B66560, 0x4);
+	ff8_externals.mag_data_dword_2798A68 = (uint8_t **)get_absolute_value(ff8_externals.mag_data_palette_sub_B66560, 0x19);
+	ff8_externals.effect_struct_2797624 = (DWORD **)get_absolute_value(ff8_externals.mag_data_palette_sub_B66560, 0x28);
+	ff8_externals.battle_set_action_upload_raw_palette_sub_B666F0 = get_relative_call(ff8_externals.leviathan_funcs_B64C3C[FF8BattleEffectOpcode::UploadPalette75], 0xD4);
+	ff8_externals.battle_set_action_upload_raw_palette_sub_B66400 = get_relative_call(ff8_externals.battle_set_action_upload_raw_palette_sub_B666F0, 0x141);
+
+	ff8_externals.sub_B63230 = get_relative_call(ff8_externals.leviathan_funcs_B64C3C[FF8BattleEffectOpcode::UploadTexture39], 0x9);
+	ff8_externals.mag_data_texture_sub_B66560 = get_relative_call(ff8_externals.sub_B63230, 0xA);
+	ff8_externals.dword_27973E8 = (BYTE**)get_absolute_value(ff8_externals.mag_data_texture_sub_B66560, 0x8F);
 
 	ff8_externals.load_magic_data_sub_571B80 = get_relative_call(ff8_externals.func_off_battle_effect_textures_50AF93[0], 0x5);
 	ff8_externals.load_magic_data_sub_571900 = get_relative_call(ff8_externals.load_magic_data_sub_571B80, 0x1E);

--- a/src/image/tim.cpp
+++ b/src/image/tim.cpp
@@ -222,25 +222,47 @@ bool Tim::toRGBA32(uint32_t *target, PaletteDetectionStrategy *paletteDetectionS
 	{
 		if (_tim.pal_data == nullptr || paletteDetectionStrategy == nullptr)
 		{
-			ffnx_error("%s bpp 0 without palette\n", __func__);
+			uint8_t *img_data8 = _tim.img_data;
 
-			return false;
-		}
-
-		uint8_t *img_data = _tim.img_data;
-
-		for (int y = 0; y < _tim.img_h; ++y)
-		{
-			for (int x = 0; x < _tim.img_w / 2; ++x)
+			for (int y = 0; y < _tim.img_h; ++y)
 			{
-				*target = fromR5G5B5Color((_tim.pal_data + paletteDetectionStrategy->palOffset(x * 2, y))[*img_data & 0xF], withAlpha);
+				for (int x = 0; x < _tim.img_w / 2; ++x)
+				{
+					// Grey color
+					uint8_t color = (*img_data8 & 0xF) * 16;
 
-				++target;
+					*target = ((color == 0 && withAlpha ? 0x00 : 0xffu) << 24) |
+						(color << 16) | (color << 8) | color;
 
-				*target = fromR5G5B5Color((_tim.pal_data + paletteDetectionStrategy->palOffset(x * 2 + 1, y))[*img_data >> 4], withAlpha);
+					++target;
 
-				++target;
-				++img_data;
+					color = (*img_data8 >> 4) * 16;
+
+					*target = ((color == 0 && withAlpha ? 0x00 : 0xffu) << 24) |
+						(color << 16) | (color << 8) | color;
+
+					++target;
+					++img_data8;
+				}
+			}
+		}
+		else
+		{
+			uint8_t *img_data = _tim.img_data;
+
+			for (int y = 0; y < _tim.img_h; ++y)
+			{
+				for (int x = 0; x < _tim.img_w / 2; ++x)
+				{
+					*target = fromR5G5B5Color((_tim.pal_data + paletteDetectionStrategy->palOffset(x * 2, y))[*img_data & 0xF], withAlpha);
+
+					++target;
+
+					*target = fromR5G5B5Color((_tim.pal_data + paletteDetectionStrategy->palOffset(x * 2 + 1, y))[*img_data >> 4], withAlpha);
+
+					++target;
+					++img_data;
+				}
 			}
 		}
 	}
@@ -248,7 +270,7 @@ bool Tim::toRGBA32(uint32_t *target, PaletteDetectionStrategy *paletteDetectionS
 	{
 		if (_tim.pal_data == nullptr || paletteDetectionStrategy == nullptr)
 		{
-			uint8_t *img_data8 = (uint8_t *)_tim.img_data;
+			uint8_t *img_data8 = _tim.img_data;
 
 			for (int y = 0; y < _tim.img_h; ++y)
 			{


### PR DESCRIPTION
## Summary

We try to ensure textures are correctly named in battle
and some textures hidden in mag.0/mag.1... files are now replaceables.

Some of those textures may not be dumped correctly with "save_texture" option, I added some "guessed colors" dumps to help modders for now.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8 (FR, US, JP)
