### PR TITLE
FF8: Add animation support for per VRAM page texture replacement

### DIFF
--- a/docs/ff8/mods/external_textures.md
+++ b/docs/ff8/mods/external_textures.md
@@ -24,6 +24,7 @@ If you mod __by VRAM page__, file names look like this:<br>
 `{mod_path}\cardgame\cards_{relative vram page}_{palette x}_{palette y}.dds`<br>
 If a texture is not found, the game will always fallback to the path with zeroed palette x and palette y:<br>
 `{mod_path}\cardgame\cards_{relative vram page}_0_0.dds`
+For animations, unlike replacement __by texture__, you must override each frame.
 
 When there are both files for the two types of mods, the VRAM page image takes priority over the other one.
 

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1240,6 +1240,7 @@ struct ff8_externals
 	uint32_t sub_554940_call_130;
 	uint32_t sub_541AE0;
 	uint32_t sub_554BC0;
+	uint32_t sub_557140;
 	uint32_t sub_54B460;
 	uint32_t sub_558D70;
 	uint32_t sub_545EA0;

--- a/src/ff8/texture_packer.h
+++ b/src/ff8/texture_packer.h
@@ -130,11 +130,22 @@ public:
 		inline bool isValid() const {
 			return !_name.empty();
 		}
+		inline bool isAnimated() const {
+			return _isAnimated;
+		}
+		void setCurrentAnimationFrame(int frameId);
+		void setCurrentAnimationFrame(int xBpp2, int y, int wBpp2, int h);
+		inline int currentAnimationFrame() const {
+			return _frameId;
+		}
 	private:
 		TextureInfos _texture, _palette;
 		std::string _name;
 		ModdedTexture *_mod;
 		std::unordered_map<ModdedTextureId, IdentifiedTexture> _redirections;
+		int _frameId;
+		std::vector<uint64_t> _frames;
+		bool _isAnimated;
 	};
 
 	enum TextureTypes {
@@ -149,11 +160,11 @@ public:
 	// Override a part of the VRAM from another part of the VRAM, typically with biggest textures (Worldmap)
 	bool setTextureRedirection(const char *name, const TextureInfos &oldTexture, const TextureInfos &newTexture, const Tim &tim);
 	void animateTextureByCopy(int sourceXBpp2, int y, int sourceWBpp2, int sourceH, int targetXBpp2, int targetY);
-	void forceCurrentPalette(int xBpp2, int y, int8_t paletteId);
+	void setCurrentAnimationFrame(int xBpp2, int y, int8_t frameId);
 	void clearTiledTexs();
 	void clearTextures();
 	// Returns the textures matching the tiledTex
-	std::list<IdentifiedTexture> matchTextures(const TiledTex &tiledTex, bool withModsOnly = false) const;
+	std::list<IdentifiedTexture> matchTextures(const TiledTex &tiledTex, bool withModsOnly = false, bool withAnimatedOnly = false) const;
 	const TiledTex &registerTiledTex(const uint8_t *texData, int xBpp2, int y, int pixelW, int h, Tim::Bpp sourceBpp, int palX = -1, int palY = -1);
 	void registerPaletteWrite(const uint8_t *texData, int palIndex, int palX, int palY);
 	TiledTex getTiledTex(const uint8_t *texData) const;

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -98,6 +98,10 @@ void ff8_find_externals()
 	ff8_externals.get_disk_number = get_relative_call(ff8_externals.main_loop, 0x1A);
 	ff8_externals.disk_data_path = (char*)get_absolute_value(ff8_externals.get_disk_number, 0xF);
 	ff8_externals.set_game_paths = (void (*)(int, char*, const char*))get_relative_call(ff8_externals.init_config, 0x3E);
+	if (JP_VERSION)
+	{
+		ff8_externals.set_game_paths = (void (*)(int, char*, const char*))get_relative_call(uint32_t(ff8_externals.set_game_paths), 0x0);
+	}
 	ff8_externals.app_path = (const char*)get_absolute_value(uint32_t(ff8_externals.set_game_paths), 0x9A);
 
 	ff8_externals.savemap = (uint32_t**)get_absolute_value(ff8_externals.main_loop, 0x21);
@@ -599,6 +603,7 @@ void ff8_find_externals()
 		ff8_externals.sub_554940_call_130 = ff8_externals.sub_554940 + 0x130;
 		ff8_externals.sub_541AE0 = get_relative_call(ff8_externals.sub_554940, 0x130);
 		ff8_externals.sub_554BC0 = get_relative_call(ff8_externals.worldmap_input_update_sub_559240, 0x25B);
+		ff8_externals.sub_557140 = get_relative_call(ff8_externals.worldmap_input_update_sub_559240, 0x263);
 		ff8_externals.sub_54B460 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x5D7);
 
 		ff8_externals.sub_549E80 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x1D5);
@@ -671,6 +676,7 @@ void ff8_find_externals()
 		ff8_externals.sub_554940_call_130 = ff8_externals.sub_554940 + 0x13C;
 		ff8_externals.sub_541AE0 = get_relative_call(ff8_externals.sub_554940, 0x13C);
 		ff8_externals.sub_554BC0 = get_relative_call(ff8_externals.worldmap_input_update_sub_559240, 0x258);
+		ff8_externals.sub_557140 = get_relative_call(ff8_externals.worldmap_input_update_sub_559240, 0x260);
 		ff8_externals.sub_54B460 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x5D9);
 
 		ff8_externals.sub_549E80 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x1D6);


### PR DESCRIPTION
## Summary

- Support rect copy animation and force palette id animation
- Optimize texture reload hack
- Fix conflict between texture caches when modding battle and worldmap (which leads to bad colors in non-replaced textures)

### Motivation

Why are you doing this? What use cases does it support? What is the expected outcome?

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
