### PR TITLE
FF8: Magic textures wrongly dumped when save_textures option is disabled

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@
 
 - Core: Expose current Wine and Proton version as well in the log, if detected.
 
+## FF8
+
+- **Important:** If you have installed [FFNx-v1.19.0.0](https://github.com/julianxhokaxhiu/FFNx/releases/tag/1.19.0), please remove the directories `mods/Textures/battle` and `mods/Textures/magic` and reinstall your battle mods if you had any. A lots of PNG textures has been wrongly dumped into those directories ( https://github.com/julianxhokaxhiu/FFNx/pull/685 )
+- Rendering: Do not dump any textures if save_textures flag is false ( https://github.com/julianxhokaxhiu/FFNx/pull/685 )
+
 # 1.19.0
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.18.1...1.19.0

--- a/src/saveload.cpp
+++ b/src/saveload.cpp
@@ -76,6 +76,12 @@ void save_texture(const void *data, uint32_t dataSize, uint32_t width, uint32_t 
 	char filename[sizeof(basedir) + 1024];
 	uint64_t hash;
 
+	if (!save_textures) {
+		ffnx_warning("Save texture skipped because the option \"save_textures\" is disabled (name=%s).\n", name);
+
+		return;
+	}
+
 	if (is_animated)
 	{
 		char xxhash_filename[sizeof(basedir) + 1024];


### PR DESCRIPTION
## Summary

Magic textures wrongly dumped when save_textures option is disabled.

**Important:** If you have installed [FFNx-v1.19.0.0](https://github.com/julianxhokaxhiu/FFNx/releases/tag/1.19.0), please remove the directories `mods/Textures/battle` and `mods/Textures/magic` and reinstall your battle mods if you had any.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
