### PR TITLE
FF7: fix 60FPS battle text when text speed is set to max SLOW

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 
 ## FF7
 - Widescreen: Added feature to extend movies in true widescreen mode ( https://github.com/julianxhokaxhiu/FFNx/pull/700 )
+- 60FPS: Fix bug that displayed battle text too quickly when set at full SLOW speed
 
 ## FF8
 

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -1049,8 +1049,8 @@ struct battle_text_data
 {
 	short buffer_idx;
 	short field_2;
-	char wait_frames;
-	char n_frames;
+	byte wait_frames;
+	byte n_frames;
 };
 
 struct battle_chdir_struc

--- a/src/voice.cpp
+++ b/src/voice.cpp
@@ -657,7 +657,8 @@ void ff7_add_text_to_display_queue(WORD buffer_idx, byte wait_frames, byte n_fra
 		text_data->buffer_idx = buffer_idx;
 		text_data->field_2 = param_4;
 		text_data->wait_frames = wait_frames * battle_frame_multiplier - 1;
-		text_data->n_frames = (n_frames == 0) ? ((int (*)())ff7_externals.get_n_frames_display_action_string)() : n_frames * battle_frame_multiplier;
+		int n_frames_int = (n_frames == 0) ? ((int (*)())ff7_externals.get_n_frames_display_action_string)() : n_frames * battle_frame_multiplier;
+		text_data->n_frames = std::min(n_frames_int, UCHAR_MAX); // safely cast int to unsigned char
 
 		if (trace_all || trace_battle_text)
 			ffnx_trace("Add text string to be displayed: (text_id: %d, field_2: %d, wait_frames: %d, n_frames: %d)\n", text_data->buffer_idx, text_data->field_2, text_data->wait_frames, text_data->n_frames);


### PR DESCRIPTION
## Summary

When battle text speed is set to max SLOW (far right), battle text popup (e.g. messages after doing a steal) will behave like it is fast due to an integer overflow when casting int to char. 

This has been fixed by fixing the data type which should have been unsigned char and just for safety, I have added also a minimum to avoid even an unsigned char overflow.

### Motivation

Better experience in 60 FPS

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
