### PR TITLE
FF8: Enable support for the override_path option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
 - External textures: Fix filename lookup which can match more textures than it should in a VRAM page ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - External textures: Split `battle/A8DEF.TIM` into three files to avoid redundant textures ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - External music: Fix music get stopped in Fisherman's Horizon concert ( https://github.com/julianxhokaxhiu/FFNx/pull/694 )
+- Files: Enable support for `override_path` option ( https://github.com/julianxhokaxhiu/FFNx/pull/705 )
 - Rendering: Avoid texture reupload in case of palette swap ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - Rendering: Fix texture unload when multiple palettes are written ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - Rendering: Prevent the game from sending textures with half-alpha colors ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1051,6 +1051,7 @@ struct ff8_externals
 	uint32_t (*sm_pc_read)(char*,void*);
 	uint32_t get_disk_number;
 	char* disk_data_path;
+	const char *app_path;
 	uint32_t swirl_main_loop;
 	uint32_t field_main_loop;
 	uint32_t field_main_exit;

--- a/src/ff8/file.h
+++ b/src/ff8/file.h
@@ -37,3 +37,5 @@ uint32_t(*ff8_read_file)(uint32_t count, void* buffer, struct ff8_file* file);
 void (*ff8_close_file)(struct ff8_file* file);
 
 void ff8_fs_lang_string(char *data);
+
+bool ff8_fs_last_fopen_is_redirected();

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -98,6 +98,7 @@ void ff8_find_externals()
 	ff8_externals.get_disk_number = get_relative_call(ff8_externals.main_loop, 0x1A);
 	ff8_externals.disk_data_path = (char*)get_absolute_value(ff8_externals.get_disk_number, 0xF);
 	ff8_externals.set_game_paths = (void (*)(int, char*, const char*))get_relative_call(ff8_externals.init_config, 0x3E);
+	ff8_externals.app_path = (const char*)get_absolute_value(uint32_t(ff8_externals.set_game_paths), 0x9A);
 
 	ff8_externals.savemap = (uint32_t**)get_absolute_value(ff8_externals.main_loop, 0x21);
 

--- a/src/game_cfg.cpp
+++ b/src/game_cfg.cpp
@@ -24,6 +24,16 @@
 
 #include "patch.h"
 
+void normalize_path(char *name)
+{
+	int idx = 0;
+	while (name[idx] != 0)
+	{
+		if (name[idx] == '/') name[idx] = '\\';
+		idx++;
+	}
+}
+
 void set_game_paths(int install_options, char *_app_path, const char *_dataDrive)
 {
 	char fileName[MAX_PATH] = {};
@@ -33,6 +43,7 @@ void set_game_paths(int install_options, char *_app_path, const char *_dataDrive
 		ffnx_info("Overriding AppPath with %s\n", app_path.c_str());
 		strncpy(fileName, app_path.c_str(), sizeof(fileName));
 		_app_path = fileName;
+		normalize_path(_app_path);
 	}
 
 	if (!steam_edition && !data_drive.empty())

--- a/src/redirect.cpp
+++ b/src/redirect.cpp
@@ -25,14 +25,17 @@
 
 #include "redirect.h"
 
-int attempt_redirection(char* in, char* out, size_t size, bool wantsSteamPath)
+int attempt_redirection(const char* in, char* out, size_t size, bool wantsSteamPath)
 {
 	std::string newIn(in);
 
-	std::transform(newIn.begin(), newIn.end(), newIn.begin(), ::tolower);
+	if (!ff8)
+	{
+		std::transform(newIn.begin(), newIn.end(), newIn.begin(), ::tolower);
+	}
 
-	bool isSavegame = strstr(newIn.data(), ".ff7") != NULL;
-	bool isCacheFile = strstr(newIn.data(), ".p") != NULL;
+	bool isSavegame = !ff8 && strstr(newIn.data(), ".ff7") != NULL;
+	bool isCacheFile = !ff8 && strstr(newIn.data(), ".p") != NULL;
 
 	if (wantsSteamPath && !fileExists(in))
 	{
@@ -133,11 +136,11 @@ int attempt_redirection(char* in, char* out, size_t size, bool wantsSteamPath)
 		}
 		else if (!isCacheFile)
 		{
-			const char* pos = strstr(newIn.data(), "data");
+			const char* pos = ff8 ? newIn.data() : strstr(newIn.data(), "data");
 
 			if (pos != NULL)
 			{
-				pos += 5;
+				pos += ff8 ? 0 : 5;
 			}
 			else
 			{
@@ -169,9 +172,9 @@ int attempt_redirection(char* in, char* out, size_t size, bool wantsSteamPath)
 	return -1;
 }
 
-int redirect_path_with_override(char* in, char* out, size_t out_size)
+int redirect_path_with_override(const char* in, char* out, size_t out_size)
 {
-  char _newFilename[260]{ 0 };
+  char _newFilename[MAX_PATH]{ 0 };
 
   // Attempt another redirection based on Steam/eStore logic
   int redirect_status = attempt_redirection(in, _newFilename, sizeof(_newFilename), steam_edition || estore_edition);

--- a/src/redirect.h
+++ b/src/redirect.h
@@ -19,5 +19,5 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-int attempt_redirection(char* in, char* out, size_t size, bool wantsSteamPath = false);
-int redirect_path_with_override(char* in, char* out, size_t out_size);
+int attempt_redirection(const char* in, char* out, size_t size, bool wantsSteamPath = false);
+int redirect_path_with_override(const char* in, char* out, size_t out_size);


### PR DESCRIPTION
## Summary

Enable override_path option for FF8

### Motivation

`override_path` option in FF7 allows modders to put files and LGP archives in another directory than the game data.
It is quite useful when a modder want to edits LGP archives without change original files from FF7 installation.

The FF8 version is basically the same thing, but simpler: any file that is opened by the game (for reading or writing) is firstly checked in the `override_path`. For example for `.\ff8input.cfg`, FFNx checks for the existence of `.\override\ff8input.cfg`, and for `.\Data\field.fs`, FFNx checks for the existence of `.\override\Data\field.fs`, and so on.

The Steam version of the game try to look to some files like saves in Documents/Square Enix (the user directory), for the lack of simplicity and uniformity between the 2000 and the Steam version, the redirection attempt is made with the 2000 path.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
