### PR TITLE
FF8: Fix wrong palette for external textures on battle and wm

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@
 
 - Audio: Fix bug that won't allow to configure vanilla SFX IDs using the `sfx/config.toml` file
 - Audio: Fix bug where overriding only fade flags in `ambient/config.toml` would not allow the ambient audio file to be loaded
-- External textures: Reuse already loaded textures on fallback to palette 0 ( https://github.com/julianxhokaxhiu/FFNx/pull/692 )
+- External textures: Reuse already loaded textures on fallback to palette 0 ( https://github.com/julianxhokaxhiu/FFNx/pull/692 https://github.com/julianxhokaxhiu/FFNx/pull/707 )
 - Modding: Allow replacing EXE text/data hardcoded in code ( https://github.com/julianxhokaxhiu/FFNx/pull/699 )
 - Rendering: Add bilinear filtering option `enable_bilinear` ( https://github.com/julianxhokaxhiu/FFNx/pull/692 )
 
@@ -22,7 +22,7 @@
 - External textures: Fix filename lookup which can match more textures than it should in a VRAM page ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - External textures: Split `battle/A8DEF.TIM` into three files to avoid redundant textures ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - External music: Fix music get stopped in Fisherman's Horizon concert ( https://github.com/julianxhokaxhiu/FFNx/pull/694 )
-- Files: Enable support for `override_path` option ( https://github.com/julianxhokaxhiu/FFNx/pull/705 )
+- Files: Enable support for `override_path` option ( https://github.com/julianxhokaxhiu/FFNx/pull/705 https://github.com/julianxhokaxhiu/FFNx/pull/707 )
 - Rendering: Avoid texture reupload in case of palette swap ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - Rendering: Fix texture unload when multiple palettes are written ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - Rendering: Prevent the game from sending textures with half-alpha colors ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )

--- a/src/ff8/texture_packer.cpp
+++ b/src/ff8/texture_packer.cpp
@@ -277,7 +277,7 @@ void TexturePacker::animateTextureByCopy(int sourceXBpp2, int sourceY, int sourc
 		textureIdTarget = _vramTextureIds.at(targetXBpp2 + targetY * VRAM_WIDTH);
 	if (textureId == INVALID_TEXTURE)
 	{
-		if (trace_all || trace_vram) ffnx_warning("TexturePacker::%s pos=(%d, %d) not found\n", __func__, sourceXBpp2, sourceY);
+		if (trace_all || trace_vram) ffnx_warning("TexturePacker::%s pos=(%d, %d) source not found\n", __func__, sourceXBpp2, sourceY);
 
 		return;
 	}
@@ -548,11 +548,11 @@ uint32_t TexturePacker::composeTextures(
 			{
 				scale = std::max(scale, pair.second.mod()->scale(palette.x(), palette.y()));
 				// Cache for redirections (texl)
-				if (gl_set->default_texture_id != 0)
+				if (gl_set->default_texture_id_compose != 0)
 				{
 					if (trace_all || trace_vram) ffnx_trace("TexturePacker::%s Texture already uploaded, not need for another one\n", __func__);
 
-					return gl_set->default_texture_id;
+					return gl_set->default_texture_id_compose;
 				}
 			}
 		}
@@ -608,7 +608,7 @@ uint32_t TexturePacker::composeTextures(
 		uint32_t texture = newRenderer.createTexture(reinterpret_cast<uint8_t *>(target), *width, *height, 0, RendererTextureType::BGRA, true, copyData);
 
 		if (palIndex == 0) {
-			gl_set->default_texture_id = texture;
+			gl_set->default_texture_id_compose = texture;
 		}
 
 		return texture;

--- a/src/game_cfg.cpp
+++ b/src/game_cfg.cpp
@@ -24,7 +24,7 @@
 
 #include "patch.h"
 
-void normalize_path(char *name)
+void normalize_path_win(char *name)
 {
 	int idx = 0;
 	while (name[idx] != 0)
@@ -43,7 +43,7 @@ void set_game_paths(int install_options, char *_app_path, const char *_dataDrive
 		ffnx_info("Overriding AppPath with %s\n", app_path.c_str());
 		strncpy(fileName, app_path.c_str(), sizeof(fileName));
 		_app_path = fileName;
-		normalize_path(_app_path);
+		normalize_path_win(_app_path);
 	}
 
 	if (!steam_edition && !data_drive.empty())

--- a/src/gl.h
+++ b/src/gl.h
@@ -100,6 +100,7 @@ struct gl_texture_set
 	uint32_t force_zsort;
 	uint32_t disable_lighting;
 	uint32_t default_texture_id;
+	uint32_t default_texture_id_compose;
 	// ANIMATED TEXTURES
 	uint32_t is_animated;
 	std::map<std::string, uint32_t> animated_textures;


### PR DESCRIPTION
## Summary

Two fixes:

- When battle is partially modded, non modded textures could use the wrong palette. This happens because the new cache conflict between the two ways of modding
- mkpath does not work anymore on ff8, because the wrong sub is called to uniformize paths


### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
