### PR TITLE
FF8: Fix LZ4 decompression

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 - Ambient: Fix missing Battle ID for battles triggered using field opcodes
 - Ambient: Fix Battle ID detection for random encounters in Field
 - Modding: Allow modding card names hardcoded in exe ( https://github.com/julianxhokaxhiu/FFNx/pull/739 )
-- Modding: Add compatibility to LZ4 compression in FS archives ( https://github.com/julianxhokaxhiu/FFNx/pull/741 )
+- Modding: Add compatibility to LZ4 compression in FS archives ( https://github.com/julianxhokaxhiu/FFNx/pull/741 https://github.com/julianxhokaxhiu/FFNx/pull/743/files )
 
 # 1.20.3
 


### PR DESCRIPTION
## Summary

My implementation was wrong, decompression data start 4 bytes further.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
