### PR TITLE
FF8: Fix FMV filenames when enable_ffmpeg_videos = true

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@
 
 - Core: Add missing Cloud models in the model to eye mapping list
 
+## FF8 2000
+
+- Movie: Fix path lookup when using ffmpeg ( https://github.com/julianxhokaxhiu/FFNx/issues/730 )
+
 # 1.20.0
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.19.1...1.20.0

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -112,8 +112,6 @@ MEMORYSTATUSEX last_ram_state = { sizeof(last_ram_state) };
 // global FF7/FF8 flag, available after version check
 uint32_t ff8 = false;
 
-uint32_t ff8_currentdisk = 0;
-
 uint32_t ff7_do_reset = false;
 
 // global FF7/FF8 flag, check if is steam edition
@@ -3299,8 +3297,6 @@ __declspec(dllexport) HANDLE __stdcall dotemuCreateFileA(LPCSTR lpFileName, DWOR
 
 			if (strstr(lpFileName, diskAsChar) != NULL)
 			{
-				ff8_currentdisk = requiredDisk;
-
 				ret = CreateFileA(newPath, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
 			}
 		}

--- a/src/globals.h
+++ b/src/globals.h
@@ -80,7 +80,6 @@ extern uint32_t num_modes;
 extern uint32_t text_colors[];
 
 extern uint32_t ff8;
-extern uint32_t ff8_currentdisk;
 
 extern uint32_t frame_counter;
 extern double frame_rate;

--- a/src/movies.cpp
+++ b/src/movies.cpp
@@ -190,15 +190,10 @@ uint32_t ff7_get_movie_frame()
 
 uint32_t ff8_movie_frames;
 
-void ff8_prepare_movie(uint32_t disc, uint32_t movie)
+void ff8_prepare_movie(uint8_t disc, uint32_t movie)
 {
 	char fmvName[MAX_PATH], camName[MAX_PATH], newFmvName[MAX_PATH], newCamName[MAX_PATH];
 	uint32_t camOffset = 0;
-
-	// Unexpected cases default to current disk
-	if (disc >= 5u) {
-		disc = ff8_currentdisk - 1;
-	}
 
 	_snprintf(fmvName, sizeof(fmvName), "%s/data/movies/disc%02i_%02ih.%s", ff8_externals.app_path, disc, movie, ffmpeg_video_ext.c_str());
 	_snprintf(camName, sizeof(camName), "%s/data/movies/disc%02i_%02i.cam", ff8_externals.app_path, disc, movie);
@@ -206,7 +201,7 @@ void ff8_prepare_movie(uint32_t disc, uint32_t movie)
 	redirect_path_with_override(fmvName, newFmvName, sizeof(newFmvName));
 	redirect_path_with_override(camName, newCamName, sizeof(newCamName));
 
-	if(trace_all || trace_movies) ffnx_trace("prepare_movie %s\n", fmvName);
+	if(trace_all || trace_movies) ffnx_trace("prepare_movie %s disc=%d movie=%d\n", fmvName, disc, movie);
 
 	if(disc != 4)
 	{


### PR DESCRIPTION
## Summary

The first argument passed to ff8_prepare_movie(disc, movie) was often (or always?) strange. There was a workaround on the Steam version, but the main question remains: why the disc id is so weird?

The answer is simple, that's because it should be a unsigned char, not a unsigned int.

### Motivation

Fixes #730

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
