### PR TITLE
FF8: Battle effects external textures improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@
 ## FF8
 
 - Graphics: Fix texture animations by copy only partially animated ( https://github.com/julianxhokaxhiu/FFNx/pull/670 )
-- Graphics: Allow more external texture replacement for battle effects ( https://github.com/julianxhokaxhiu/FFNx/pull/674 )
+- Graphics: Allow more external texture replacement for battle effects ( https://github.com/julianxhokaxhiu/FFNx/pull/674 https://github.com/julianxhokaxhiu/FFNx/pull/676 )
 - SFX: Fix some external SFX effects that were not stopping when they were looped in certain scenes
 - Vibration: Added vibration option in the config menu and the battle pause menu ( https://github.com/julianxhokaxhiu/FFNx/pull/658 )
 - Vibration: do not rely on hashes anymore to identify vibration data ( https://github.com/julianxhokaxhiu/FFNx/pull/675 )


### PR DESCRIPTION
## Summary

Some effects still have issues to get overriden correctly.

- Doomtrain (and maybe some others): first texture is not named correctly, we use the filename of the last loaded weapon
- Cerberus/Cactuar (and maybe some others): some textures are not dumped, because we don't have any palette 
- Carbuncle: We assumed that a tim file contains only one texture, that's not the case for Carbuncle
- Effect Tims with multiple palettes: dump all the palettes

### Motivation

To please digixu

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
