### PR TITLE
FF7: Add option to clip camera position during scripted events

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 - Rendering: Add bilinear filtering option `enable_bilinear` ( https://github.com/julianxhokaxhiu/FFNx/pull/692 )
 
 ## FF7
+- Widescreen: Added option to clip camera position during scripted events
 - Widescreen: Added feature to extend movies in true widescreen mode ( https://github.com/julianxhokaxhiu/FFNx/pull/700 )
 - 60FPS: Fix bug that displayed battle text too quickly when set at full SLOW speed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,7 @@
 - Rendering: Add bilinear filtering option `enable_bilinear` ( https://github.com/julianxhokaxhiu/FFNx/pull/692 )
 
 ## FF7
-- Widescreen: Added option to clip camera position during scripted events
+- Widescreen: Added option to clip camera position during scripted events ( https://github.com/julianxhokaxhiu/FFNx/pull/706 )
 - Widescreen: Added feature to extend movies in true widescreen mode ( https://github.com/julianxhokaxhiu/FFNx/pull/700 )
 - 60FPS: Fix bug that displayed battle text too quickly when set at full SLOW speed
 

--- a/src/ff7/field/background.cpp
+++ b/src/ff7/field/background.cpp
@@ -550,6 +550,14 @@ namespace ff7::field
             point->x = camera_range.right - half_width;
         if (point->x < camera_range.left + half_width)
             point->x = camera_range.left + half_width;
+
+        if(widescreen.isScriptedVerticalClipEnabled())
+        {
+            if (point->y > camera_range.bottom - 120)
+                point->y = camera_range.bottom - 120;
+            if (point->y < camera_range.top + 120)
+                point->y = camera_range.top + 120;
+        }
     }
 
     void engine_set_game_engine_world_coord_float_661B23(int field_world_x, int field_world_y)

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -390,6 +390,7 @@ void Widescreen::initParamsFromConfig()
     v_offset = 0;
     is_reset_vertical_pos = false;
     is_scripted_clip_enabled = true;
+    is_scripted_vertical_clip_enabled = false;
     movie_v_offset.clear();
 
     auto pName = get_current_field_name();
@@ -406,7 +407,8 @@ void Widescreen::initParamsFromConfig()
         if(auto hOffsetNode = node["h_offset"]) h_offset = hOffsetNode.value_or(0);
         if(auto vOffsetNode = node["v_offset"]) v_offset = vOffsetNode.value_or(0);
         if(auto vResetVerticalPosNode = node["reset_vertical_pos"]) is_reset_vertical_pos = vResetVerticalPosNode.value_or(false);
-        if(auto vScripteClipNode = node["scripted_clip"]) is_scripted_clip_enabled = vScripteClipNode.value_or(true);
+        if(auto vScriptedClipNode = node["scripted_clip"]) is_scripted_clip_enabled = vScriptedClipNode.value_or(true);
+        if(auto vScriptedVerticalClipNode = node["scripted_vertical_clip"]) is_scripted_vertical_clip_enabled = vScriptedVerticalClipNode.value_or(false);
 
         if(auto modeNode = node["mode"]) widescreen_mode = static_cast<WIDESCREEN_MODE>(modeNode.value_or(0));
 

--- a/src/ff7/widescreen.h
+++ b/src/ff7/widescreen.h
@@ -73,6 +73,7 @@ public:
     int getVerticalOffset();
     bool isResetVerticalPos();
     bool isScriptedClipEnabled();
+    bool isScriptedVerticalClipEnabled();
     WIDESCREEN_MODE getMode();
 
     KeyPair getMovieKeyPair(int frame);
@@ -94,6 +95,7 @@ private:
     int v_offset = 0;
     bool is_reset_vertical_pos = false;
     bool is_scripted_clip_enabled = true;
+    bool is_scripted_vertical_clip_enabled = false;
     WIDESCREEN_MODE widescreen_mode = WM_DISABLED;
 
     std::vector<Keyframe> movie_v_offset;
@@ -123,6 +125,11 @@ inline bool Widescreen::isResetVerticalPos()
 inline bool Widescreen::isScriptedClipEnabled()
 {
     return is_scripted_clip_enabled;
+}
+
+inline bool Widescreen::isScriptedVerticalClipEnabled()
+{
+    return is_scripted_vertical_clip_enabled;
 }
 
 inline WIDESCREEN_MODE Widescreen::getMode()


### PR DESCRIPTION
## Summary

Added option to clip camera position during scripted events. This will be use to fix scenes where the camera goes beyond the boundaries showing black empty space.

### Motivation

Save the planet.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
