### PR TITLE
FF8: Make Creative EAX Unified as an optional dependency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,10 @@
 - SFX: Add missing support for audio effects to be stopped in time
 - Speedhack: Fix support in field which were not getting the real speed up despite FFNx prompting it on screen.
 
+# FF8 2000
+
+- Audio: Creative EAX Unified is now optional to launch the game ( https://github.com/julianxhokaxhiu/FFNx/pull/718 )
+
 # FF8 Steam
 
 - Files: Fix `app_path` option support ( https://github.com/julianxhokaxhiu/FFNx/pull/714 )


### PR DESCRIPTION
## Summary

Make Creative EAX Unified as an optional dependency
+ search the eax.dll in ./creative_eax.dll before searching in system dir

### Motivation

On the 2000-version, eax.dll is replaced by FFNx, but the original eax.dll is still mandatory, as it is used to instanciate DirectSound.
On today hardware, EAX does nothing special, so it seems fair to partially remove this dependency.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
