### PR TITLE
FF8: Fix game over crash with external textures

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 
 - **Important:** If you have installed [FFNx-v1.19.0.0](https://github.com/julianxhokaxhiu/FFNx/releases/tag/1.19.0), please remove the directories `mods/Textures/battle` and `mods/Textures/magic` and reinstall your battle mods if you had any. A lots of PNG textures has been wrongly dumped into those directories ( https://github.com/julianxhokaxhiu/FFNx/pull/685 )
 - Rendering: Do not dump any textures if save_textures flag is false ( https://github.com/julianxhokaxhiu/FFNx/pull/685 )
+- Rendering: Fix game over crash with external texture ( https://github.com/julianxhokaxhiu/FFNx/pull/686 )
 
 # 1.19.0
 

--- a/src/image/image.cpp
+++ b/src/image/image.cpp
@@ -118,10 +118,18 @@ bool loadPng(const char *filename, bimg::ImageMip &mip, bimg::TextureFormat::Enu
     _width = png_get_image_width(png_ptr, info_ptr);
     _height = png_get_image_height(png_ptr, info_ptr);
 
+    if (color_type == PNG_COLOR_TYPE_RGB && (targetFormat == bimg::TextureFormat::BGRA8 || targetFormat == bimg::TextureFormat::RGBA8)) {
+        ffnx_warning("%s: PNG files without alpha is not supported, please convert it to RGBA for improved performance\n", __func__);
+
+        return false;
+    }
+
     rowptrs = png_get_rows(png_ptr, info_ptr);
     rowbytes = png_get_rowbytes(png_ptr, info_ptr);
 
     datasize = rowbytes * _height;
+
+    if (trace_all || trace_loaders) ffnx_trace("%s: data_size=%d width=%d height=%d bit_depth=%d color_type=%X\n", __func__, datasize, _width, _height, bit_depth, color_type);
 
     if (!Renderer::doesItFitInMemory(datasize))
     {


### PR DESCRIPTION
## Summary

Ignore PNGs without alpha (for now)

### Motivation

Converting PNGs adds a little overhead, it is not big, but we don't want to promote PNGs in mods

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
