### PR TITLE
FF8: Fix app_path configuration for movies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,7 +9,7 @@
 ## FF8
 
 - Fix crash on JP version ( https://github.com/julianxhokaxhiu/FFNx/pull/733 )
-- Movie: Fix `override_path` support
+- Movie: Fix `override_path` support ( TrueOdin + https://github.com/julianxhokaxhiu/FFNx/pull/734 )
 
 ## FF8 2000
 

--- a/src/movies.cpp
+++ b/src/movies.cpp
@@ -198,8 +198,12 @@ void ff8_prepare_movie(uint8_t disc, uint32_t movie)
 	_snprintf(fmvName, sizeof(fmvName), "data/movies/disc%02i_%02ih.%s", disc, movie, ffmpeg_video_ext.c_str());
 	_snprintf(camName, sizeof(camName), "data/movies/disc%02i_%02i.cam", disc, movie);
 
-	redirect_path_with_override(fmvName, newFmvName, sizeof(newFmvName));
-	redirect_path_with_override(camName, newCamName, sizeof(newCamName));
+	if (redirect_path_with_override(fmvName, newFmvName, sizeof(newFmvName)) != 0) {
+		_snprintf(newFmvName, sizeof(newFmvName), "%s/%s", ff8_externals.app_path, fmvName);
+	}
+	if (redirect_path_with_override(camName, newCamName, sizeof(newCamName)) != 0) {
+		_snprintf(newCamName, sizeof(newCamName), "%s/%s", ff8_externals.app_path, camName);
+	}
 
 	if(trace_all || trace_movies) ffnx_trace("prepare_movie %s disc=%d movie=%d\n", newFmvName, disc, movie);
 

--- a/src/redirect.h
+++ b/src/redirect.h
@@ -21,5 +21,17 @@
 
 #pragma once
 
+/**
+ * Returns:
+ *  -1 if the file was not found
+ *   0 if the file is redirected
+ *   1 if the file was not found but required
+ */
 int attempt_redirection(const char* in, char* out, size_t size, bool wantsSteamPath = false);
+/**
+ * Returns:
+ *  -1 if the file was not found, in this case, `out` path is filled with `in` path content
+ *  0  if the file is redirected
+ *  1  if the file was not found but required
+ */
 int redirect_path_with_override(const char* in, char* out, size_t out_size);


### PR DESCRIPTION
## Summary

- Move app_path back to movies, but only if the redirection failed.
- Document the redirection return values, and force redirect_path_with_override to return 0 only when a redirection happened

### Motivation

file redirection works on relative paths, so @julianxhokaxhiu moved the app_path outside the movies logic to the redirection logic.
But if we do this, redirection will be relative to app_path, which I don't want, because app_path is reserved for game data, not mods.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
