### PR TITLE
FF8: Bring back shadows and tinted window

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 - Ambient: Fix Battle ID detection for random encounters in Field
 - Modding: Allow modding card names hardcoded in exe ( https://github.com/julianxhokaxhiu/FFNx/pull/739 )
 - Modding: Add compatibility to LZ4 compression in FS archives ( https://github.com/julianxhokaxhiu/FFNx/pull/741 https://github.com/julianxhokaxhiu/FFNx/pull/743/files )
+- Rendering: Add support for substractive blending ( https://github.com/julianxhokaxhiu/FFNx/pull/750 )
 - Voice: Add support for Worldmap question dialogs
 - Voice: Add support for Auto text in World messages
 

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1059,7 +1059,9 @@ struct ff8_externals
 	uint32_t get_disk_number;
 	char* disk_data_path;
 	const char *app_path;
+	uint32_t swirl_enter;
 	uint32_t swirl_main_loop;
+	uint32_t sub_460B60;
 	uint32_t field_main_loop;
 	uint32_t field_main_exit;
 	uint32_t psxvram_texture_pages_free;
@@ -1068,6 +1070,8 @@ struct ff8_externals
 	uint32_t engine_set_init_time;
 	uint32_t sub_4672C0;
 	uint32_t sub_471F70;
+	uint32_t field_fade_transition_sub_472990;
+	uint32_t sub_45CDD0;
 	uint32_t sub_4767B0;
 	uint32_t sub_4789A0;
 	char (*sub_47CA90)();
@@ -1214,6 +1218,7 @@ struct ff8_externals
 	uint32_t sub_45B310;
 	uint32_t sub_45B460;
 	uint32_t ssigpu_init;
+	uint32_t *sub_blending_capability;
 	uint32_t *d3dcaps;
 	uint32_t sub_53BB90;
 	uint32_t worldmap_fog_filter_polygons_in_block_1;

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -123,6 +123,7 @@ void ff8_find_externals()
 		ff8_externals.battle_main_loop = get_absolute_value(ff8_externals.main_loop, 0x340 + 4);
 		// Search battle sound function to find play/stop midi related methods
 		ff8_externals.sm_battle_sound = get_relative_call(ff8_externals.main_loop, 0x487 + 5);
+		ff8_externals.swirl_enter = get_absolute_value(ff8_externals.main_loop, 0x493 + 5);
 		ff8_externals.swirl_main_loop = get_absolute_value(ff8_externals.main_loop, 0x4A3 + 5);
 		ff8_externals.sub_470250 = get_relative_call(ff8_externals.main_loop, 0x6E7 - 15);
 	}
@@ -140,6 +141,7 @@ void ff8_find_externals()
 		ff8_externals.battle_main_loop = get_absolute_value(ff8_externals.main_loop, 0x340);
 		// Search battle sound function to find play/stop midi related methods
 		ff8_externals.sm_battle_sound = get_relative_call(ff8_externals.main_loop, 0x487);
+		ff8_externals.swirl_enter = get_absolute_value(ff8_externals.main_loop, 0x493);
 		ff8_externals.swirl_main_loop = get_absolute_value(ff8_externals.main_loop, 0x4A3);
 		ff8_externals.sub_470250 = get_relative_call(ff8_externals.main_loop, 0x6E7);
 	}
@@ -149,6 +151,7 @@ void ff8_find_externals()
 	ff8_externals.psxvram_texture_page_free = get_relative_call(ff8_externals.psxvram_texture_pages_free, 0x21);
 	ff8_externals.psxvram_texture_page_tex_header_free = get_relative_call(ff8_externals.psxvram_texture_page_free, 0x98);
 	ff8_externals.engine_set_init_time = get_relative_call(ff8_externals.battle_enter, 0x35);
+	ff8_externals.sub_460B60 = get_relative_call(ff8_externals.swirl_enter, 0x9);
 
 	common_externals.debug_print2 = get_relative_call(uint32_t(ff8_externals.sm_pc_read), 0x16);
 	ff8_externals.moriya_filesystem_open = get_relative_call(uint32_t(ff8_externals.sm_pc_read), 0x21);
@@ -221,6 +224,8 @@ void ff8_find_externals()
 	common_externals.assert_malloc = (void* (*)(uint32_t, const char*, uint32_t))get_relative_call(ff8_externals.load_fonts, JP_VERSION ? 0x29 : 0x2A);
 
 	ff8_externals.sub_471F70 = get_relative_call(ff8_externals.field_main_loop, 0x148);
+	ff8_externals.field_fade_transition_sub_472990 = get_relative_call(ff8_externals.field_main_loop, 0x19E);
+	ff8_externals.sub_45CDD0 = get_relative_call(ff8_externals.field_fade_transition_sub_472990, 0x5C);
 
 	if (JP_VERSION)
 	{
@@ -572,6 +577,7 @@ void ff8_find_externals()
 	ff8_externals.sub_45B310 = get_relative_call(ff8_externals.pubintro_init, 0x91);
 	ff8_externals.sub_45B460 = get_relative_call(ff8_externals.sub_45B310, 0x0);
 	ff8_externals.ssigpu_init = get_relative_call(ff8_externals.sub_45B460, 0x26);
+	ff8_externals.sub_blending_capability = (uint32_t *)get_absolute_value(ff8_externals.sub_45B460, 0x19);
 	ff8_externals.d3dcaps = (uint32_t *)get_absolute_value(ff8_externals.ssigpu_init, 0x6C);
 
 	if(FF8_US_VERSION)

--- a/src/voice.cpp
+++ b/src/voice.cpp
@@ -1420,10 +1420,10 @@ void voice_init()
 		replace_call_function(ff8_externals.sub_54FDA0 + (FF8_US_VERSION ? 0xAE : 0xAC), ff8_world_dialog_assign_text);
 		replace_call_function(ff8_externals.sub_54FDA0 + (FF8_US_VERSION ? 0x178 : 0x175), ff8_world_dialog_assign_text);
 		replace_call_function(ff8_externals.sub_543CB0 + (FF8_US_VERSION ? 0x5EE : (FF8_SP_VERSION || FF8_IT_VERSION) ? 0x5D2 : 0x5BB), ff8_world_dialog_question_assign_text);
-		replace_call_function(ff8_externals.sub_5484B0 + (FF8_US_VERSION ? 0xBD : 0x96), ff8_world_dialog_question_assign_text);
-		replace_call_function(ff8_externals.sub_5484B0 + (FF8_US_VERSION ? 0x24F : 0x228), ff8_world_dialog_question_assign_text);
+		replace_call_function(ff8_externals.sub_5484B0 + (FF8_US_VERSION ? 0xBD : 0x131), ff8_world_dialog_question_assign_text);
+		replace_call_function(ff8_externals.sub_5484B0 + (FF8_US_VERSION ? 0x24F : 0x244), ff8_world_dialog_question_assign_text);
 		replace_call_function(ff8_externals.sub_54D7E0 + (FF8_US_VERSION ? 0x119 : 0x116), ff8_world_dialog_question_assign_text);
-		replace_call_function(ff8_externals.sub_54E9B0 + (FF8_US_VERSION ? 0x621 : (FF8_SP_VERSION ? 0x66E : 0x633)), ff8_world_dialog_question_assign_text);
-		replace_call_function(ff8_externals.sub_54E9B0 + (FF8_US_VERSION ? 0xBE4 : (FF8_SP_VERSION ? 0xC31 : 0xBF6)), ff8_world_dialog_question_assign_text);
+		replace_call_function(ff8_externals.sub_54E9B0 + (FF8_US_VERSION ? 0x621 : (FF8_SP_VERSION ? 0x66A : 0x62F)), ff8_world_dialog_question_assign_text);
+		replace_call_function(ff8_externals.sub_54E9B0 + (FF8_US_VERSION ? 0xBE4 : (FF8_SP_VERSION ? 0xC99 : 0xC5E)), ff8_world_dialog_question_assign_text);
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #693 and more

**Bring back shadows and tinted window**
![2024-11-11 22_25_03-Final Fantasy VIII _ FPS_ 30,0](https://github.com/user-attachments/assets/1b3a1d6d-4e90-4ff8-a6df-ff4f3cac1082)
_Elevator window is darker_
![2024-11-13 00_01_53-Final Fantasy VIII _ FPS_ 15,0](https://github.com/user-attachments/assets/cf824f83-77ed-487b-a84c-1f256a34e26b)
_Shadows are back_

**Battle transition + shadows**
https://github.com/user-attachments/assets/674a7e17-cfd7-48ae-b84d-d32bb228cd5a

**Field transition**
https://github.com/user-attachments/assets/f26643be-1462-439a-bd11-076ec4b18471



### Motivation

Substractive blending is enabled only if the graphic driver is software and use paletted textures.

### Regression

Unfortunately Battle transition (from worldmap at least) suffer from this change

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
