### PR TITLE
FF8: Allow mod textures per VRAM page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,12 @@
 ## FF8
 
 - Audio: Add ambient layer support for Fields and Battles
+- External textures: Add support for modding VRAM pages directly, like Tonberry Mods does, see [documentation](https://github.com/julianxhokaxhiu/FFNx/blob/master/docs/ff8/mods/external_textures.md) ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
+- External textures: Fix filename lookup which can match more textures than it should in a VRAM page ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
+- External textures: Split `battle/A8DEF.TIM` into three files to avoid redundant textures ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
+- Rendering: Avoid texture reupload in case of palette swap ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
+- Rendering: Fix texture unload when multiple palettes are written ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
+- Rendering: Prevent the game from sending textures with half-alpha colors ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 
 
 # 1.19.1

--- a/docs/ff8/mods/external_textures.md
+++ b/docs/ff8/mods/external_textures.md
@@ -4,8 +4,28 @@ Texture names pattern in FF8 mostly follows the paths used in FS/FL/FI archives 
 
 It is recommended to use uncompressed DDS for improved loading times.
 
-Except for the Menu module, you can add the language at the beginning of the path for localization:
+There are two types of override:
+- By texture: the easiest for modders, but with a little loading penalty
+- By VRAM page: the fastest, but textures are split into chunks of 256x256, and animation are more difficult to handle
+
+The menu module is only available by VRAM page, since source textures are already splitted by VRAM page,
+the game pass thoses textures directly to the GPU.
+
+If you mod __by texture__, file names look like this:<br>
+`{mod_path}\cardgame\cards_{palette index}.dds` (palette index is zero padded)<br>
+If not specified, the game will always fallback to the path with palette index equals to 00:<br>
+`{mod_path}\cardgame\cards_00.dds`<br>
+You can add the language at the beginning of the path for localization:<br>
 `{mod_path}\fre\cardgame\cards_00.dds`
+
+If you mod __by VRAM page__, file names look like this:<br>
+`{mod_path}\cardgame\cards_{relative vram page}_{palette x}_{palette y}.dds`<br>
+If a texture is not found, the game will always fallback to the path with zeroed palette x and palette y:<br>
+`{mod_path}\cardgame\cards_{relative vram page}_0_0.dds`
+
+When there are both files for the two types of mods, the VRAM page image takes priority over the other one.
+
+Again, use [`trace_loaders`](../../mods/external_textures.md) option to see in the logs the paths the game try to lookup.
 
 ## Triple Triad
 

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -438,8 +438,8 @@ struct ff7_tex_header
 	unsigned char *old_palette_data;
 	uint32_t field_DC;
 	uint32_t field_E0;
-	uint32_t field_E4;
-	uint32_t field_E8;
+	uint32_t *vram_positions;
+	uint32_t y;
 };
 
 struct ff7_texture_set

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -334,7 +334,7 @@ struct ff8_tex_header
 	unsigned char *old_palette_data;
 	uint32_t field_DC;
 	uint32_t field_E0;
-	uint32_t x;
+	uint32_t *vram_positions;
 	uint32_t y;
 };
 
@@ -1055,6 +1055,8 @@ struct ff8_externals
 	uint32_t field_main_loop;
 	uint32_t field_main_exit;
 	uint32_t psxvram_texture_pages_free;
+	uint32_t psxvram_texture_page_free;
+	uint32_t psxvram_texture_page_tex_header_free;
 	uint32_t engine_set_init_time;
 	uint32_t sub_4672C0;
 	uint32_t sub_471F70;

--- a/src/ff8/texture_packer.h
+++ b/src/ff8/texture_packer.h
@@ -79,6 +79,7 @@ public:
 		inline bool hasMultiBpp() const {
 			return _multiBpp;
 		}
+		int vramId() const;
 	private:
 		int _x, _y;
 		int _w, _h;
@@ -154,7 +155,7 @@ public:
 	void clearTextures();
 	// Returns the textures matching the tiledTex
 	std::list<IdentifiedTexture> matchTextures(const TiledTex &tiledTex, bool withModsOnly = false) const;
-	void registerTiledTex(const uint8_t *texData, int x, int y, int w, int h, Tim::Bpp bpp, int palX = -1, int palY = -1);
+	const TiledTex &registerTiledTex(const uint8_t *texData, int xBpp2, int y, int pixelW, int h, Tim::Bpp sourceBpp, int palX = -1, int palY = -1);
 	void registerPaletteWrite(const uint8_t *texData, int palIndex, int palX, int palY);
 	TiledTex getTiledTex(const uint8_t *texData) const;
 

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -138,6 +138,8 @@ void ff8_find_externals()
 
 	ff8_externals.psxvram_texture_pages_free = get_relative_call(ff8_externals.field_main_exit, 0x58);
 	ff8_externals.sub_4672C0 = get_relative_call(ff8_externals.psxvram_texture_pages_free, 0x5A);
+	ff8_externals.psxvram_texture_page_free = get_relative_call(ff8_externals.psxvram_texture_pages_free, 0x21);
+	ff8_externals.psxvram_texture_page_tex_header_free = get_relative_call(ff8_externals.psxvram_texture_page_free, 0x98);
 	ff8_externals.engine_set_init_time = get_relative_call(ff8_externals.battle_enter, 0x35);
 
 	common_externals.debug_print2 = get_relative_call(uint32_t(ff8_externals.sm_pc_read), 0x16);

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -1079,6 +1079,8 @@ void ff8_init_hooks(struct game_obj *_game_object)
 
 	// Fix blue color in battle with fire spells
 	patch_code_byte(ff8_externals.read_vram_palette_sub_467370 + 0x6F, 0);
