### PR TITLE
FF8: Do not use hashes to name vibration config files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 - Graphics: Allow more external texture replacement for battle effects ( https://github.com/julianxhokaxhiu/FFNx/pull/674 )
 - SFX: Fix some external SFX effects that were not stopping when they were looped in certain scenes
 - Vibration: Added vibration option in the config menu and the battle pause menu ( https://github.com/julianxhokaxhiu/FFNx/pull/658 )
+- Vibration: do not rely on hashes anymore to identify vibration data ( https://github.com/julianxhokaxhiu/FFNx/pull/675 )
 
 ## FF8 2000
 

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1277,6 +1277,7 @@ struct ff8_externals
 	uint32_t opcode_moviesync;
 	uint32_t opcode_spuready;
 	uint32_t opcode_movieready;
+	uint32_t opcode_setvibrate;
 	uint32_t opcode_musicload;
 	uint32_t opcode_crossmusic;
 	uint32_t opcode_dualmusic;
@@ -1381,6 +1382,7 @@ struct ff8_externals
 	uint32_t open_battle_vibrate_vib;
 	uint8_t **vibrate_data_main;
 	uint8_t **vibrate_data_battle;
+	uint8_t *vibrate_data_field;
 	uint32_t sub_537F30;
 	uint32_t sub_5391B0;
 	uint32_t sub_534560;

--- a/src/ff8/battle/effects.h
+++ b/src/ff8/battle/effects.h
@@ -24,9 +24,41 @@
 #pragma once
 
 namespace FF8BattleEffect {
+    // See https://github.com/DarkShinryu/doomtrain/blob/master/Doomtrain/Resources/Magic_ID_List.txt
     enum Effect {
+        Cure = 0,
         Leviathan = 5,
-        Quezacotl = 115
+        Tonberry = 89,
+        Siren = 94,
+        Minimog = 95,
+        BokoChocofire = 96,
+        BokoChocoflare = 97,
+        BokoChocometeor = 98,
+        BokoChocobocle = 99,
+        Quezacotl = 115,
+        Phoenix = 139,
+        Ultima = 148,
+        Shiva = 184,
+        Odin = 186,
+        Doomtrain = 190,
+        Cactuar = 198,
+        Ifrit = 200,
+        Bahamut = 201,
+        Cerberus = 202,
+        Alexander = 203,
+        Brothers = 204,
+        Eden = 205,
+        Apocalypse = 220,
+        Meteor = 222,
+        Carbuncle = 277,
+        Pandemona = 290,
+        Diablos = 324,
+        GilgameshZantetsukenReverse = 325,
+        GilgameshZantetsuken = 326,
+        GilgameshMasamune = 327,
+        GilgameshExcaliber = 328,
+        GilgameshExcalipoor = 329,
+        Moomba = 337,
     };
 }
 

--- a/src/ff8/vibration.cpp
+++ b/src/ff8/vibration.cpp
@@ -26,7 +26,7 @@
 #include "../joystick.h"
 #include "../patch.h"
 #include "../vibration.h"
-#include <xxhash.h>
+#include "battle/effects.h"
 
 char vibrateName[32] = "";
 ff8_menu_config_input_keymap menu_options_keymap_desc[11];
@@ -92,28 +92,6 @@ const char *set_name(const char *name)
 	return strncpy(vibrateName, name, sizeof(vibrateName));
 }
 
-size_t vibrate_data_size(const uint8_t *data)
-{
-	const uint32_t *header = (const uint32_t *)data;
-	uint32_t max_pos = 0;
-
-	while (header - (const uint32_t *)data < 64) {
-		if (*header > max_pos) {
-			max_pos = *header;
-		}
-		header++;
-	}
-
-	if (max_pos == 0) {
-		return 0;
-	}
-
-	const uint16_t *it = (const uint16_t *)(data + max_pos);
-	uint16_t left_size = it[0], right_size = it[1];
-
-	return max_pos + 4 + left_size + right_size;
-}
-
 const char *vibrate_data_name(const uint8_t *data)
 {
 	if (trace_all || trace_gamepad) ffnx_trace("%s: data=0x%X\n", __func__, data);
@@ -133,81 +111,83 @@ const char *vibrate_data_name(const uint8_t *data)
 		return set_name("world");
 	}
 
-	size_t size = vibrate_data_size(data);
-	if (size == 0)
+	if (data == ff8_externals.vibrate_data_field)
+	{
+		return set_name("field");
+	}
+
+	if (getmode_cached()->driver_mode != MODE_BATTLE)
 	{
 		return nullptr;
 	}
 
-	XXH64_hash_t hash = XXH3_64bits(data, size);
-
-	if (trace_all || trace_gamepad) ffnx_trace("%s: hash=0x%llX\n", __func__, hash);
-
-	switch (hash)
+	switch (FF8BattleEffect::Effect(*ff8_externals.battle_magic_id))
 	{
-	case 0x3A8B11844E20E005:
-		return set_name("field");
-	case 0x12ED0CB959EE1D06:
+	case FF8BattleEffect::Quezacotl:
 		return set_name("battle_quezacotl");
-	case 0x5609D2CFA36FAA0A:
+	case FF8BattleEffect::Shiva:
 		return set_name("battle_shiva");
-	case 0xCEFDFB6A96824726:
+	case FF8BattleEffect::Ifrit:
 		return set_name("battle_ifrit");
-	case 0x453F6DFFE0C9349F:
+	case FF8BattleEffect::Siren:
 		return set_name("battle_siren");
-	case 0xEBD9E3F6260E3959:
+	case FF8BattleEffect::Brothers:
 		return set_name("battle_brothers");
-	case 0x9BFBB2F64D8D7481:
+	case FF8BattleEffect::Diablos:
 		return set_name("battle_diablos");
-	case 0xBB77D755D1E18AAE:
+	case FF8BattleEffect::Carbuncle:
 		return set_name("battle_carbuncle");
-	case 0x6CE5937D628A4A8C:
+	case FF8BattleEffect::Leviathan:
 		return set_name("battle_leviathan");
-	case 0x9FC2EA78F38A8DB2:
+	case FF8BattleEffect::Pandemona:
 		return set_name("battle_pandemona");
-	case 0xA0CB223A3095EF8E:
+	case FF8BattleEffect::Cerberus:
 		return set_name("battle_cerberus");
-	case 0x4618E0051D8EB26A:
+	case FF8BattleEffect::Alexander:
 		return set_name("battle_alexander");
-	case 0x8226A772A7F38BE3:
-		return set_name("battle_helltrain");
-	case 0xB0A0606DC821934F:
+	case FF8BattleEffect::Doomtrain:
+		return set_name("battle_doomtrain");
+	case FF8BattleEffect::Bahamut:
 		return set_name("battle_bahamut");
-	case 0x9B9C719D7B06C9F6:
+	case FF8BattleEffect::Cactuar:
 		return set_name("battle_cactuar");
-	case 0xC5C7EEC0C8CA65F0:
+	case FF8BattleEffect::Tonberry:
 		return set_name("battle_tonberry");
-	case 0x52E0D8894C20D609:
+	case FF8BattleEffect::Eden:
 		return set_name("battle_eden");
-	case 0x928D553922FE8248:
+	case FF8BattleEffect::Odin:
 		return set_name("battle_odin");
-	case 0x79AC9002E7CD9699:
+	case FF8BattleEffect::GilgameshZantetsuken:
 		return set_name("battle_gilgamesh_zantetsuken");
-	case 0x50BE9269B62CFD2E:
+	case FF8BattleEffect::GilgameshMasamune:
+		return set_name("battle_gilgamesh_masamune");
+	case FF8BattleEffect::GilgameshExcaliber:
+		return set_name("battle_gilgamesh_excaliber");
+	case FF8BattleEffect::GilgameshExcalipoor:
 		return set_name("battle_gilgamesh_excalipoor");
-	case 0x182DC6DE431B0B59:
+	case FF8BattleEffect::Phoenix:
 		return set_name("battle_phoenix");
-	case 0xFCF682172921F687:
+	case FF8BattleEffect::Moomba:
 		return set_name("battle_moomba");
-	case 0x2870C502E6C869CA:
+	case FF8BattleEffect::Minimog:
 		return set_name("battle_minimog");
-	case 0x34A36AEB4BDB2873:
+	case FF8BattleEffect::BokoChocofire:
 		return set_name("battle_boko_chocofire");
-	case 0x71C550B41E196BF5:
+	case FF8BattleEffect::BokoChocoflare:
 		return set_name("battle_boko_chocoflare");
-	case 0x58D0E469C7393C42:
+	case FF8BattleEffect::BokoChocometeor:
 		return set_name("battle_boko_chocometeor");
-	case 0x711807BEA87AE308:
+	case FF8BattleEffect::BokoChocobocle:
 		return set_name("battle_boko_chocobocle");
-	case 0x66A9AC8656CDA67E:
+	case FF8BattleEffect::Meteor:
 		return set_name("battle_meteor");
-	case 0x8CB04A5C704B20BB:
+	case FF8BattleEffect::Apocalypse:
 		return set_name("battle_apocalypse");
-	case 0xE443180422A17638:
+	case FF8BattleEffect::Ultima:
 		return set_name("battle_ultima");
 	}
 
-	snprintf(vibrateName, sizeof(vibrateName), "%llX", hash);
+	snprintf(vibrateName, sizeof(vibrateName), "battle_effect_%d", *ff8_externals.battle_magic_id);
 
 	return vibrateName;
 }

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -267,6 +267,7 @@ void ff8_find_externals()
 	ff8_externals.opcode_ames = common_externals.execute_opcode_table[0x65];
 	ff8_externals.opcode_battle = common_externals.execute_opcode_table[0x69];
 	ff8_externals.opcode_aask = common_externals.execute_opcode_table[0x6F];
+	ff8_externals.opcode_setvibrate = common_externals.execute_opcode_table[0xA1];
 	ff8_externals.opcode_movieready = common_externals.execute_opcode_table[0xA3];
 	ff8_externals.opcode_musicload = common_externals.execute_opcode_table[0xB5];
 	ff8_externals.opcode_crossmusic = common_externals.execute_opcode_table[0xBA];
@@ -282,6 +283,7 @@ void ff8_find_externals()
 	ff8_externals.opcode_getmusicoffset = common_externals.execute_opcode_table[0x16F];
 	ff8_externals.opcode_tuto = common_externals.execute_opcode_table[0x177];
 
+	ff8_externals.vibrate_data_field = (uint8_t*)get_absolute_value(ff8_externals.opcode_setvibrate, 0x27);
 	ff8_externals.current_tutorial_id = (BYTE*)get_absolute_value(ff8_externals.opcode_tuto, 0x2A);
 
 	common_externals.cross_fade_midi = get_relative_call(ff8_externals.opcode_crossmusic, 0x5C);


### PR DESCRIPTION
## Summary

Use the current magic id to identify battle vibrate sequences

### Breaking change

Vibration config file are not named with hashes anymore, but with the magic id like this:

```
battle_effect_{magicID}.toml
```



### Motivation

There are several pools of vibration sequences:
- the common one (for the pause menu)
- the field one (for setvibrate opcode)
- the world one (for vehicles)
- and a lot for battle effects

Before this PR I wasn't able to identify which battle effect is linked to which vibrate pool.
So I used hashes over the data to identify most of them.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
