### PR TITLE
Gardening: Refactor includes, header guards and related things

### DIFF
--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -24,9 +24,12 @@
 #include <steamworkssdk/isteamuserstats.h>
 #include <steamworkssdk/isteamuser.h>
 
-#include "achievement.h"
 #include <numeric>
 #include <algorithm>
+
+#include "achievement.h"
+#include "log.h"
+#include "cfg.h"
 
 using std::string;
 

--- a/src/achievement.h
+++ b/src/achievement.h
@@ -22,9 +22,14 @@
 
 #pragma once
 
+#include <memory>
 #include <steamworkssdk/steam_api.h>
 #include <array>
-#include "log.h"
+#include <vector>
+#include <string>
+#include <windows.h>
+
+#include "ff7.h"
 
 #define _ACH_ID(id)           \
     {                         \

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -23,6 +23,7 @@
 
 #include "log.h"
 #include "gamehacks.h"
+#include "utils.h"
 
 #if defined(__cplusplus)
 extern "C" {

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -19,6 +19,8 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include "audio/openpsf/openpsf.h"
+
 #include "audio.h"
 
 #include "log.h"

--- a/src/audio.h
+++ b/src/audio.h
@@ -30,6 +30,8 @@
 #include "audio/openpsf/openpsf.h"
 #include "audio/vgmstream/vgmstream.h"
 
+#include "log.h"
+
 #define NXAUDIOENGINE_INVALID_HANDLE 0xfffff000
 
 static void NxAudioEngineVgmstreamCallback(int level, const char* str)

--- a/src/audio.h
+++ b/src/audio.h
@@ -27,7 +27,6 @@
 #include <unordered_map>
 #include <soloud.h>
 #include "audio/memorystream/memorystream.h"
-#include "audio/openpsf/openpsf.h"
 #include "audio/vgmstream/vgmstream.h"
 
 #include "log.h"

--- a/src/audio/openpsf/openpsf.cpp
+++ b/src/audio/openpsf/openpsf.cpp
@@ -21,6 +21,7 @@
 
 #include "openpsf.h"
 #include "utils.h"
+#include "log.h"
 
 constexpr auto SOLOUD_OPENPSF_VOLUME_SCALE = float(3.2f / double(0x8000));
 

--- a/src/audio/openpsf/openpsf.cpp
+++ b/src/audio/openpsf/openpsf.cpp
@@ -20,6 +20,7 @@
 /****************************************************************************/
 
 #include "openpsf.h"
+#include "utils.h"
 
 constexpr auto SOLOUD_OPENPSF_VOLUME_SCALE = float(3.2f / double(0x8000));
 

--- a/src/audio/openpsf/openpsf.h
+++ b/src/audio/openpsf/openpsf.h
@@ -24,7 +24,6 @@
 #include <soloud.h>
 #include <stdint.h>
 #include <openpsf/openpsf.h>
-#include "../../log.h"
 
 namespace SoLoud
 {

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -20,7 +20,12 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include <toml++/toml.h>
+
 #include "cfg.h"
+#include "common.h"
+#include "globals.h"
+#include "log.h"
 
 #define FFNX_CFG_FILE "FFNx.toml"
 

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -24,7 +24,6 @@
 
 #include <string>
 #include <vector>
-#include "log.h"
 
 #define RENDERER_BACKEND_AUTO 0
 #define RENDERER_BACKEND_OPENGL 1

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -21,6 +21,10 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#define _WIN32_WINNT 0x0A00
+
+#include "renderer.h"
+
 #include <windows.h>
 #include <windowsx.h>
 #include <dwmapi.h>
@@ -30,7 +34,6 @@
 #include <hwinfo/hwinfo.h>
 #include <regex>
 
-#include "renderer.h"
 #include "hext.h"
 #include "ff8_data.h"
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -21,10 +21,6 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#define _WIN32_WINNT 0x0600
-
-#include "renderer.h"
-
 #include <windows.h>
 #include <windowsx.h>
 #include <dwmapi.h>
@@ -33,7 +29,14 @@
 #include <steamworkssdk/steam_api.h>
 #include <hwinfo/hwinfo.h>
 #include <regex>
+#include <shlwapi.h>
+#include <shlobj.h>
+#include <psapi.h>
+#include <mmsystem.h>
+#include <malloc.h>
+#include <ddraw.h>
 
+#include "renderer.h"
 #include "hext.h"
 #include "ff8_data.h"
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -28,6 +28,7 @@
 #include <sys/timeb.h>
 #include <steamworkssdk/steam_api.h>
 #include <hwinfo/hwinfo.h>
+#include <regex>
 
 #include "renderer.h"
 #include "hext.h"
@@ -57,6 +58,7 @@
 #include "game_cfg.h"
 #include "exe_data.h"
 
+#include "ff7/defs.h"
 #include "ff7/widescreen.h"
 #include "ff7/time.h"
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -21,7 +21,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#define _WIN32_WINNT 0x0A00
+#define _WIN32_WINNT 0x0600
 
 #include "renderer.h"
 

--- a/src/common.h
+++ b/src/common.h
@@ -22,6 +22,11 @@
 
 #pragma once
 
+#include <windows.h>
+#include <mmsystem.h>
+#include <dinput.h>
+#include <dsound.h>
+
 #include "common_imports.h"
 
 // all known OFFICIAL versions of FF7 & FF8 released for the PC

--- a/src/common.h
+++ b/src/common.h
@@ -22,7 +22,6 @@
 
 #pragma once
 
-#include "matrix.h"
 #include "common_imports.h"
 
 // all known OFFICIAL versions of FF7 & FF8 released for the PC

--- a/src/common_imports.h
+++ b/src/common_imports.h
@@ -35,6 +35,8 @@
 #include <dinput.h>
 #include <dsound.h>
 
+#include "matrix.h"
+
 /*
  * Render states supported by the graphics engine
  *

--- a/src/common_imports.h
+++ b/src/common_imports.h
@@ -26,9 +26,7 @@
 #include <psapi.h>
 #include <mmsystem.h>
 
-#include <time.h>
 #include <malloc.h>
-#include <stdio.h>
 #include <stdint.h>
 
 #include <ddraw.h>

--- a/src/common_imports.h
+++ b/src/common_imports.h
@@ -21,17 +21,8 @@
 
 #pragma once
 
-#include <Shlwapi.h>
-#include <shlobj.h>
-#include <psapi.h>
-#include <mmsystem.h>
-
-#include <malloc.h>
+#include <windows.h>
 #include <stdint.h>
-
-#include <ddraw.h>
-#include <dinput.h>
-#include <dsound.h>
 
 #include "matrix.h"
 

--- a/src/crashdump.cpp
+++ b/src/crashdump.cpp
@@ -19,6 +19,8 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include <shlwapi.h>
+
 #include "audio.h"
 
 #include "crashdump.h"

--- a/src/crashdump.cpp
+++ b/src/crashdump.cpp
@@ -20,7 +20,6 @@
 /****************************************************************************/
 
 #include "audio.h"
-#include "renderer.h"
 
 #include "crashdump.h"
 

--- a/src/crashdump.h
+++ b/src/crashdump.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#include <stdio.h>
 #include <StackWalker.h>
 #include <dbghelp.h>
 
-#include "crashdump.h"
 #include "log.h"
 
 #define STACK_MAX_NAME_LENGTH 256

--- a/src/external_mesh.cpp
+++ b/src/external_mesh.cpp
@@ -25,6 +25,7 @@
 
 #include "cfg.h"
 #include "renderer.h"
+#include "utils.h"
 
 #define CGLTF_IMPLEMENTATION
 #include "cgltf.h"
@@ -166,7 +167,7 @@ bool ExternalMesh::importExternalMeshGltfFile(char* file_path, char* tex_path)
 					colorBuffer = (float*)((char*)attr.data->buffer_view->buffer->data + attr.data->buffer_view->offset);
 				}
 			}
-            
+
             outShape.isDoubleSided = primitive.material->double_sided;
 
 			auto texture = primitive.material->pbr_metallic_roughness.base_color_texture.texture;

--- a/src/external_mesh.cpp
+++ b/src/external_mesh.cpp
@@ -24,7 +24,7 @@
 #include "external_mesh.h"
 
 #include "cfg.h"
-#include "renderer.h"
+#include "log.h"
 #include "utils.h"
 
 #define CGLTF_IMPLEMENTATION

--- a/src/external_mesh.h
+++ b/src/external_mesh.h
@@ -25,9 +25,8 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <toml++/toml.h>
 
-#include "common.h"
-#include "globals.h"
 #include "renderer.h"
 
 struct Material
@@ -61,7 +60,7 @@ public:
     void bindField3dIndexBuffer(uint32_t offset, uint32_t inCount);
     void clearExternalMesh3dBuffers();
     void unloadExternalMesh();
-    
+
     std::vector<Shape> shapes;
 	std::map<std::string, Material> materials;
 private:
@@ -78,5 +77,5 @@ private:
     bgfx::DynamicVertexBufferHandle vertexBufferHandle = BGFX_INVALID_HANDLE;
 
     std::vector<uint32_t> indexBufferData;
-    bgfx::DynamicIndexBufferHandle indexBufferHandle = BGFX_INVALID_HANDLE;   
+    bgfx::DynamicIndexBufferHandle indexBufferHandle = BGFX_INVALID_HANDLE;
 };