+	// Fix half alpha for palettes
+	patch_code_byte(ff8_externals.read_vram_palette_sub_467370 + 0x64, 0xFF);
 
 	// #####################
 	// battle toggle

--- a/src/image/tim.cpp
+++ b/src/image/tim.cpp
@@ -60,8 +60,8 @@ bool operator<(const TimRect &rect, const TimRect &other)
 	return ((uint64_t(rect.palIndex) << 56) | (uint64_t(rect.x1) << 28) | uint64_t(rect.y1)) < ((uint64_t(other.palIndex) << 56) | (uint64_t(other.x1) << 28) | uint64_t(other.y1));
 }
 
-Tim::Tim(Bpp bpp, const ff8_tim &tim) :
-	_bpp(bpp), _tim(tim)
+Tim::Tim(Bpp bpp, const ff8_tim &tim, int lineSkip) :
+	_bpp(bpp), _tim(tim), _lineSkip(lineSkip)
 {
 	_tim.img_w *= 4 >> int(bpp);
 }
@@ -244,6 +244,8 @@ bool Tim::toRGBA32(uint32_t *target, PaletteDetectionStrategy *paletteDetectionS
 					++target;
 					++img_data8;
 				}
+
+				img_data8 += _lineSkip / 2;
 			}
 		}
 		else
@@ -263,6 +265,8 @@ bool Tim::toRGBA32(uint32_t *target, PaletteDetectionStrategy *paletteDetectionS
 					++target;
 					++img_data;
 				}
+
+				img_data += _lineSkip / 2;
 			}
 		}
 	}
@@ -283,6 +287,8 @@ bool Tim::toRGBA32(uint32_t *target, PaletteDetectionStrategy *paletteDetectionS
 					++target;
 					++img_data8;
 				}
+
+				img_data8 += _lineSkip;
 			}
 		}
 		else
@@ -298,6 +304,8 @@ bool Tim::toRGBA32(uint32_t *target, PaletteDetectionStrategy *paletteDetectionS
 					++target;
 					++img_data;
 				}
+
+				img_data += _lineSkip;
 			}
 		}
 	}
@@ -314,6 +322,8 @@ bool Tim::toRGBA32(uint32_t *target, PaletteDetectionStrategy *paletteDetectionS
 				++target;
 				++img_data16;
 			}
+
+			img_data16 += _lineSkip;
 		}
 	}
 	else
@@ -324,6 +334,23 @@ bool Tim::toRGBA32(uint32_t *target, PaletteDetectionStrategy *paletteDetectionS
 	}
 
 	return true;
+}
+
+Tim Tim::chunk(int x, int y, int w, int h)
+{
+	ff8_tim infos = ff8_tim();
+	infos.img_data = _tim.img_data + (x + y * imageWidth()) * 2;
+	infos.img_x = _tim.img_x + x;
+	infos.img_y = _tim.img_y + y;
+	infos.img_w = w;
+	infos.img_h = h;
+	infos.pal_data = _tim.pal_data;
+	infos.pal_x = _tim.pal_x;
+	infos.pal_y = _tim.pal_y;
+	infos.pal_w = _tim.pal_w;
+	infos.pal_h = _tim.pal_h;
+
+	return Tim(_bpp, infos, _tim.img_w - w * (4 >> int(_bpp)));
 }
 
 bool Tim::save(const char *fileName, PaletteDetectionStrategy *paletteDetectionStrategy, bool withAlpha, int forcePaletteId) const

--- a/src/image/tim.h
+++ b/src/image/tim.h
@@ -115,7 +115,7 @@ public:
 		Bpp16 = 2
 	};
 
-	Tim(Bpp bpp, const ff8_tim &tim);
+	Tim(Bpp bpp, const ff8_tim &tim, int lineSkip = 0);
 	uint16_t colorsPerPal() const;
 	inline Bpp bpp() const {
 		return _bpp;
@@ -170,6 +170,7 @@ public:
 		uint32_t *target, const std::vector<TimRect> &rectangles,
 		bool withAlpha = false
 	) const;
+	Tim chunk(int x, int y, int w, int h);
 	static Tim fromLzsData(const uint8_t *uncompressed_data);
 	static Tim fromTimData(const uint8_t *data);
 private:
@@ -177,4 +178,5 @@ private:
 	bool toRGBA32(uint32_t *target, PaletteDetectionStrategy *paletteDetectionStrategy, bool withAlpha) const;
 	ff8_tim _tim;
 	Bpp _bpp;
+	int _lineSkip;
 };


### PR DESCRIPTION
## Summary

Allow mod textures per VRAM page. This is like how [Tonberry](https://forums.qhimm.com/index.php?topic=15945.0) works, but no hashes needed.

File name format: the vram page id is added and if there are several textures in the vram page, most of them are put in the filename `{texture_names}_{vram page id}_{palette x}_{palette y}`
Example: `A0STG101.X-0_16_0_255`

### Motivation

Even if VRAM pages are fragmented and can contains several unrelated textures, they could be useful for modders.

- They are GPU accelerated, meaning that DDS files are uncompressed on the GPU without blocking the CPU
- Some part of some big textures could be reduced in size, especialy in battle where some VRAM pages are animated, and other not
- A lot of existing mods could be ported easily to FFNx

### Remaining Issues

- [X] Palette index can change for the same texture in FF8. Override texture by palette index is possible but can lead to glitches in battle or worldmap => fixed by using palette coordinates in vram instead
- [ ] File names could colide if several textures were found, because I choose to truncate the filename if it is too big
- [ ] I only use texture file names to compose the vram page file name, so if textures are in several different directories, I use the first directory name as a directory for the vram page file
- [ ] Field background is not stable, prefer use the tonberry compatibility layer

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
