### PR TITLE
Audio: Ensure Voice handle exists before stopping it

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 - External textures: Add support for modding VRAM pages directly, like Tonberry Mods does, see [documentation](https://github.com/julianxhokaxhiu/FFNx/blob/master/docs/ff8/mods/external_textures.md) ( https://github.com/julianxhokaxhiu/FFNx/pull/687 https://github.com/julianxhokaxhiu/FFNx/pull/692 )
 - External textures: Fix filename lookup which can match more textures than it should in a VRAM page ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - External textures: Split `battle/A8DEF.TIM` into three files to avoid redundant textures ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
+- External music: Fix music get stopped in Fisherman's Horizon concert ( https://github.com/julianxhokaxhiu/FFNx/pull/694 )
 - Rendering: Avoid texture reupload in case of palette swap ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - Rendering: Fix texture unload when multiple palettes are written ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - Rendering: Prevent the game from sending textures with half-alpha colors ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -760,6 +760,8 @@ void NxAudioEngine::playSynchronizedMusics(const std::vector<std::string>& names
 		}
 	}
 
+	if (trace_all || trace_music) ffnx_trace("NxAudioEngine::%s: handle=%X\n", __func__, groupHandle);
+
 	if (!_engine.isVoiceGroupEmpty(groupHandle)) {
 		_musics[channel].handle = groupHandle;
 		_musics[channel].id = id;
@@ -1090,7 +1092,7 @@ bool NxAudioEngine::playVoice(const char* name, int slot, float volume)
 		exists = getFilenameFullPath(filename, name, NxAudioEngineLayer::NXAUDIOENGINE_VOICE);
 	}
 
-	if (trace_all || trace_voice) ffnx_trace("NxAudioEngine::%s: slot[%d] %s\n", __func__, slot, filename);
+	if (trace_all || trace_voice) ffnx_trace("NxAudioEngine::%s: slot[%d] %s exists=%d\n", __func__, slot, filename, exists);
 
 	if (exists)
 	{
@@ -1123,14 +1125,23 @@ bool NxAudioEngine::playVoice(const char* name, int slot, float volume)
 
 void NxAudioEngine::stopVoice(int slot, double time)
 {
+	SoLoud::handle handle = _currentVoice[slot].handle;
+
+	if (trace_all || trace_voice) ffnx_trace("NxAudioEngine::%s: slot=%d time=%lf handle=%X\n", __func__, slot, time, handle);
+
+	if (!_engine.isValidVoiceHandle(handle))
+	{
+		return;
+	}
+
 	if (time > 0.0)
 	{
-		_engine.fadeVolume(_currentVoice[slot].handle, 0, time);
-		_engine.scheduleStop(_currentVoice[slot].handle, time);
+		_engine.fadeVolume(handle, 0, time);
+		_engine.scheduleStop(handle, time);
 	}
 	else
 	{
-		_engine.stop(_currentVoice[slot].handle);
+		_engine.stop(handle);
 	}
 }
 
@@ -1250,7 +1261,7 @@ bool NxAudioEngine::playAmbient(const char* name, float volume, double time)
 		exists = getFilenameFullPath(filename, name, NxAudioEngineLayer::NXAUDIOENGINE_AMBIENT);
 	}
 
-	if (trace_all || trace_ambient) ffnx_trace("NxAudioEngine::%s: %s\n", __func__, filename);
+	if (trace_all || trace_ambient) ffnx_trace("NxAudioEngine::%s: %s exists=%d handle=%X\n", __func__, filename, exists, _currentAmbient.handle);
 
 	// Stop any previously playing ambient
 	if (_engine.isValidVoiceHandle(_currentAmbient.handle))
@@ -1377,7 +1388,7 @@ bool NxAudioEngine::playMovieAudio(const char* nameWithPath, int slot, float vol
 	char filename[MAX_PATH];
 	bool exists = getFilenameFullPath(filename, nameWithPath, NxAudioEngineLayer::NXAUDIOENGINE_MOVIE_AUDIO);
 
-	if (trace_all || trace_movies) ffnx_trace("NxAudioEngine::%s: %s\n", __func__, filename);
+	if (trace_all || trace_movies) ffnx_trace("NxAudioEngine::%s: %s exists=%d\n", __func__, filename, exists);
 
 	// Stop any previously playing movie audio
 	if (_engine.isValidVoiceHandle(_currentMovieAudio[slot].handle))


### PR DESCRIPTION
## Summary

Fix sudden stop of musics, for example in Fisherman Horizon Concert, when the dialog starts with Rinoa next to the stage.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
