### PR TITLE
FF8: Fix field bg mods reload hack

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,7 +20,7 @@
 
 - 60FPS: Add support for 60FPS in the entire game ( separate mods are still required for a stable gameplay )
 - Audio: Add ambient layer support for Fields and Battles
-- External textures: Add support for modding VRAM pages directly, like Tonberry Mods does, see [documentation](https://github.com/julianxhokaxhiu/FFNx/blob/master/docs/ff8/mods/external_textures.md) ( https://github.com/julianxhokaxhiu/FFNx/pull/687 https://github.com/julianxhokaxhiu/FFNx/pull/692 )
+- External textures: Add support for modding VRAM pages directly, like Tonberry Mods does, see [documentation](https://github.com/julianxhokaxhiu/FFNx/blob/master/docs/ff8/mods/external_textures.md) ( https://github.com/julianxhokaxhiu/FFNx/pull/687 https://github.com/julianxhokaxhiu/FFNx/pull/692 https://github.com/julianxhokaxhiu/FFNx/pull/696 https://github.com/julianxhokaxhiu/FFNx/pull/712 )
 - External textures: Fix filename lookup which can match more textures than it should in a VRAM page ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - External textures: Split `battle/A8DEF.TIM` into three files to avoid redundant textures ( https://github.com/julianxhokaxhiu/FFNx/pull/687 )
 - External music: Fix music get stopped in Fisherman's Horizon concert ( https://github.com/julianxhokaxhiu/FFNx/pull/694 )

--- a/src/ff8/texture_packer.cpp
+++ b/src/ff8/texture_packer.cpp
@@ -177,6 +177,8 @@ bool TexturePacker::setTextureBackground(const char *name, int x, int y, int w, 
 	if (mod->createImages(extension, found_extension))
 	{
 		tex.setMod(mod);
+		// Force texture_reload_hack
+		tex.setCurrentAnimationFrame(-1);
 	}
 	else
 	{

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -1099,6 +1099,8 @@ uint32_t ff8_field_read_map_data(char *filename, uint8_t *map_data)
 		snprintf(tex_directory, sizeof(tex_directory), "field/mapdata/%.2s/%s/%s", get_current_field_name(), get_current_field_name(), get_current_field_name());
 
 		texturePacker.setTexture(tex_directory, TexturePacker::TextureInfos(0, 256, VRAM_PAGE_MIM_MAX_COUNT * TEXTURE_WIDTH_BPP16, TEXTURE_HEIGHT, Tim::Bpp16, true), TexturePacker::TextureInfos(0, 232, 256, 24, Tim::Bpp16), 0);
+		// Force texture_reload_hack
+		texturePacker.setCurrentAnimationFrame(0, 256, -1);
 	}
 
 	return ret;


### PR DESCRIPTION
## Summary

Field background mods broken again since texture_reload_hack was tuned to minimize texture uploads on worldmap

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
