### PR TITLE
FF8: Fix elevator blending for mods #746

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,8 +9,10 @@
 ## FF8
 
 - Core: Fix crash for non-us versions introduced in 1.20.3 ( https://github.com/julianxhokaxhiu/FFNx/pull/741 )
+- Core: Fix crash when `more_debug` option is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/749 )
 - Ambient: Fix missing Battle ID for battles triggered using field opcodes
 - Ambient: Fix Battle ID detection for random encounters in Field
+- Modding: Fix blending in external textures ( https://github.com/julianxhokaxhiu/FFNx/pull/749 )
 - Modding: Allow modding card names hardcoded in exe ( https://github.com/julianxhokaxhiu/FFNx/pull/739 )
 - Modding: Add compatibility to LZ4 compression in FS archives ( https://github.com/julianxhokaxhiu/FFNx/pull/741 https://github.com/julianxhokaxhiu/FFNx/pull/743/files )
 - Voice: Add support for Worldmap question dialogs

--- a/docs/mods/exe_data.md
+++ b/docs/mods/exe_data.md
@@ -16,3 +16,6 @@ And then FFNx will look for those files directly instead of data from the EXE.
 - `battle_scans.msd`: Texts in battle scans. Note: this is not exactly the same
   format in the EXE, the msd format is used because it is a well documented format
   of FF8.
+- `card_names.msd`: Card names. Note: this is not exactly the same
+  format in the EXE, the msd format is used because it is a well documented format
+  of FF8.

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -903,11 +903,6 @@ int common_create_window(HINSTANCE hInstance, struct game_obj* game_object)
 				if (more_debug)
 				{
 					replace_function(common_externals.debug_print2, external_debug_print2);
-
-					if (ff8)
-					{
-						patch_code_dword(ff8_externals.outputdebugstringa, DWORD(external_debug_print));
-					}
 				}
 
 #ifdef NO_EXT_HEAP

--- a/src/gl/gl.cpp
+++ b/src/gl/gl.cpp
@@ -337,8 +337,7 @@ void gl_draw_indexed_primitive(uint32_t primitivetype, uint32_t vertextype, stru
 	newRenderer.isTLVertex(vertextype == TLVERTEX);
 	newRenderer.isFBTexture(current_state.fb_texture);
 
-	if (ff8) newRenderer.doModulateAlpha(false);
-	else newRenderer.doModulateAlpha(true);
+	newRenderer.doModulateAlpha(true);
 
 	//// upload vertex data
 	newRenderer.bindVertexBuffer(vertices, normals, vertexcount);


### PR DESCRIPTION
## Summary

- Fix elevator blending for mods
- Fix crash when more_debug option is enabled -> replacing OutputDebugStringA was a bad idea and leaves the game in a undefined state

![2024-11-10 22_56_52-Final Fantasy VIII _ FPS_ 30,0](https://github.com/user-attachments/assets/de22fc6e-9dbf-4a50-b667-b04928624e0b)

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