--- a/src/fake_dd.h
+++ b/src/fake_dd.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 struct ddsurface
 {
 	void *query_interface;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <ddraw.h>
 #include <stdio.h>
 #include <array>
 #include <span>

--- a/src/ff7/battle/animations.h
+++ b/src/ff7/battle/animations.h
@@ -22,7 +22,10 @@
 
 #pragma once
 
-#include "../../ff7.h"
+#include <unordered_map>
+#include <unordered_set>
+#include <stdint.h>
+#include <windows.h>
 
 namespace ff7::battle
 {

--- a/src/ff7/battle/camera.cpp
+++ b/src/ff7/battle/camera.cpp
@@ -25,11 +25,9 @@
 
 #include <unordered_set>
 #include <unordered_map>
-#include <utility>
 #include <span>
 
 #include "../../patch.h"
-#include "../../log.h"
 #include "../../globals.h"
 
 #include <bx/math.h>
@@ -265,7 +263,7 @@ namespace ff7::battle
         ((void(*)(short))ff7_externals.update_battle_camera_sub_5C20CE)(cameraScriptIndex);
 
         byte battle_enter_frames_to_wait = *ff7_externals.battle_enter_frames_to_wait;
-        if(cameraScriptIndex == -2 && battle_enter_frames_to_wait > 5) 
+        if(cameraScriptIndex == -2 && battle_enter_frames_to_wait > 5)
         {
             camera.reset();
             camera.setupInitialCamera();

--- a/src/ff7/battle/camera.h
+++ b/src/ff7/battle/camera.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include "../../common.h"
+#include "matrix.h"
 
 namespace ff7::battle
 {

--- a/src/ff7/battle/menu.cpp
+++ b/src/ff7/battle/menu.cpp
@@ -25,7 +25,9 @@
 #include "../../renderer.h"
 
 #include "menu.h"
+#include "cfg.h"
 #include "defs.h"
+#include "gl.h"
 
 namespace ff7::battle
 {

--- a/src/ff7/defs.h
+++ b/src/ff7/defs.h
@@ -21,9 +21,9 @@
 
 #pragma once
 
-#include "field/defs.h"
-#include "battle/defs.h"
-#include "world/defs.h"
+#include "ff7.h"
+#include <windows.h>
+#include <stdint.h>
 
 // kernel
 void kernel2_reset_counters();

--- a/src/ff7/dsound.cpp
+++ b/src/ff7/dsound.cpp
@@ -20,7 +20,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include "../ff7.h"
+#include <windows.h>
 
 int ff7_dsound_create(HWND hwnd, LPGUID guid)
 {

--- a/src/ff7/field/background.cpp
+++ b/src/ff7/field/background.cpp
@@ -21,7 +21,6 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include "../../log.h"
 #include "../../common.h"
 #include "../../globals.h"
 #include "../widescreen.h"
@@ -534,7 +533,7 @@ namespace ff7::field
         }
 
         auto camera_range = widescreen.getCameraRange();
-        
+
         // Adjustment to prevent scrolling stopping one pixel too early
         camera_range.left += 1;
         camera_range.right -= 1;
@@ -774,8 +773,8 @@ namespace ff7::field
                         *ff7_externals.scripted_world_final_pos_x = -world_pos.x;
 
                         world_pos = {-(*ff7_externals.scripted_world_initial_pos_x), -(*ff7_externals.scripted_world_initial_pos_y)};
-                        field_widescreen_width_clip_with_camera_range(&world_pos);    
-                        *ff7_externals.scripted_world_initial_pos_x = -world_pos.x;                    
+                        field_widescreen_width_clip_with_camera_range(&world_pos);
+                        *ff7_externals.scripted_world_initial_pos_x = -world_pos.x;
                     }
 
                     std::function<int(int, int, int, int)> field_get_interpolated_value = ff7_externals.modules_global_object->world_move_mode == 5 ?
@@ -942,7 +941,7 @@ namespace ff7::field
                 {
                     bg_delta_position.x = -last_valid_scripted_field_delta_world_pos.x;
                     bg_delta_position.y = -last_valid_scripted_field_delta_world_pos.y;
-                    
+
                     field_clip_with_camera_range_float(&bg_delta_position);
                     field_curr_delta_world_pos.x = -bg_delta_position.x;
                     field_curr_delta_world_pos.y = -bg_delta_position.y;
@@ -954,8 +953,8 @@ namespace ff7::field
             {
                 if(is_position_valid(field_curr_delta_world_pos))
                     set_world_and_background_positions({-field_curr_delta_world_pos.x, -field_curr_delta_world_pos.y}, true);
-            }           
-            
+            }
+
 
             if((*ff7_externals.field_event_data_ptr)[player_model_id].field_62)
                 compute_pointer_hand_position(field_3d_world_pos, player_model_id);

--- a/src/ff7/field/background.h
+++ b/src/ff7/field/background.h
@@ -21,7 +21,6 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include "../../common.h"
 #include "../../ff7.h"
 
 #pragma once
@@ -44,7 +43,7 @@ namespace ff7::field
     void ff7_field_submit_draw_arrow(field_arrow_graphics_data* arrow_data);
     void ff7_field_submit_draw_cursor(field_arrow_graphics_data* arrow_data);
     void draw_gray_quads_sub_644E90();
-    bool is_position_valid(vector2<float> position) {
+    inline bool is_position_valid(vector2<float> position) {
         return position.x != INVALID_VALUE && position.y != INVALID_VALUE;
     }
 

--- a/src/ff7/field/background.h
+++ b/src/ff7/field/background.h
@@ -21,9 +21,9 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include "../../ff7.h"
-
 #pragma once
+
+#include "../../ff7.h"
 
 namespace ff7::field
 {

--- a/src/ff7/field/camera.h
+++ b/src/ff7/field/camera.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include "../../common.h"
+#include "matrix.h"
 
 namespace ff7::field
 {

--- a/src/ff7/field/defs.h
+++ b/src/ff7/field/defs.h
@@ -23,8 +23,7 @@
 
 #pragma once
 
-#include "../../common.h"
-#include "../../globals.h"
+#include "ff7.h"
 
 namespace ff7::field
 {

--- a/src/ff7/field/enter.h
+++ b/src/ff7/field/enter.h
@@ -21,6 +21,8 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#pragma once
+
 #include "model.h"
 #include "background.h"
 #include "../widescreen.h"

--- a/src/ff7/field/enter.h
+++ b/src/ff7/field/enter.h
@@ -29,7 +29,7 @@
 
 namespace ff7::field
 {
-    void ff7_field_initialize_variables()
+    inline void ff7_field_initialize_variables()
     {
         ((void(*)())ff7_externals.field_initialize_variables)();
 

--- a/src/ff7/field/field.cpp
+++ b/src/ff7/field/field.cpp
@@ -30,6 +30,7 @@
 #include "../../patch.h"
 #include "../../common.h"
 #include "../widescreen.h"
+#include "../defs.h"
 
 #include "opcode.h"
 #include "background.h"

--- a/src/ff7/field/model.cpp
+++ b/src/ff7/field/model.cpp
@@ -24,6 +24,7 @@
 #include "../../globals.h"
 #include "../../sfx.h"
 #include "../../movies.h"
+#include "../../utils.h"
 #include "../widescreen.h"
 
 #include "utils.h"

--- a/src/ff7/field/model.h
+++ b/src/ff7/field/model.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include "../../common.h"
+#include "ff7.h"
 
 #include <array>
 

--- a/src/ff7/field/opcode.cpp
+++ b/src/ff7/field/opcode.cpp
@@ -24,7 +24,6 @@
 #include "../../log.h"
 #include "../../globals.h"
 #include "../../ff7.h"
-#include "../../common.h"
 #include "../../field.h"
 #include "opcode.h"
 #include "utils.h"

--- a/src/ff7/field/opcode.h
+++ b/src/ff7/field/opcode.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <array>
+#include <windows.h>
 
 namespace ff7::field
 {

--- a/src/ff7/field/utils.h
+++ b/src/ff7/field/utils.h
@@ -21,6 +21,8 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#pragma once
+
 #include "../../movies.h"
 #include "../../cfg.h"
 #include "../../globals.h"

--- a/src/ff7/field/utils.h
+++ b/src/ff7/field/utils.h
@@ -30,7 +30,7 @@
 
 namespace ff7::field
 {
-    bool is_fps_running_more_than_original()
+    inline bool is_fps_running_more_than_original()
     {
         if(is_overlapping_movie_playing())
             return movie_fps_ratio > 1;
@@ -38,7 +38,7 @@ namespace ff7::field
             return ff7_fps_limiter == FPS_LIMITER_60FPS;
     }
 
-    int get_frame_multiplier()
+    inline int get_frame_multiplier()
     {
         if(is_overlapping_movie_playing())
             return movie_fps_ratio;
@@ -46,23 +46,23 @@ namespace ff7::field
             return common_frame_multiplier;
     }
 
-    bool is_fieldmap_wide()
+    inline bool is_fieldmap_wide()
     {
         return widescreen_enabled && widescreen.getMode() != WM_DISABLED;
     }
 
-    float field_get_linear_interpolated_value_float(float initial_value, float final_value, int n_steps, int step_idx)
+    inline float field_get_linear_interpolated_value_float(float initial_value, float final_value, int n_steps, int step_idx)
     {
         return std::lerp(initial_value, final_value, step_idx / (float)n_steps);
     }
 
-    float field_get_smooth_interpolated_value_float(float initial_value, float final_value, int n_steps, int step_idx)
+    inline float field_get_smooth_interpolated_value_float(float initial_value, float final_value, int n_steps, int step_idx)
     {
         float delta = final_value - initial_value;
         return initial_value + delta * (0.5f + sin(-M_PI/2.f + M_PI * (step_idx / (float)n_steps)) / 2.f);
     }
 
-    int engine_apply_matrix_product_float_66307D(vector3<float> *input_vector, vector2<float> *output_vector, int *dummy1, int *dummy2)
+    inline int engine_apply_matrix_product_float_66307D(vector3<float> *input_vector, vector2<float> *output_vector, int *dummy1, int *dummy2)
     {
         int ret;
         float matrix[16];
@@ -90,7 +90,7 @@ namespace ff7::field
         return ret;
     }
 
-    int field_apply_2D_translation_float_64314F(vector3<float> *input_vector, vector2<float> *output_vector)
+    inline int field_apply_2D_translation_float_64314F(vector3<float> *input_vector, vector2<float> *output_vector)
     {
         int dummy_1, dummy_2;
         int ret;

--- a/src/ff7/file.cpp
+++ b/src/ff7/file.cpp
@@ -19,16 +19,13 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include <filesystem>
 #include <string.h>
 #include <sys/stat.h>
 #include <io.h>
 
 #include "../ff7.h"
 #include "../log.h"
-#include "../hext.h"
 #include "../redirect.h"
-#include "../achievement.h"
 
 FILE *open_lgp_file(char *filename, uint32_t mode)
 {

--- a/src/ff7/graphics.cpp
+++ b/src/ff7/graphics.cpp
@@ -28,6 +28,7 @@
 #include "../macro.h"
 #include "../log.h"
 #include "../gl.h"
+#include "defs.h"
 
 /*
  * Most of these functions are lifted from the game with only minor changes to

--- a/src/ff7/minigames.cpp
+++ b/src/ff7/minigames.cpp
@@ -17,7 +17,7 @@
 #include <stdint.h>
 
 #include "../ff7.h"
-#include "../log.h"
+#include "../globals.h"
 
 void ff7_condor_fix_unit_texture_load(uint32_t unk, struc_3 *struc_3)
 {

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 
+#include "defs.h"
 #include "battle/camera.h"
 #include "field/camera.h"
 #include "world/camera.h"

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -36,7 +36,6 @@
 #include "../ff7.h"
 #include "../log.h"
 #include "../metadata.h"
-#include "../sfx.h"
 #include "../achievement.h"
 
 #include <bx/math.h>

--- a/src/ff7/time.cpp
+++ b/src/ff7/time.cpp
@@ -13,14 +13,13 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include "time.h"
-#include "cfg.h"
-#include "field/background.h"
-
-#include "../patch.h"
-#include "../ff7.h"
 #include "../renderer.h"
-#include "../lighting.h"
+#include "../globals.h"
+#include "../patch.h"
+#include "../cfg.h"
+
+#include "time.h"
+#include "field/background.h"
 
 namespace ff7
 {

--- a/src/ff7/time.h
+++ b/src/ff7/time.h
@@ -15,7 +15,8 @@
 
 #pragma once
 
-#include "globals.h"
+#include <toml++/toml.h>
+#include <windows.h>
 #include "bx/math.h"
 
 namespace ff7

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -21,16 +21,20 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include "widescreen.h"
-#include "ff7/field/defs.h"
-#include "field/background.h"
-#include "../patch.h"
+#include "cmath"
+
 #include "../ff7.h"
 #include "../cfg.h"
 #include "../renderer.h"
 #include "../video/movies.h"
 #include "../movies.h"
-#include "cmath"
+#include "../gl.h"
+#include "../globals.h"
+#include "../patch.h"
+
+#include "widescreen.h"
+#include "field/defs.h"
+#include "field/background.h"
 
 int viewport_width_plus_x_widescreen_fix = 750;
 int swirl_framebuffer_offset_x_widescreen_fix = 106;

--- a/src/ff7/widescreen.cpp
+++ b/src/ff7/widescreen.cpp
@@ -22,6 +22,7 @@
 /****************************************************************************/
 
 #include "widescreen.h"
+#include "ff7/field/defs.h"
 #include "field/background.h"
 #include "../patch.h"
 #include "../ff7.h"
@@ -105,17 +106,17 @@ void ifrit_second_third_wave_effect_widescreen_fix_sub_66A47E(int wave_data_poin
     ff7_externals.engine_draw_sub_66A47E(wave_data_pointer);
 }
 
-void pollensalta_cold_breath_atk_white_dot_effect() 
+void pollensalta_cold_breath_atk_white_dot_effect()
 {
     effect100_data* effect_data = &ff7_externals.effect100_array_data[*ff7_externals.effect100_array_idx];
     ff7_externals.pollensalta_cold_breath_atk_draw_white_dots_547E75(*ff7_externals.pollensalta_cold_breath_white_dot_rgb_scalar);
-    if (!*ff7_externals.g_is_battle_paused) 
+    if (!*ff7_externals.g_is_battle_paused)
     {
         for (int i = 0; i < 400; i++)
         {
             short offset = 2 * (i % 2) + 2;
             ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x = (offset + ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x);
-            if (ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x < wide_viewport_x) 
+            if (ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x < wide_viewport_x)
                 ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x = ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x + wide_viewport_width;
             if (ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x > wide_viewport_width + wide_viewport_x)
                 ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x = ff7_externals.pollensalta_cold_breath_white_dots_pos[i].x - wide_viewport_width;
@@ -129,7 +130,7 @@ void pollensalta_cold_breath_atk_white_dot_effect()
             *ff7_externals.pollensalta_cold_breath_white_dot_rgb_scalar -= 1;
         if (++effect_data->field_2 == 50)
             effect_data->field_0 = 0xFFFF;
-        
+
     }
 }
 

--- a/src/ff7/widescreen.h
+++ b/src/ff7/widescreen.h
@@ -23,10 +23,11 @@
 
 #pragma once
 
-#include "common.h"
-#include "globals.h"
-
 #include <vector>
+#include <toml++/toml.h>
+
+#include "common.h"
+#include "ff7.h"
 
 int wide_viewport_x = -107;
 int wide_viewport_y = 0;

--- a/src/ff7/world/camera.cpp
+++ b/src/ff7/world/camera.cpp
@@ -21,12 +21,11 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include "../../globals.h"
 #include "camera.h"
 #include "world.h"
 #include "utils.h"
-
 #include "defs.h"
-#include "../../patch.h"
 
 namespace ff7::world
 {
@@ -38,7 +37,7 @@ namespace ff7::world
         int movement_multiplier = *ff7_externals.world_movement_multiplier_DFC480;
         int world_map_type = *ff7_externals.world_map_type_E045E8;
         int camera_view_type = *ff7_externals.world_camera_viewtype_DFC4B4;
-    
+
         if (world_map_type == SNOWSTORM)
         {
             auto flag = current_key_input & ANY_DIRECTIONAL_KEY;
@@ -51,7 +50,7 @@ namespace ff7::world
 
             auto rotationSpeed = camera.getRotationSpeed();
 
-            int current_key_input = ff7_externals.world_get_current_key_input_status(); 
+            int current_key_input = ff7_externals.world_get_current_key_input_status();
             float playerDeltaMovement = static_cast<float>(*ff7_externals.world_special_delta_movement_DE6A18);
             int movement_speed = get_player_movement_speed(player_model_id);
             float speedCoeff = std::abs(playerDeltaMovement) / (movement_speed);
@@ -78,22 +77,22 @@ namespace ff7::world
                 }
                 else
                 {
-                    float t = 0.02 * movement_multiplier;   
+                    float t = 0.02 * movement_multiplier;
 
                     bool isMovementButtonPressed = is_key_pressed(current_key_input, CIRCLE | R1 | SQUARE | L1 );
 
-                    if (abs(joyDir.x) == 0.0f && !isMovementButtonPressed) t = 0.0f;                  
-    
-                    if (player_model_id == BUGGY) t *= speedCoeff;                        
-                    else t *= isMovementButtonPressed ? std::max(0.1f, speedCoeff) : abs(joyDir.x);                    
-                    
+                    if (abs(joyDir.x) == 0.0f && !isMovementButtonPressed) t = 0.0f;
+
+                    if (player_model_id == BUGGY) t *= speedCoeff;
+                    else t *= isMovementButtonPressed ? std::max(0.1f, speedCoeff) : abs(joyDir.x);
+
                     float diff = player_direction - camera.localTargetRotation.y;
                     if (diff > 180) camera.localTargetRotation.y += 360;
                     else if (diff < - 180)  camera.localTargetRotation.y -= 360;
                     camera.localTargetRotation.y = (1.0f - t) * camera.localTargetRotation.y + t * player_direction;
                 }
                 camera.targetRotation.y = camera.localTargetRotation.y;
-                camera.targetRotation.x = camera.localTargetRotation.x;                
+                camera.targetRotation.x = camera.localTargetRotation.x;
             }
             else
             {
@@ -125,9 +124,9 @@ namespace ff7::world
             float targetRotationY = *ff7_externals.world_camera_front_DFC484 * 360.0f / 4096.0f;
 
             int world_map_type = *ff7_externals.world_map_type_E045E8;
-            
+
             float diff = targetRotationY - camera.rotationOffset.y;
-            if (diff > 180) 
+            if (diff > 180)
                 camera.rotationOffset.y += 360;
             else if (diff < - 180)  camera.rotationOffset.y -= 360;
 
@@ -169,19 +168,19 @@ namespace ff7::world
         static float zoomTarget = 10000.0f;
         static int cameraStatusCounter = 0;
         float maxZoomDist = camera.getMaxZoomDist();
-        
+
         if(world_map_type != SNOWSTORM && ff7_externals.world_get_unknown_flag_75335C())
         {
             targetRotationX = camera.targetRotation.x;
-            zoomTarget = std::min(maxZoomDist, std::max(camera.minZoomDist, zoomTarget - camera.getZoomSpeed()));            
+            zoomTarget = std::min(maxZoomDist, std::max(camera.minZoomDist, zoomTarget - camera.getZoomSpeed()));
             cameraStatusCounter = 0;
-        } else 
+        } else
         {
-            if (cameraStatusCounter > 0) zoomTarget = 10000.0f;            
+            if (cameraStatusCounter > 0) zoomTarget = 10000.0f;
             cameraStatusCounter++;
         }
 
-        const float t = 0.05f * movement_multiplier;     
+        const float t = 0.05f * movement_multiplier;
         camera.rotationOffset.x = (1.0f - t) * camera.rotationOffset.x + t * targetRotationX;
 
         bx::Vec3 up = { 0, 1, 0 };
@@ -199,7 +198,7 @@ namespace ff7::world
         float rotMat[16];
         bx::mtxFromQuaternion(rotMat, quaternion);
 
-        
+
         camera.zoomOffset = (1.0f - t) * camera.zoomOffset + t * zoomTarget;
 
         camera.zoomOffset = std::min(maxZoomDist, std::max(camera.minZoomDist, camera.zoomOffset));

--- a/src/ff7/world/camera.h
+++ b/src/ff7/world/camera.h
@@ -22,7 +22,7 @@
 /****************************************************************************/
 #pragma once
 
-#include "../../common.h"
+#include "matrix.h"
 
 #include <bx/math.h>
 #include <bx/bx.h>

--- a/src/ff7/world/player.cpp
+++ b/src/ff7/world/player.cpp
@@ -21,13 +21,14 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include "globals.h"
 #include "world.h"
 #include "camera.h"
+#include "cfg.h"
 #include "utils.h"
 
 #include <math.h>
-#include "defs.h"
-#include "../../cfg.h"
+#include "ff7/world/defs.h"
 
 namespace ff7::world {
 

--- a/src/ff7/world/player.cpp
+++ b/src/ff7/world/player.cpp
@@ -27,7 +27,7 @@
 
 #include <math.h>
 #include "defs.h"
-#include "../../patch.h"
+#include "../../cfg.h"
 
 namespace ff7::world {
 
@@ -128,7 +128,7 @@ namespace ff7::world {
 
                 static float deltaMovement = 0.0f;
                 static int horizontalDeltaInterp = 0;
-                
+
                 bool highwind_view_and_square_pressed = camera_view_type == HIGHWIND_VIEW && is_key_pressed(current_key_input, SQUARE | L1);
 
                 int horizontal_delta = 0;
@@ -142,7 +142,7 @@ namespace ff7::world {
                     horizontal_delta = -2048;
                 }
 
-                horizontalDeltaInterp = (15 * horizontalDeltaInterp + horizontal_delta) / 16;                
+                horizontalDeltaInterp = (15 * horizontalDeltaInterp + horizontal_delta) / 16;
                 if(camera_view_type == HIGHWIND_VIEW || worldmap_type == UNDERWATER || player_model_id == TINY_BRONCO || player_model_id == BUGGY || player_model_id == SUBMARINE)
                 {
                     bool is_movement_key_pressed = is_key_pressed(current_key_input, highwind_view_and_square_pressed ? ANY_DIRECTIONAL_KEY: CIRCLE | R1);
@@ -151,7 +151,7 @@ namespace ff7::world {
                     if(is_back_movement_key_pressed && (player_model_id == BUGGY || player_model_id == SUBMARINE))
                     {
                         if(!is_movement_key_pressed)
-                        {                   
+                        {
                             movement_speed = -movement_speed * 0.75f;
                         } else movement_speed = 0;
 
@@ -159,7 +159,7 @@ namespace ff7::world {
                     }
 
                     if (!is_movement_key_pressed || highwind_view_and_square_pressed) movement_speed = 0;
-                    
+
                     deltaMovement = (deltaMovement * 31.0f + movement_speed) / 32.0f;
 
                     if(!is_movement_key_pressed && std::abs(deltaMovement) < 10.0f) deltaMovement = 0.0f;
@@ -208,14 +208,14 @@ namespace ff7::world {
                         short delta = -static_cast<short>(rotationSpeedInterp);
 
                         if (player_model_id == BUGGY )
-                        {                                
+                        {
                             auto maxSpeed = static_cast<float>(get_player_movement_speed(player_model_id));
                             if (is_back_movement_key_pressed) maxSpeed *= 0.5f;
                             delta *= std::abs(deltaMovement) / maxSpeed;
                         }
 
                         last_valid_player_direction += delta;
-                        
+
 
                         if(last_valid_player_direction > 2048)
                             last_valid_player_direction -= 4096;
@@ -252,7 +252,7 @@ namespace ff7::world {
                 static float verticalSpeedinterp = 0.0;
                 float verticalSpeed = 0.0;
                 if(camera_view_type == HIGHWIND_VIEW && !highwind_view_and_square_pressed)
-                {                    
+                {
                     vector4<int> player_highwind_position;
                     ff7_externals.world_copy_player_pos_to_param_762798(&player_highwind_position);
 

--- a/src/ff7/world/renderer.cpp
+++ b/src/ff7/world/renderer.cpp
@@ -23,6 +23,8 @@
 
 #include "renderer.h"
 #include "camera.h"
+#include "cfg.h"
+#include "gl.h"
 
 #include "../defs.h"
 #include "../../lighting.h"

--- a/src/ff7/world/renderer.cpp
+++ b/src/ff7/world/renderer.cpp
@@ -21,10 +21,11 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include "renderer.h"
+#include "ff7/world/renderer.h"
 #include "camera.h"
 #include "cfg.h"
 #include "gl.h"
+#include "globals.h"
 
 #include "../defs.h"
 #include "../../lighting.h"
@@ -45,9 +46,9 @@ namespace ff7::world {
     }
 
     void wm0_overworld_draw_all() {
-       auto game_object = (struct ff7_game_obj *)common_externals.get_game_object();               
+       auto game_object = (struct ff7_game_obj *)common_externals.get_game_object();
         if (game_object) update_view_matrix (game_object);
-        worldRenderer.drawWorldMapExternalMesh();    
+        worldRenderer.drawWorldMapExternalMesh();
         ff7_externals.world_wm0_overworld_draw_all_74C179();
     }
 
@@ -61,7 +62,7 @@ namespace ff7::world {
     }
 
     void wm2_underwater_draw_all() {
-        auto game_object = (struct ff7_game_obj *)common_externals.get_game_object();               
+        auto game_object = (struct ff7_game_obj *)common_externals.get_game_object();
         if (game_object) update_view_matrix (game_object);
         		const int worldmap_type = *ff7_externals.world_map_type_E045E8;
 		newRenderer.setFogEnabled(true);
@@ -71,7 +72,7 @@ namespace ff7::world {
     }
 
     void wm3_snowstorm_draw_all() {
-        auto game_object = (struct ff7_game_obj *)common_externals.get_game_object();               
+        auto game_object = (struct ff7_game_obj *)common_externals.get_game_object();
         if (game_object) update_view_matrix (game_object);
         worldRenderer.drawWorldMapExternalMesh();
         ff7_externals.world_wm3_snowstorm_draw_all_74C589();
@@ -113,7 +114,7 @@ namespace ff7::world {
         ::memcpy(&viewMatrix.m[0][0], newRenderer.getViewMatrix(), sizeof(viewMatrix.m));
 
         vector3<float> viewPos = {0.0f, 0.0f, 0.0f};
-        transform_point(&viewMatrix, &worldPos, &viewPos);    
+        transform_point(&viewMatrix, &worldPos, &viewPos);
 
         struct matrix invViewMatrix;
         ::memcpy(&invViewMatrix.m[0][0], newRenderer.getInvViewMatrix(), sizeof(invViewMatrix.m));
@@ -141,7 +142,7 @@ namespace ff7::world {
     void world_draw_effects()
     {
         short v0;
-        transform_matrix rot_matrix_0; 
+        transform_matrix rot_matrix_0;
         transform_matrix rot_matrix_1;
         int v3;
         transform_matrix rot_matrix_2;
@@ -161,7 +162,7 @@ namespace ff7::world {
 
         world_effect_2d_list_node* eff_node = *ff7_externals.dword_E35648;
         world_effect_2d_list_node* next_node = nullptr;
-        while (eff_node) 
+        while (eff_node)
         {
             vector3<float> worldPos = {static_cast<float>(eff_node->x), static_cast<float>(eff_node->y), static_cast<float>(eff_node->z)};
             vector3<float> newWorldPos = calcSphericalWorldPos(worldPos);
@@ -221,18 +222,18 @@ namespace ff7::world {
         if ( previous_position < ff7_externals.world_snake_data_position_E29F80 )
             previous_position = &(ff7_externals.world_snake_data_position_E29F80[47]);
 
-        
+
         for ( snake_data = ff7_externals.world_snake_graphics_data_E2A490;
                 snake_data < ff7_externals.world_snake_graphics_data_end_E2A6D0;
                 ++snake_data )
-        {     
+        {
             previous_position += 4;
             if ( previous_position >= ff7_externals.snake_position_size_of_array_E2A100 )
-            previous_position -= 48;            
-            
+            previous_position -= 48;
+
             if ( ff7_externals.sub_753366(((int)previous_position->x >> 13) + 26, ((int)previous_position->y >> 13) + 16) )
             {
-                vector3<float> prevPos = { static_cast<float>(previous_position->x + 212992), 
+                vector3<float> prevPos = { static_cast<float>(previous_position->x + 212992),
                                            static_cast<float>(0),
                                            static_cast<float>(previous_position->y + 0x20000)};
                 vector3<float> newPrevWorldPos = calcSphericalWorldPos(prevPos);
@@ -252,7 +253,7 @@ namespace ff7::world {
                         ff7_externals.world_draw_snake_texture_75D544(300, 300, unknown + v1, v2, snake_data, 0);// first two parameters = width and height of one block of the snake
                         previous_position = previous_position_backup;
                     }
-                }               
+                }
             }
 
 
@@ -273,7 +274,7 @@ namespace ff7::world {
         struct game_mode* mode = getmode_cached();
 
         struct matrix projection_matrix;
-        ::memcpy(&projection_matrix.m[0][0], &a2->m[0][0], sizeof(projection_matrix.m));    
+        ::memcpy(&projection_matrix.m[0][0], &a2->m[0][0], sizeof(projection_matrix.m));
 
         if (mode->driver_mode == MODE_WORLDMAP)
         {
@@ -287,11 +288,11 @@ namespace ff7::world {
             float f = b / (a + 1.0f) + f_offset;
             float n = b / (a - 1.0f) + n_offset;
 
-            
+
             projection_matrix._33 = -(f + n) / (f -n);
-            projection_matrix._43 = -(2*f*n) / (f - n);            
+            projection_matrix._43 = -(2*f*n) / (f - n);
         }
-    
+
         ff7_externals.engine_apply_4x4_matrix_product_between_matrices_66C6CD(a1, &projection_matrix, a3);
     }
 
@@ -357,7 +358,7 @@ namespace ff7::world {
     {
         externalWorldMapModel.unloadExternalMesh();
         externalCloudsModel.unloadExternalMesh();
-        externalMeteorModel.unloadExternalMesh();    
+        externalMeteorModel.unloadExternalMesh();
     }
 
     bool Renderer::drawWorldMapExternalMesh()
@@ -473,7 +474,7 @@ namespace ff7::world {
                     vector3<float> centerShifted;
                     centerShifted.x = center.x + gridX * 294912;
                     centerShifted.y = center.z;
-                    centerShifted.z = center.y + gridZ * 229376;      
+                    centerShifted.z = center.y + gridZ * 229376;
 
                     vector2<float> diff;
                     diff.x = world_pos_x - centerShifted.x;
@@ -502,7 +503,7 @@ namespace ff7::world {
                     {
                         continue;
                     }
-                    
+
                     if (isFirstBinding)
                     {
                         newRenderer.setWorldViewMatrix(&worldViewMatrix[3 * (gridX + 1) + gridZ + 1]);
@@ -511,8 +512,8 @@ namespace ff7::world {
                         isFirstBinding = false;
                     }
                     else
-                    {				
-                        newRenderer.setWorldViewMatrix(&worldViewMatrix[3 * (gridX + 1) + gridZ + 1], false);    
+                    {
+                        newRenderer.setWorldViewMatrix(&worldViewMatrix[3 * (gridX + 1) + gridZ + 1], false);
                         newRenderer.setUniform(RendererUniform::WORLD_VIEW, newRenderer.getWorldViewMatrix());
                     }
 
@@ -612,7 +613,7 @@ namespace ff7::world {
         const float scaleY = scaleX / 4;
         for(int i = 0; i < numQuads; ++i)
         {
-            identity_matrix(&worldViewMatrix[i]);  
+            identity_matrix(&worldViewMatrix[i]);
 
             float offset = 2.0f * scaleX * (i- numQuads / 2);
             float cameraOffset = -4.0f * scaleX * (std::remainder(ff7::world::camera.getRotationOffsetY(), 360.0f) / 360.0f);
@@ -634,14 +635,14 @@ namespace ff7::world {
             worldMatrix._43 = focusPos.z + forward.z * 100000 + totalOffset * right.z;
 
             multiply_matrix(&worldMatrix, &viewMatrix, &worldViewMatrix[i]);
-        
+
         }
 
         newRenderer.setInterpolationQualifier(SMOOTH);
         newRenderer.setPrimitiveType();
         newRenderer.isTLVertex(false);
         newRenderer.setBlendMode(RendererBlendMode::BLEND_ADD);
-        newRenderer.doTextureFiltering(true);    
+        newRenderer.doTextureFiltering(true);
         newRenderer.isExternalTexture(true);
         newRenderer.isTexture(true);
         newRenderer.doDepthTest(true);
@@ -670,7 +671,7 @@ namespace ff7::world {
             }
         }
 
-        newRenderer.setWorldViewMatrix(&worldViewMatrix[0]);    
+        newRenderer.setWorldViewMatrix(&worldViewMatrix[0]);
         newRenderer.setCommonUniforms();
 
         auto shapeCount = externalCloudsModel.shapes.size();
@@ -709,7 +710,7 @@ namespace ff7::world {
                     else newRenderer.useTexture(0, RendererTextureSlot::TEX_PBR);
                 }
 
-                newRenderer.bindTextures();      
+                newRenderer.bindTextures();
             }
 
             for(int i = 0; i < numQuads; ++i)
@@ -723,7 +724,7 @@ namespace ff7::world {
                 newRenderer.draw(true, true, true);
             }
         }
-        
+
         newRenderer.discardAllBindings();
 
         newRenderer.setSphericalWorldRate(1.0f);
@@ -817,7 +818,7 @@ namespace ff7::world {
             }
         }
 
-        newRenderer.setWorldViewMatrix(&worldViewMatrix);    
+        newRenderer.setWorldViewMatrix(&worldViewMatrix);
         newRenderer.setCommonUniforms();
 
         auto shapeCount = externalMeteorModel.shapes.size();
@@ -856,12 +857,12 @@ namespace ff7::world {
                     else newRenderer.useTexture(0, RendererTextureSlot::TEX_PBR);
                 }
 
-                newRenderer.bindTextures();      
+                newRenderer.bindTextures();
             }
 
             newRenderer.draw(true, true, true);
         }
-        
+
         newRenderer.discardAllBindings();
 
         newRenderer.setSphericalWorldRate(1.0f);
@@ -874,8 +875,8 @@ namespace ff7::world {
         if(gl_defer_cloud_external_mesh()) return false;
 
         if (isDrawMeteor) drawMeteorExternalMesh();
-        drawCloudsExternalMesh();  
+        drawCloudsExternalMesh();
 
-        return true;  
+        return true;
     }
 }

--- a/src/ff7/world/renderer.cpp
+++ b/src/ff7/world/renderer.cpp
@@ -24,6 +24,7 @@
 #include "renderer.h"
 #include "camera.h"
 
+#include "../defs.h"
 #include "../../lighting.h"
 
 namespace ff7::world {

--- a/src/ff7/world/renderer.h
+++ b/src/ff7/world/renderer.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "../../external_mesh.h"
+#include "../../ff7.h"
 
 namespace ff7::world {
 

--- a/src/ff7/world/renderer.h
+++ b/src/ff7/world/renderer.h
@@ -23,8 +23,8 @@
 
 #pragma once
 
-#include "../../external_mesh.h"
-#include "../../ff7.h"
+#include "external_mesh.h"
+#include "ff7.h"
 
 namespace ff7::world {
 

--- a/src/ff7/world/utils.h
+++ b/src/ff7/world/utils.h
@@ -21,6 +21,8 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#pragma once
+
 namespace ff7::world
 {
     bool is_key_pressed(int current_key_status, int key)

--- a/src/ff7/world/world.cpp
+++ b/src/ff7/world/world.cpp
@@ -26,6 +26,7 @@
 #include "../../patch.h"
 #include "../../sfx.h"
 
+#include "cfg.h"
 #include "defs.h"
 #include "world.h"
 #include "utils.h"

--- a/src/ff7/world/world.h
+++ b/src/ff7/world/world.h
@@ -25,10 +25,6 @@
 
 #include "matrix.h"
 
-#include "globals.h"
-
-#include <string>
-
 namespace ff7::world
 {
     enum input_key

--- a/src/ff7/world/world.h
+++ b/src/ff7/world/world.h
@@ -20,6 +20,9 @@
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
+
+#pragma once
+
 #include "matrix.h"
 
 #include "globals.h"

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -22,6 +22,11 @@
 
 #pragma once
 
+#include <functional>
+
+#include "ff7.h"
+#include "globals.h"
+#include "log.h"
 #include "patch.h"
 
 // FF7 game mode definitions

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -61,14 +61,14 @@ static struct game_mode ff7_modes[] = {
 	{FF7_MODE_UNKNOWN28,   "MODE_UNKNOWN28",   MODE_UNKNOWN,     false },
 };
 
-void ff7_set_main_loop(uint32_t driver_mode, uint32_t main_loop)
+inline void ff7_set_main_loop(uint32_t driver_mode, uint32_t main_loop)
 {
 	uint32_t i;
 
 	for(i = 0; i < num_modes; i++) if(ff7_modes[i].driver_mode == driver_mode) ff7_modes[i].main_loop = main_loop;
 }
 
-void ff7_find_externals(struct ff7_game_obj* game_object)
+inline void ff7_find_externals(struct ff7_game_obj* game_object)
 {
 	uint32_t main_init_loop = (uint32_t)game_object->engine_loop_obj.init;
 	uint32_t main_loop = (uint32_t)game_object->engine_loop_obj.main_loop;
@@ -1130,7 +1130,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.pollensalta_cold_breath_atk_draw_white_dots_547E75 = (void(*)(short))get_relative_call(ff7_externals.pollensalta_cold_breath_atk_white_dot_effect_547D56, 0x20);
 	ff7_externals.pollensalta_cold_breath_white_dots_pos = std::span((vector4<short>*) get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_white_dot_effect_547D56, 0x79), 400);
 	ff7_externals.pollensalta_cold_breath_white_dot_rgb_scalar = (short*) get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_white_dot_effect_547D56, 0x1B);
-	ff7_externals.pollensalta_cold_breath_bg_texture_ctx = get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_draw_bg_effect_547B94, 0x2A);	
+	ff7_externals.pollensalta_cold_breath_bg_texture_ctx = get_absolute_value(ff7_externals.pollensalta_cold_breath_atk_draw_bg_effect_547B94, 0x2A);
 	uint32_t pandora_box_skill_enter_5667E1 = ff7_externals.enemy_skill_effects_fn_table[23];
 	uint32_t pandora_box_skill_main_566806 = get_relative_call(pandora_box_skill_enter_5667E1, 0x1A);
 	uint32_t pandora_box_skill_sub_566871 = get_absolute_value(pandora_box_skill_main_566806, 0x30);
@@ -1204,7 +1204,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.world_snake_data_position_E29F80 = (vector4<short> *)get_absolute_value((uint32_t)ff7_externals.animate_world_snake_75692A, 0x2A);
 	ff7_externals.world_snake_graphics_data_E2A490 = (world_snake_graphics_data *)get_absolute_value(ff7_externals.animate_world_snake_75692A, 0x3A);
 	ff7_externals.world_snake_graphics_data_end_E2A6D0 = (world_snake_graphics_data *)get_absolute_value(ff7_externals.animate_world_snake_75692A, 0x4C);
-	ff7_externals.snake_position_size_of_array_E2A100 = (vector4<short> *)get_absolute_value(ff7_externals.update_world_snake_position_7564CD, 0x3C);	
+	ff7_externals.snake_position_size_of_array_E2A100 = (vector4<short> *)get_absolute_value(ff7_externals.update_world_snake_position_7564CD, 0x3C);
 	ff7_externals.world_opcode_message_sub_75EE86 = get_relative_call(ff7_externals.run_world_event_scripts_system_operations, 0xB6D);
 	ff7_externals.world_opcode_ask_sub_75EEBB = get_relative_call(ff7_externals.run_world_event_scripts_system_operations, 0xBA1);
 	ff7_externals.world_opcode_message = get_relative_call(ff7_externals.world_sub_75EF46, 0x8C);
@@ -1296,7 +1296,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.world_compute_skybox_data_754100 = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x537);
 	ff7_externals.world_submit_draw_clouds_and_meteor_7547A6 = get_relative_call(ff7_externals.world_mode_loop_sub_74DB8C, 0x547);
 	ff7_externals.world_sub_75F0AD = get_relative_call(ff7_externals.world_sub_751EFC, 0x551);
-	ff7_externals.world_sub_75042B = get_relative_call(ff7_externals.world_compute_3d_model_data_76328F, 0x37D);	
+	ff7_externals.world_sub_75042B = get_relative_call(ff7_externals.world_compute_3d_model_data_76328F, 0x37D);
 	ff7_externals.world_player_pos_E04918 = (vector4<int>*)get_absolute_value(ff7_externals.world_sub_75042B, 0xE);
 		ff7_externals.sub_74C9A5 = (int (*)())get_relative_call(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6, 0x09);
 	ff7_externals.is_meteor_flag_on_E2AAE4 = (int*)get_absolute_value(ff7_externals.world_submit_draw_clouds_and_meteor_7547A6, 0x592);
@@ -1308,7 +1308,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.world_get_world_current_camera_rotation_x_74D3C6 = (short (*)())get_relative_call(ff7_externals.world_sub_75C0FD, 0x30);
 	ff7_externals.world_submit_draw_effects_75C283 = (int (_stdcall *)(world_texture_data *, int, vector3<short>*, short))get_relative_call(ff7_externals.world_sub_75C0FD, 0x175);
 	ff7_externals.dword_E35648 = (world_effect_2d_list_node**)get_absolute_value(ff7_externals.world_sub_75C0FD, 0x5B);
-	ff7_externals.byte_96D6A8 = (byte*)get_absolute_value(ff7_externals.world_sub_75C0FD, 0x169);	
+	ff7_externals.byte_96D6A8 = (byte*)get_absolute_value(ff7_externals.world_sub_75C0FD, 0x169);
 
 	// Swirl externals
 	ff7_externals.swirl_main_loop = swirl_main_loop;
@@ -1452,7 +1452,7 @@ void ff7_find_externals(struct ff7_game_obj* game_object)
 	// --------------------------------
 }
 
-void ff7_data(struct ff7_game_obj* game_object)
+inline void ff7_data(struct ff7_game_obj* game_object)
 {
 	num_modes = sizeof(ff7_modes) / sizeof(ff7_modes[0]);
 

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -21,13 +21,9 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include "renderer.h"
 #include "cfg.h"
 #include "ff7.h"
-#include "gl.h"
 #include "patch.h"
-#include "movies.h"
-#include "music.h"
 #include "ff7/defs.h"
 #include "ff7_data.h"
 #include "ff7/widescreen.h"

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -32,6 +32,9 @@
 #include "ff7_data.h"
 #include "ff7/widescreen.h"
 #include "ff7/time.h"
+#include "ff7/battle/defs.h"
+#include "ff7/field/defs.h"
+#include "ff7/world/defs.h"
 
 unsigned char midi_fix[] = {0x8B, 0x4D, 0x14};
 WORD snowboard_fix[] = {0x0F, 0x10, 0x0F};
@@ -253,7 +256,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 			if(ff7_fps_limiter == FPS_LIMITER_60FPS)
 			{
 				common_frame_multiplier = 2;
-				
+
 				// Swirl mode 60FPS fix
 				patch_multiply_code<byte>(ff7_externals.swirl_main_loop + 0x184, common_frame_multiplier); // wait frames before swirling
 				patch_multiply_code<byte>(ff7_externals.swirl_loop_sub_4026D4 + 0x3E, common_frame_multiplier);
@@ -347,9 +350,9 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	if(enable_analogue_controls) {
 		replace_call_function(ff7_externals.battle_sub_42D992 + 0xFB, ff7::battle::update_battle_camera);
 		replace_function((uint32_t)ff7_externals.field_clip_with_camera_range_6438F6, ff7::field::ff7_field_clip_with_camera_range);
-		
+
 		// Disable show targets with R2 in battles
-        memset_code(ff7_externals.handle_actor_ready + 0xA8, 0x90, 29);	
+        memset_code(ff7_externals.handle_actor_ready + 0xA8, 0x90, 29);
 	}
 
 	//######################

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -22,8 +22,10 @@
 
 #pragma once
 
-#include "common.h"
-#include "matrix.h"
+#include <stdint.h>
+#include <windows.h>
+
+#include "common_imports.h"
 
 // FF7 modules, unknowns are either unused or not relevant to rendering
 enum ff8_game_modes

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdio.h>
 #include <windows.h>
 
 #include "common_imports.h"

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -25,6 +25,8 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <windows.h>
+#include <ddraw.h>
+#include <dinput.h>
 
 #include "common_imports.h"
 

--- a/src/ff8/ambient.cpp
+++ b/src/ff8/ambient.cpp
@@ -20,6 +20,9 @@
 /****************************************************************************/
 
 #include "ambient.h"
+#include "audio.h"
+#include "common.h"
+#include "globals.h"
 
 void ff8_handle_ambient_playback()
 {

--- a/src/ff8/ambient.h
+++ b/src/ff8/ambient.h
@@ -21,7 +21,4 @@
 
 #pragma once
 
-#include "../audio.h"
-#include "../ff8.h"
-
 void ff8_handle_ambient_playback();

--- a/src/ff8/battle/stage.cpp
+++ b/src/ff8/battle/stage.cpp
@@ -23,7 +23,6 @@
 
 #include "stage.h"
 #include "../../image/tim.h"
-#include "../../saveload.h"
 #include "../../log.h"
 
 #include <set>

--- a/src/ff8/battle/stage.h
+++ b/src/ff8/battle/stage.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include "../../common.h"
 #include "../../image/tim.h"
 
 #include <vector>

--- a/src/ff8/engine.cpp
+++ b/src/ff8/engine.cpp
@@ -20,9 +20,12 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include <vector>
+#include <string>
+
+#include "../globals.h"
+
 #include "engine.h"
-#include "../ff8.h"
-#include "../log.h"
 
 static const std::vector<std::string> ff8_table = {
   " ","0","1","2","3","4","5","6","7","8","9","%","/",":","!","?",

--- a/src/ff8/engine.h
+++ b/src/ff8/engine.h
@@ -22,9 +22,7 @@
 
 #pragma once
 
-#include "../ff8.h"
-
-#include <sstream>
+#include <string>
 
 int ff8_manage_time_engine(int enable_rdtsc);
 std::string ff8_decode_text(const char* encoded_text);

--- a/src/ff8/field/background.h
+++ b/src/ff8/field/background.h
@@ -23,8 +23,6 @@
 
 #pragma once
 
-#include "../../common.h"
-
 #include <vector>
 
 constexpr int TEXTURE_WIDTH_BYTES = 128; // Real texture width depends on the texture depth (bpp4 => 256, bpp8 => 128, bpp16 => 64)

--- a/src/ff8/field/chara_one.cpp
+++ b/src/ff8/field/chara_one.cpp
@@ -23,7 +23,6 @@
 
 #include "chara_one.h"
 #include "../../image/tim.h"
-#include "../../saveload.h"
 #include "../../log.h"
 
 std::unordered_map<uint32_t, CharaOneModel> ff8_chara_one_parse_models(const uint8_t *chara_one_data, size_t size)

--- a/src/ff8/field/chara_one.h
+++ b/src/ff8/field/chara_one.h
@@ -23,8 +23,6 @@
 
 #pragma once
 
-#include "../../common.h"
-
 #include <vector>
 #include <unordered_map>
 

--- a/src/ff8/file.cpp
+++ b/src/ff8/file.cpp
@@ -21,6 +21,7 @@
 /****************************************************************************/
 
 #include "file.h"
+#include "utils.h"
 #include "../ff8.h"
 #include "../log.h"
 #include "../redirect.h"

--- a/src/ff8/mod.cpp
+++ b/src/ff8/mod.cpp
@@ -19,12 +19,13 @@
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
-#include "mod.h"
 
 #include "../image/image.h"
 #include "../log.h"
 #include "../renderer.h"
 #include "../utils.h"
+
+#include "mod.h"
 #include "file.h"
 
 

--- a/src/ff8/mod.cpp
+++ b/src/ff8/mod.cpp
@@ -21,11 +21,10 @@
 /****************************************************************************/
 #include "mod.h"
 
-#include <set>
-
 #include "../image/image.h"
 #include "../log.h"
 #include "../renderer.h"
+#include "../utils.h"
 #include "file.h"
 
 

--- a/src/ff8/texture_packer.cpp
+++ b/src/ff8/texture_packer.cpp
@@ -23,7 +23,6 @@
 
 #include "texture_packer.h"
 #include "../saveload.h"
-#include "../patch.h"
 #include "../renderer.h"
 #include "cfg.h"
 #include "log.h"

--- a/src/ff8/texture_packer.cpp
+++ b/src/ff8/texture_packer.cpp
@@ -19,12 +19,16 @@
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
+#include <set>
+
 #include "texture_packer.h"
 #include "../saveload.h"
 #include "../patch.h"
 #include "../renderer.h"
+#include "cfg.h"
+#include "log.h"
 #include "mod.h"
-#include <set>
+#include "gl.h"
 
 // Scale 32-bit BGRA image
 void scale_up_image_data(const uint32_t *source, uint32_t *target, uint32_t w, uint32_t h, uint8_t scale)

--- a/src/ff8/uv_patch.cpp
+++ b/src/ff8/uv_patch.cpp
@@ -20,10 +20,12 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include "uv_patch.h"
+#include <stdint.h>
 
-#include "../log.h"
+#include "../globals.h"
 #include "../patch.h"
+
+#include "uv_patch.h"
 
 struct TexCoord {
 	uint8_t x, y;

--- a/src/ff8/vibration.cpp
+++ b/src/ff8/vibration.cpp
@@ -22,8 +22,6 @@
 #include "vibration.h"
 #include "../ff8.h"
 #include "../log.h"
-#include "../gamepad.h"
-#include "../joystick.h"
 #include "../patch.h"
 #include "../vibration.h"
 #include "battle/effects.h"

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -35,6 +35,7 @@
 #include "world/wmset.h"
 #include "battle/stage.h"
 
+#include <shlwapi.h>
 #include <unordered_map>
 #include <vector>
 

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -28,6 +28,7 @@
 #include "../utils.h"
 #include "../globals.h"
 #include "../cfg.h"
+#include "../log.h"
 #include "field/background.h"
 #include "field/chara_one.h"
 #include "world/chara_one.h"

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -26,6 +26,8 @@
 #include "../macro.h"
 #include "../image/tim.h"
 #include "../utils.h"
+#include "../globals.h"
+#include "../cfg.h"
 #include "field/background.h"
 #include "field/chara_one.h"
 #include "world/chara_one.h"

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -34,11 +34,9 @@
 #include "world/chara_one.h"
 #include "world/wmset.h"
 #include "battle/stage.h"
-#include "file.h"
 
 #include <unordered_map>
 #include <vector>
-#include <filesystem>
 
 TexturePacker texturePacker;
 

--- a/src/ff8/world/chara_one.cpp
+++ b/src/ff8/world/chara_one.cpp
@@ -23,7 +23,6 @@
 
 #include "chara_one.h"
 #include "../../image/tim.h"
-#include "../../saveload.h"
 #include "../../log.h"
 
 std::vector<CharaOneModelTextures> ff8_world_chara_one_parse_models(const uint8_t *chara_one_data, size_t size)

--- a/src/ff8/world/chara_one.h
+++ b/src/ff8/world/chara_one.h
@@ -23,8 +23,6 @@
 
 #pragma once
 
-#include "../../common.h"
-
 #include <vector>
 
 typedef std::vector<uint32_t> CharaOneModelTextures;

--- a/src/ff8/world/wmset.cpp
+++ b/src/ff8/world/wmset.cpp
@@ -23,7 +23,6 @@
 
 #include "wmset.h"
 #include "../../image/tim.h"
-#include "../../saveload.h"
 #include "../../log.h"
 
 std::vector<WmsetSection17Texture> ff8_world_wmset_wave_animations_parse(const uint8_t *wmset_section17_data, size_t size)

--- a/src/ff8/world/wmset.h
+++ b/src/ff8/world/wmset.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include "../../common.h"
 #include "../../image/tim.h"
 
 #include <vector>

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -22,6 +22,7 @@
 
 #include "ff8_data.h"
 
+#include "globals.h"
 #include "patch.h"
 #include "ff8/battle/effects.h"
 

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -20,6 +20,8 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include <stdio.h>
+
 #include "ff8_data.h"
 
 #include "globals.h"

--- a/src/ff8_data.h
+++ b/src/ff8_data.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "common.h"
 #include "ff8.h"
 
 // FF8 game mode definitions

--- a/src/ff8_data.h
+++ b/src/ff8_data.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include "patch.h"
+#include "ff8.h"
 
 // FF8 game mode definitions
 static struct game_mode ff8_modes[] = {

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -19,7 +19,6 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include "renderer.h"
 #include "globals.h"
 #include "common.h"
 #include "ff8.h"
@@ -29,7 +28,6 @@
 #include "macro.h"
 #include "movies.h"
 #include "gl.h"
-#include "saveload.h"
 #include "gamepad.h"
 #include "joystick.h"
 #include "gamehacks.h"

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -33,8 +33,10 @@
 #include "gamepad.h"
 #include "joystick.h"
 #include "gamehacks.h"
+#include "utils.h"
 #include "vibration.h"
 #include "ff8/file.h"
+#include "ff8/vram.h"
 #include "metadata.h"
 
 unsigned char texture_reload_fix1[] = {0x5B, 0x5F, 0x5E, 0x5D, 0x81, 0xC4, 0x10, 0x01, 0x00, 0x00};

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -26,6 +26,7 @@
 #include "globals.h"
 #include "common.h"
 #include "patch.h"
+#include "log.h"
 
 #include "field.h"
 

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -27,6 +27,7 @@
 #include "common.h"
 #include "patch.h"
 #include "log.h"
+#include "utils.h"
 
 #include "field.h"
 

--- a/src/field.h
+++ b/src/field.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <unordered_set>
+#include "globals.h"
 
 void field_init();
 void field_debug(bool *isOpen);

--- a/src/game_cfg.cpp
+++ b/src/game_cfg.cpp
@@ -25,6 +25,7 @@
 #include "patch.h"
 #include "globals.h"
 #include "cfg.h"
+#include "log.h"
 
 void normalize_path_win(char *name)
 {

--- a/src/game_cfg.cpp
+++ b/src/game_cfg.cpp
@@ -23,6 +23,8 @@
 #include "game_cfg.h"
 
 #include "patch.h"
+#include "globals.h"
+#include "cfg.h"
 
 void normalize_path_win(char *name)
 {

--- a/src/gamehacks.cpp
+++ b/src/gamehacks.cpp
@@ -20,8 +20,8 @@
 /****************************************************************************/
 
 #include "gamehacks.h"
-#include "music.h"
 #include "audio.h"
+#include "ff7/defs.h"
 #include "gamepad.h"
 #include "joystick.h"
 

--- a/src/gamehacks.h
+++ b/src/gamehacks.h
@@ -21,7 +21,8 @@
 
 #pragma once
 
-#include "log.h"
+#include <stdint.h>
+#include <windows.h>
 
 class GameHacks
 {

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -19,6 +19,8 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include <cmath>
+
 #include "gamepad.h"
 
 Gamepad gamepad;

--- a/src/gamepad.h
+++ b/src/gamepad.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <cmath>
 #include <Windows.h>
 #include <Xinput.h>
 

--- a/src/gl.h
+++ b/src/gl.h
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#include <map>
+#include <string>
+#include <vector>
+
 #include "common.h"
 
 #define VERTEX 1

--- a/src/gl/deferred.cpp
+++ b/src/gl/deferred.cpp
@@ -30,7 +30,6 @@
 #include "../ff7/battle/menu.h"
 #include "../ff7/widescreen.h"
 
-#include "ff7/field/background.h"
 #include "ff7/world/renderer.h"
 
 uint32_t nodefer = false;
@@ -135,7 +134,7 @@ uint32_t gl_defer_draw(uint32_t primitivetype, uint32_t vertextype, struct nvert
 		memcpy(deferred_draws[defer].normals, normals, sizeof(*normals) * vertexcount);
 	}
 
-	if(lightdata) 
+	if(lightdata)
 	{
 		deferred_draws[defer].lightdata = (struct light_data*)driver_malloc(sizeof(struct light_data));
 		memcpy(deferred_draws[defer].lightdata, lightdata, sizeof(struct light_data));

--- a/src/gl/gl.cpp
+++ b/src/gl/gl.cpp
@@ -20,14 +20,11 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include <windows.h>
 #include <stdio.h>
 #include <math.h>
 #include <algorithm>
 
 #include "../renderer.h"
-#include "../lighting.h"
-
 #include "../cfg.h"
 #include "../gl.h"
 #include "../macro.h"
@@ -254,7 +251,7 @@ void gl_calculate_normals(std::vector<vector3<float>>* pNormals, struct indexed_
 void gl_draw_without_lighting(struct indexed_primitive* ip, struct polygon_data *polydata, struct light_data* lightdata, uint32_t clip)
 {
 	static std::vector<vector3<float>> normals;
-	if (!ff8 && lightdata != nullptr && game_lighting != GAME_LIGHTING_ORIGINAL) 
+	if (!ff8 && lightdata != nullptr && game_lighting != GAME_LIGHTING_ORIGINAL)
 	{
 		gl_calculate_normals(&normals, ip, polydata, lightdata);
 		gl_draw_indexed_primitive(ip->primitivetype, ip->vertextype, ip->vertices, normals.data(), ip->vertexcount, ip->indices, ip->indexcount, 0, 0, lightdata, clip, true);
@@ -266,7 +263,7 @@ void gl_draw_with_lighting(struct indexed_primitive *ip, struct polygon_data *po
 {
 	static std::vector<vector3<float>> normals;
 	if (!ff8)
-	{ 
+	{
 		gl_calculate_normals(&normals, ip, polydata, lightdata);
 		gl_draw_indexed_primitive(ip->primitivetype, ip->vertextype, ip->vertices, normals.data(), ip->vertexcount, ip->indices, ip->indexcount, 0, polydata->boundingboxdata, lightdata, clip, true);
 	}
@@ -348,12 +345,12 @@ void gl_draw_indexed_primitive(uint32_t primitivetype, uint32_t vertextype, stru
 	newRenderer.bindIndexBuffer(indices, count);
 	newRenderer.setPrimitiveType(RendererPrimitiveType(primitivetype));
 
-	if(!ff8 && lightdata != nullptr && normals != nullptr && game_lighting != GAME_LIGHTING_ORIGINAL) 
+	if(!ff8 && lightdata != nullptr && normals != nullptr && game_lighting != GAME_LIGHTING_ORIGINAL)
 	{
 		newRenderer.setGameLightData(lightdata);
 	} else newRenderer.setGameLightData(nullptr);
 
-	if (!ff8 && enable_lighting && normals != nullptr && isLightingEnabledTexture) 
+	if (!ff8 && enable_lighting && normals != nullptr && isLightingEnabledTexture)
 	{
 		newRenderer.drawToShadowMap();
 		newRenderer.drawWithLighting(true, true);

--- a/src/gl/special_case.cpp
+++ b/src/gl/special_case.cpp
@@ -22,14 +22,11 @@
 
 #define _USE_MATH_DEFINES
 #include <math.h>
-#include "../renderer.h"
 
 #include "../gl.h"
 #include "../cfg.h"
 #include "../macro.h"
-#include "../log.h"
-#include "../ff8.h"
-#include "../saveload.h"
+#include "../globals.h"
 
 #include "../ff7/widescreen.h"
 

--- a/src/gl/texture.cpp
+++ b/src/gl/texture.cpp
@@ -24,7 +24,6 @@
 #include "../log.h"
 #include "../gl.h"
 #include "../macro.h"
-#include "../saveload.h"
 
 // check to make sure we can actually load a given texture
 bool gl_check_texture_dimensions(uint32_t width, uint32_t height, char *source)

--- a/src/globals.h
+++ b/src/globals.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <mimalloc-new-delete.h>
-#include <fstream>
 #include <windows.h>
 #include <toml++/toml.h>
 
@@ -40,12 +39,8 @@ extern "C" {
 }
 #endif
 
-#include "utils.h"
-
 #include "ff7.h"
-#include "ff7/defs.h"
 #include "ff8.h"
-#include "ff8/vram.h"
 
 #define FFNX_API __declspec(dllexport)
 

--- a/src/hext.cpp
+++ b/src/hext.cpp
@@ -22,6 +22,8 @@
 #include "hext.h"
 #include "log.h"
 #include "patch.h"
+#include "utils.h"
+#include <filesystem>
 #include <io.h>
 
 Hext hextPatcher;

--- a/src/hext.cpp
+++ b/src/hext.cpp
@@ -20,6 +20,8 @@
 /****************************************************************************/
 
 #include "hext.h"
+#include "log.h"
+#include "patch.h"
 #include <io.h>
 
 Hext hextPatcher;

--- a/src/hext.h
+++ b/src/hext.h
@@ -38,8 +38,6 @@
 #include <sstream>
 #include <vector>
 
-#include "patch.h"
-
 class Hext {
 private:
 	int inGlobalOffset;

--- a/src/hext.h
+++ b/src/hext.h
@@ -30,12 +30,7 @@
 
 #pragma once
 
-#include <algorithm>
-#include <cctype>
-#include <filesystem>
-#include <fstream>
-#include <locale>
-#include <sstream>
+#include <string>
 #include <vector>
 
 class Hext {

--- a/src/image/image.cpp
+++ b/src/image/image.cpp
@@ -20,11 +20,13 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include <stdio.h>
+#include <libpng16/png.h>
+
 #include "image.h"
 #include "../common.h"
 #include "../renderer.h"
-#include <stdio.h>
-#include <libpng16/png.h>
+#include "log.h"
 
 static void LibPngErrorCb(png_structp png_ptr, const char* error)
 {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -22,8 +22,8 @@
 #include <windowsx.h>
 #include <dinput.h>
 #include "input.h"
-#include "api.h"
 #include "gamehacks.h"
+#include "globals.h"
 
 byte keys[256];
 bool blockKeys = false;

--- a/src/input.h
+++ b/src/input.h
@@ -22,7 +22,6 @@
 #pragma once
 
 #include <windows.h>
-#include <functional>
 #include <vector>
 
 struct KeyEventArgs

--- a/src/joystick.h
+++ b/src/joystick.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <string>
 #include <vector>
 #include <dinput.h>
 

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -27,6 +27,7 @@
 #include "ff8.h"
 #include "field.h"
 #include "cfg.h"
+#include "utils.h"
 
 Lighting lighting;
 

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -22,11 +22,9 @@
 
 #include "lighting.h"
 #include "gl.h"
+#include "globals.h"
 #include "renderer.h"
 #include "macro.h"
-#include "ff7.h"
-#include "ff8.h"
-#include "field.h"
 #include "cfg.h"
 #include "utils.h"
 

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -21,6 +21,7 @@
 /****************************************************************************/
 
 #include "lighting.h"
+#include "gl.h"
 #include "renderer.h"
 #include "macro.h"
 #include "ff7.h"

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -22,11 +22,11 @@
 
 #pragma once
 
-#include "matrix.h"
-#include "common.h"
-#include "globals.h"
+#include "common_imports.h"
 
 #include <vector>
+#include <toml++/toml.h>
+#include <windows.h>
 
 enum DebugOutput
 {

--- a/src/lighting_debug.cpp
+++ b/src/lighting_debug.cpp
@@ -16,6 +16,7 @@
 #include "lighting_debug.h"
 #include "lighting.h"
 #include "cfg.h"
+#include "common.h"
 
 #include <imgui.h>
 #include <math.h>
@@ -81,7 +82,7 @@ void lighting_debug(bool* isOpen)
         float lightIntensity = lighting.getLightIntensity();
         if (ImGui::DragFloat("Intensity##0", &lightIntensity, 0.01f, 0.0f, 100.0f))
         {
-            lighting.setLightIntensity(lightIntensity);            
+            lighting.setLightIntensity(lightIntensity);
             lighting.setConfigEntry("light_intensity", lightIntensity);
         }
         vector3<float> lightColorPoint3d = lighting.getLightColor();

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -25,8 +25,7 @@
 
 #include "log.h"
 #include "hext.h"
-
-#include "renderer.h"
+#include "utils.h"
 
 #define FFNX_DEBUG_BUFFER_SIZE 4096
 

--- a/src/log.h
+++ b/src/log.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+// Header include necessary due to macro dependencies
 #include "cfg.h"
 #include "common.h"
 #include "globals.h"

--- a/src/macro.h
+++ b/src/macro.h
@@ -21,9 +21,6 @@
 
 #pragma once
 
-#include "globals.h"
-#include "cfg.h"
-
 #define LIST_FOR_EACH(X, Y) for((X) = (Y)->head; (X); (X) = (X)->next)
 
 /*

--- a/src/md5.h
+++ b/src/md5.h
@@ -32,7 +32,6 @@ documentation and/or software.
 
 #pragma once
 
-#include <cstring>
 #include <iostream>
 
 

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -19,7 +19,11 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include <chrono>
+
 #include "metadata.h"
+#include "log.h"
+#include "md5.h"
 
 Metadata metadataPatcher;
 

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -19,6 +19,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include <shlwapi.h>
 #include <chrono>
 
 #include "metadata.h"

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -24,6 +24,7 @@
 #include "metadata.h"
 #include "log.h"
 #include "md5.h"
+#include "utils.h"
 
 Metadata metadataPatcher;
 

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -21,16 +21,10 @@
 
 #pragma once
 
-#include <chrono>
-#include <cstring>
 #include <io.h>
-#include <sstream>
 
 #include <pugiconfig.hpp>
 #include <pugixml.hpp>
-
-#include "log.h"
-#include "md5.h"
 
 class Metadata
 {

--- a/src/movies.cpp
+++ b/src/movies.cpp
@@ -22,11 +22,7 @@
 
 #include "audio.h"
 #include "movies.h"
-#include "renderer.h"
-#include "gl.h"
 #include "patch.h"
-#include "field.h"
-#include "ff7/defs.h"
 #include "ff7/widescreen.h"
 #include "video/movies.h"
 #include "redirect.h"

--- a/src/movies.h
+++ b/src/movies.h
@@ -22,8 +22,6 @@
 
 #pragma once
 
-#include "common.h"
-
 extern short movie_fps_ratio = 1;
 extern bool is_movie_bgfield = false;
 

--- a/src/music.h
+++ b/src/music.h
@@ -21,5 +21,7 @@
 
 #pragma once
 
+#include <stdint.h>
+
 void ff7_play_midi(uint32_t music_id);
 void music_init();

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -21,14 +21,12 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
-#include "renderer.h"
+#include "api.h"
+#include "field.h"
 #include "overlay.h"
 #include <bx/file.h>
 #include "cfg.h"
-#include "field.h"
 #include "world.h"
-#include "api.h"
-#include "renderer.h"
 #include "lighting_debug.h"
 
 #define IMGUI_VIEW_ID 255

--- a/src/patch.h
+++ b/src/patch.h
@@ -21,7 +21,8 @@
 
 #pragma once
 
-#include "log.h"
+#include <cstdint>
+#include <windows.h>
 
 uint32_t replace_function(uint32_t offset, void *func);
 // Can also unreplace a call_function

--- a/src/patch.h
+++ b/src/patch.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <windows.h>
 
 uint32_t replace_function(uint32_t offset, void *func);

--- a/src/redirect.cpp
+++ b/src/redirect.cpp
@@ -19,6 +19,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include <shlwapi.h>
 #include <filesystem>
 #include <io.h>
 #include "log.h"

--- a/src/redirect.cpp
+++ b/src/redirect.cpp
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <io.h>
 #include "log.h"
+#include "utils.h"
 
 #include "redirect.h"
 

--- a/src/redirect.h
+++ b/src/redirect.h
@@ -19,5 +19,7 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#pragma once
+
 int attempt_redirection(const char* in, char* out, size_t size, bool wantsSteamPath = false);
 int redirect_path_with_override(const char* in, char* out, size_t out_size);

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -2641,3 +2641,4 @@ void Renderer::setGameLightData(light_data* lightdata)
         internalState.gameScriptedLightColor[2] = 1.0;
     }
 }
+

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -31,15 +31,14 @@
 #include <windows.h>
 #include <vector>
 
-#include "renderer.h"
 #include "lighting.h"
 #include "ff7/widescreen.h"
-#include "ff7/world/world.h"
 #include "image/image.h"
 #include "gl.h"
 #include "log.h"
 #include "cfg.h"
 #include "utils.h"
+#include "renderer.h"
 
 CMRC_DECLARE(FFNx);
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -28,17 +28,18 @@
 #define WINVER 0x0A00
 #define _WIN32_WINNT 0x0A00
 
+#include <windows.h>
+#include <vector>
+
 #include "renderer.h"
 #include "lighting.h"
 #include "ff7/widescreen.h"
-#include "ff7/time.h"
 #include "ff7/world/world.h"
-#include "ff7/world/camera.h"
+#include "image/image.h"
+#include "gl.h"
+#include "log.h"
 #include "cfg.h"
 #include "utils.h"
-#include "image/image.h"
-#include <windows.h>
-#include <vector>
 
 CMRC_DECLARE(FFNx);
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -35,6 +35,7 @@
 #include "ff7/world/world.h"
 #include "ff7/world/camera.h"
 #include "cfg.h"
+#include "utils.h"
 #include "image/image.h"
 #include <windows.h>
 #include <vector>

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include "common.h"
+#include "overlay.h"
+
 #include <cmrc/cmrc.hpp>
 #include <vector>
 #include <array>
@@ -36,9 +39,6 @@
 #include <bimg/encode.h>
 #include <bgfx/platform.h>
 #include <bgfx/bgfx.h>
-
-#include "common.h"
-#include "overlay.h"
 
 #define FFNX_RENDERER_INVALID_HANDLE { 0 }
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+// TODO: fix imports
+
 #include <filesystem>
 #include <iterator>
 #include <vector>

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <cmrc/cmrc.hpp>
 #include <vector>
 #include <array>
 #include <string>
@@ -35,7 +36,6 @@
 #include <bimg/encode.h>
 #include <bgfx/platform.h>
 #include <bgfx/bgfx.h>
-#include <cmrc/cmrc.hpp>
 
 #include "common.h"
 #include "overlay.h"

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -22,12 +22,8 @@
 
 #pragma once
 
-// TODO: fix imports
-
-#include <filesystem>
-#include <iterator>
 #include <vector>
-#include <map>
+#include <array>
 #include <string>
 #include <math.h>
 #include <bx/math.h>
@@ -40,8 +36,8 @@
 #include <bgfx/platform.h>
 #include <bgfx/bgfx.h>
 #include <cmrc/cmrc.hpp>
-#include "log.h"
-#include "gl.h"
+
+#include "common.h"
 #include "overlay.h"
 
 #define FFNX_RENDERER_INVALID_HANDLE { 0 }

--- a/src/saveload.cpp
+++ b/src/saveload.cpp
@@ -26,7 +26,7 @@
 
 #include "log.h"
 #include "gl.h"
-#include "macro.h"
+#include "utils.h"
 
 #include <xxhash.h>
 

--- a/src/saveload.h
+++ b/src/saveload.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 void make_path(const char *name);
 void normalize_path(char *name);
 void save_texture(const void *data, uint32_t dataSize, uint32_t width, uint32_t height, uint32_t palette_index, const char *name, bool is_animated);

--- a/src/sfx.h
+++ b/src/sfx.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <math.h>
 #include <stdint.h>
 
 void sfx_process_footstep(bool is_player_moving);

--- a/src/vibration.h
+++ b/src/vibration.h
@@ -25,8 +25,7 @@
 #include <stdint.h>
 #include <unordered_map>
 #include <string>
-
-#include "cfg.h"
+#include <toml++/toml.h>
 
 constexpr int LEFT_MOTOR_DURATION_FRAMES = 5;
 constexpr int LEFT_MOTOR_MAX_VALUE = 240;

--- a/src/video/movies.cpp
+++ b/src/video/movies.cpp
@@ -21,6 +21,7 @@
 
 #include "../audio.h"
 #include "../renderer.h"
+#include "../gl.h"
 
 #include "movies.h"
 

--- a/src/video/movies.h
+++ b/src/video/movies.h
@@ -25,10 +25,7 @@
 #include <math.h>
 #include <sys/timeb.h>
 #include <dbghelp.h>
-
-#include "../crashdump.h"
-#include "../log.h"
-#include "../gl.h"
+#include <stdint.h>
 
 void ffmpeg_movie_init();
 void ffmpeg_release_movie_objects();

--- a/src/voice.cpp
+++ b/src/voice.cpp
@@ -24,11 +24,10 @@
 #include "audio.h"
 #include "field.h"
 #include "patch.h"
+#include "utils.h"
 
 #include "ff8/engine.h"
 
-#include <iomanip>
-#include <sstream>
 #include <queue>
 
 enum class display_type

--- a/src/wine.h
+++ b/src/wine.h
@@ -25,7 +25,7 @@
 #include <windows.h>
 
 typedef const char* (*WineVersionFunction)();
-const char* GetWineVersion() {
+inline const char* GetWineVersion() {
     HMODULE hModule = LoadLibraryA("ntdll.dll");
     if (!hModule) {
         return "Wine is not detected.";


### PR DESCRIPTION
## Summary

Huge cleanup of the codebase:
- Refactor includes by using the finest granularity possible (e.g. if vector is necessary include directly <vector> without using an include that transitively included vector). @julianxhokaxhiu Do we have any guidelines to the order of includes? Sometimes if I change the order, it does fix some redefinition error (that is probably ignored by some cflags or linker flags)
- Add pragma once header guard where missing
- Add inline to function in header files where necessary
- Trimming whitespace at the end

### Motivation

Overall, this sped up the build time from 2 minutes to 1 minutes and 36 seconds on my machine (excluding vcpkg install step, basically I timed only the cmake --build). But the main motivation was to understand all deps in order to try something new with the build system.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
