### PR TITLE
Common: Bilinear filtering + external texture optimizations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,11 +6,13 @@
 
 - Audio: Fix bug that won't allow to configure vanilla SFX IDs using the `sfx/config.toml` file
 - Audio: Fix bug where overriding only fade flags in `ambient/config.toml` would not allow the ambient audio file to be loaded
+- External textures: Reuse already loaded textures on fallback to palette 0 ( https://github.com/julianxhokaxhiu/FFNx/pull/692 )
+- Rendering: Add bilinear filtering option `enable_bilinear` ( https://github.com/julianxhokaxhiu/FFNx/pull/692 )
 
 ## FF8
 
 - Audio: Add ambient layer support for Fields and Battles
-- External textures: Add support for modding VRAM pages directly, like Tonberry Mods does, see [documentation](https://github.com/julianxhokaxhiu/FFNx/blob/master/docs/ff8/mods/external_textures.md) ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
+- External textures: Add support for modding VRAM pages directly, like Tonberry Mods does, see [documentation](https://github.com/julianxhokaxhiu/FFNx/blob/master/docs/ff8/mods/external_textures.md) ( https://github.com/julianxhokaxhiu/FFNx/pull/687 https://github.com/julianxhokaxhiu/FFNx/pull/692 )
 - External textures: Fix filename lookup which can match more textures than it should in a VRAM page ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - External textures: Split `battle/A8DEF.TIM` into three files to avoid redundant textures ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - Rendering: Avoid texture reupload in case of palette swap ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )

--- a/docs/ff8/mods/external_textures.md
+++ b/docs/ff8/mods/external_textures.md
@@ -144,8 +144,9 @@ Some mobile models.
 Path: `{mod_path}\world\dat\texl\texture{texture number}_00`
 
 High res version of `wmset\section38\texture{0,7}_00`. Will be loaded by the game as you travel the worldmap.
-Ideally, for a smooth experience, keep `wmset\section38\texture{0,7}_00` texture resolution
-low (and uncompressed DDS) and increase the resolution in the texl directory.
+
+**Note:** Ideally, for a smooth experience, do not use texl, instead use `world\dat\wmset\section38\texture0_texture1_16_0_0.dds`
+which is GPU accelerated.
 
 ### chara.one
 
@@ -158,7 +159,7 @@ Path: `{mod_path}\world\esk\chara_one\model{model number}-{texture number}_00`
 | model2-0_00 -> model3-1_00 | Chocobos         |
 | model4-0_00 -> model4-1_00 | Squall (Student) |
 | model5-0_00 -> model5-1_00 | Zell             |
-| model6-0_00 -> model6-1_00 | Selphie (unused) |
+| model6-0_00 -> model6-1_00 | Selphie          |
 
 ## Menu
 

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -85,6 +85,11 @@ enable_antialiasing = 0
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 enable_anisotropic = true
 
+#[BILINEAR]
+# Enable bilinear filtering on 3D textures. For FF7, textures in menu are also filtered.
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+enable_bilinear = false
+
 #[LIGHTING]
 # Enable advanced lighting mode with real-time shadows.
 # NOTICE: Parameters such as light direction and color can be edited on the lighting debug window in the FFNx DevTools.

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -89,6 +89,7 @@ bool enable_vsync;
 bool mdef_fix;
 long enable_antialiasing;
 bool enable_anisotropic;
+bool enable_bilinear;
 bool enable_lighting;
 bool prefer_lighting_cpu_calculations;
 long game_lighting;
@@ -246,6 +247,7 @@ void read_cfg()
 	mdef_fix = config["mdef_fix"].value_or(true);
 	enable_antialiasing = config["enable_antialiasing"].value_or(0);
 	enable_anisotropic = config["enable_anisotropic"].value_or(true);
+	enable_bilinear = config["enable_bilinear"].value_or(false);
 	enable_lighting = config["enable_lighting"].value_or(false);
 	prefer_lighting_cpu_calculations = config["prefer_lighting_cpu_calculations"].value_or(true);
 	game_lighting = config["game_lighting"].value_or(GAME_LIGHTING_PER_VERTEX);

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -106,6 +106,7 @@ extern bool enable_vsync;
 extern bool mdef_fix;
 extern long enable_antialiasing;
 extern bool enable_anisotropic;
+extern bool enable_bilinear;
 extern bool enable_lighting;
 extern bool prefer_lighting_cpu_calculations;
 extern long game_lighting;

--- a/src/ff8/mod.h
+++ b/src/ff8/mod.h
@@ -80,8 +80,8 @@ public:
 		uint32_t *targetRgba, int targetW, int targetH, uint8_t targetScale, Tim::Bpp targetBpp,
 		int16_t paletteVramX, int16_t paletteVramY
 	) const=0;
-protected:
 	static bool findExternalTexture(const char *name, char *outFilename, uint8_t palette_index, bool hasPal, const char *extension = nullptr, char *foundExtension = nullptr);
+protected:
 	static void drawImage(
 		const uint32_t *sourceRgba, int sourceRgbaW, uint8_t sourceScale,
 		uint32_t *targetRgba, int targetRgbaW, uint8_t targetScale,
@@ -98,7 +98,7 @@ protected:
 	}
 private:
 	TexturePacker::IdentifiedTexture _originalTexture;
-	bool _isInternal;
+	bool _isInternal, _isFlushed;
 };
 
 class TextureModStandard : public ModdedTexture {
@@ -134,13 +134,12 @@ class TextureBackground : public ModdedTexture {
 public:
 	TextureBackground(
 		const TexturePacker::IdentifiedTexture &originalTexture,
-		const std::vector<Tile> &mapTiles,
-		int vramPageId
+		const std::vector<Tile> &mapTiles
 	);
 	TextureBackground(const TextureBackground &other) = delete;
 	~TextureBackground();
 	bool isBpp(Tim::Bpp bpp) const override;
-	uint8_t scale(int vramPalXBpp2, int vramPalY) const override {
+	inline uint8_t scale(int vramPalXBpp2, int vramPalY) const override {
 		return _texture.scale();
 	}
 	bool createImages(const char *extension = nullptr, char *foundExtension = nullptr);
@@ -153,7 +152,6 @@ private:
 	std::vector<Tile> _mapTiles;
 	std::unordered_multimap<uint16_t, size_t> _tileIdsByTextureId;
 	TextureImage _texture;
-	int _vramPageId;
 	uint8_t _colsCount, _usedBpps;
 };
 
@@ -167,7 +165,7 @@ struct TextureRawImage : public ModdedTexture {
 	inline bool isValid() const {
 		return _scale != 0;
 	}
-	uint8_t scale(int vramPalXBpp2, int vramPalY) const override {
+	inline uint8_t scale(int vramPalXBpp2, int vramPalY) const override {
 		return _scale;
 	}
 	TexturePacker::TextureTypes drawToImage(

--- a/src/ff8/texture_packer.h
+++ b/src/ff8/texture_packer.h
@@ -140,15 +140,14 @@ public:
 	enum TextureTypes {
 		NoTexture = 0,
 		ExternalTexture = 1,
-		InternalTexture = 2,
-		RemoveTexture = 4
+		InternalTexture = 2
 	};
 
 	explicit TexturePacker();
 	bool setTexture(const char *name, const TextureInfos &texture, const TextureInfos &palette = TextureInfos(), int textureCount = -1, bool clearOldTexture = true);
-	bool setTextureBackground(const char *name, int x, int y, int w, int h, const std::vector<Tile> &mapTiles, int bgTexId = -1, const char *extension = nullptr, char *found_extension = nullptr);
+	bool setTextureBackground(const char *name, int x, int y, int w, int h, const std::vector<Tile> &mapTiles, const char *extension = nullptr, char *found_extension = nullptr);
 	// Override a part of the VRAM from another part of the VRAM, typically with biggest textures (Worldmap)
-	void setTextureRedirection(const char *name, const TextureInfos &oldTexture, const TextureInfos &newTexture, const Tim &tim);
+	bool setTextureRedirection(const char *name, const TextureInfos &oldTexture, const TextureInfos &newTexture, const Tim &tim);
 	void animateTextureByCopy(int sourceXBpp2, int y, int sourceWBpp2, int sourceH, int targetXBpp2, int targetY);
 	void forceCurrentPalette(int xBpp2, int y, int8_t paletteId);
 	void clearTiledTexs();
@@ -159,9 +158,9 @@ public:
 	void registerPaletteWrite(const uint8_t *texData, int palIndex, int palX, int palY);
 	TiledTex getTiledTex(const uint8_t *texData) const;
 
-	TextureTypes drawTextures(
-		const uint8_t *texData, uint32_t *rgbaImageData, uint32_t dataSize, int originalW, int originalH,
-		int palIndex, uint8_t *outScale, uint32_t **outTarget
+	uint32_t composeTextures(
+		const uint8_t *texData, uint32_t *rgbaImageData, int originalW, int originalH,
+		int palIndex, uint32_t* width, uint32_t* height, struct gl_texture_set* gl_set, bool *isExternal
 	) const;
 
 	static void debugSaveTexture(int textureId, const uint32_t *source, int w, int h, bool removeAlpha = true, bool after = false, TextureTypes textureType = NoTexture);

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -1077,11 +1077,6 @@ void ff8_init_hooks(struct game_obj *_game_object)
 		patch_code_byte(ff8_externals.worldmap_alter_uv_sub_553B40 + 0x234, 0);
 	}
 
-	// Fix blue color in battle with fire spells
-	patch_code_byte(ff8_externals.read_vram_palette_sub_467370 + 0x6F, 0);
-	// Fix half alpha for palettes
-	patch_code_byte(ff8_externals.read_vram_palette_sub_467370 + 0x64, 0xFF);
-
 	// #####################
 	// battle toggle
 	// #####################

--- a/src/gl.h
+++ b/src/gl.h
@@ -99,6 +99,7 @@ struct gl_texture_set
 	uint32_t force_filter;
 	uint32_t force_zsort;
 	uint32_t disable_lighting;
+	uint32_t default_texture_id;
 	// ANIMATED TEXTURES
 	uint32_t is_animated;
 	std::map<std::string, uint32_t> animated_textures;

--- a/src/gl/special_case.cpp
+++ b/src/gl/special_case.cpp
@@ -55,7 +55,8 @@ uint32_t gl_special_case(uint32_t primitivetype, uint32_t vertextype, struct nve
 	if(current_state.texture_set && VREF(texture_set, ogl.gl_set->force_filter) && VREF(texture_set, ogl.external)) current_state.texture_filter = true;
 
 	// Texture filtering mostly does not work well in FF8
-	if(ff8) current_state.texture_filter = false;
+	if(ff8) current_state.texture_filter = enable_bilinear && vertextype != TLVERTEX && current_state.texture_set;
+	else if (enable_bilinear && (vertextype != TLVERTEX || mode == MODE_MENU || (current_state.texture_set && VREF(texture_set, ogl.gl_set->force_filter)))) current_state.texture_filter = true;
 
 	// some modpath textures have z-sort forced on
 	if(current_state.texture_set && VREF(texture_set, ogl.gl_set->force_zsort) && VREF(texture_set, ogl.external)) defer = true;

--- a/src/saveload.cpp
+++ b/src/saveload.cpp
@@ -92,7 +92,7 @@ void save_texture(const void *data, uint32_t dataSize, uint32_t width, uint32_t 
 	{
 		_snprintf(filename, sizeof(filename), "%s/%s/%s.png", basedir, mod_path.c_str(), name);
 	}
-	else if ((palette_index & 0xC0000000) == 0xC0000000)
+	else if (palette_index & 0x40000000)
 	{
 		_snprintf(filename, sizeof(filename), "%s/%s/%s_%u_%u.png", basedir, mod_path.c_str(), name, (palette_index & 0x7FFF), ((palette_index & 0x3FFFFFFF) >> 15) & 0x7FFF);
 	}
@@ -146,7 +146,7 @@ uint32_t load_normal_texture(const void* data, uint32_t dataSize, const char* na
 		{
 			_snprintf(filename, sizeof(filename), "%s/%s/%s.%s", basedir, tex_path.c_str(), name, mod_ext[idx].c_str());
 		}
-		else if ((palette_index & 0xC0000000) == 0xC0000000)
+		else if (palette_index & 0x40000000)
 		{
 			_snprintf(filename, sizeof(filename), "%s/%s/%s_%u_%u.%s", basedir, tex_path.c_str(), name, (palette_index & 0x7FFF), ((palette_index & 0x3FFFFFFF) >> 15) & 0x7FFF, mod_ext[idx].c_str());
 		}
@@ -166,10 +166,19 @@ uint32_t load_normal_texture(const void* data, uint32_t dataSize, const char* na
 
 	if(!ret)
 	{
-		if((palette_index & 0x3FFFFFFF) != 0)
+		if(palette_index != uint32_t(-1) && (palette_index & 0x3FFFFFFF) != 0)
 		{
 			if(trace_all || show_missing_textures) ffnx_info("No external texture found [%s], falling back to palette 0\n", filename);
-			return load_normal_texture(data, dataSize, name, palette_index & 0xC0000000, width, height, gl_set, tex_path);
+			if(gl_set->default_texture_id)
+			{
+				return gl_set->default_texture_id;
+			}
+			else
+			{
+				gl_set->default_texture_id = load_normal_texture(data, dataSize, name, (palette_index & 0xC0000000) == 0xC0000000 ? -1 : (palette_index & 0x40000000), width, height, gl_set, tex_path);
+
+				return gl_set->default_texture_id;
+			}
 		}
 		else
 		{
@@ -188,7 +197,7 @@ uint32_t load_normal_texture(const void* data, uint32_t dataSize, const char* na
 				{
 					_snprintf(filename, sizeof(filename), "%s/%s/%s_%s.%s", basedir, tex_path.c_str(), name, it.second.c_str(), mod_ext[idx].c_str());
 				}
-				else if ((palette_index & 0xC0000000) == 0xC0000000)
+				else if (palette_index & 0x40000000)
 				{
 					_snprintf(filename, sizeof(filename), "%s/%s/%s_%u_%u_%s.%s", basedir, tex_path.c_str(), name, (palette_index & 0x7FFF), ((palette_index & 0x3FFFFFFF) >> 15) & 0x7FFF, it.second.c_str(), mod_ext[idx].c_str());
 				}
@@ -266,7 +275,15 @@ uint32_t load_animated_texture(const void* data, uint32_t dataSize, const char* 
 	if(palette_index != 0)
 	{
 		if(trace_all || show_missing_textures) ffnx_info("No external texture found, falling back to palette 0\n");
-		ret = load_animated_texture(data, dataSize, name, 0, width, height, gl_set, tex_path);
+		if(gl_set->default_texture_id)
+		{
+			ret = gl_set->default_texture_id;
+		}
+		else
+		{
+			ret = load_animated_texture(data, dataSize, name, 0, width, height, gl_set, tex_path);
+			gl_set->default_texture_id = ret;
+		}
 		if(ret) gl_set->animated_textures[texture_key] = ret;
 		return ret;
 	}


### PR DESCRIPTION
## Summary

- External textures: Reuse already loaded textures on fallback to palette 0
- External textures (FF8): Optimize field external textures support (Tonberry Mods layer)
- Rendering: Add bilinear filtering option `enable_bilinear`

### Motivation

#### Reuse already loaded textures on fallback to palette 0

Sometimes for the same texture, there are many palettes. In the graphic driver, we do not upload palettes anymore, and external textures often does not need one texture per palette, but are optimized to one texture for all palettes.
In this case, it is interesting for performance that this "one texture" is opened from disk and uploaded to gpu only once. And if the game try to upload the same texture, but with a different palette, it could detects this case and just reuse the already uploaded texture.

#### Add bilinear filtering option `enable_bilinear`

If was asked by few users. For now I just added the option with a filtering enabled only for 3D models, like we already do in ff7 for external texture.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
