### PR TITLE
Common: Fix bgfx crash when there is not enough RAM available

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 ## Common
 
+- Core: Fix bgfx crash when memory cannot be allocated ( https://github.com/julianxhokaxhiu/FFNx/pull/755 )
 - Voice: Add support for `config.toml` configuration override based on Game Moment ID
 
 ## FF8

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1840,7 +1840,11 @@ uint32_t Renderer::createTexture(uint8_t* data, size_t width, size_t height, int
 
         if (copyData)
         {
-            mem = bgfx::copy(data, texInfo.storageSize);
+            mem = bgfx::alloc(texInfo.storageSize);
+            // Protect from crashes
+            if (mem != NULL) {
+                bx::memCopy(mem->data, data, texInfo.storageSize);
+            }
         }
         else
         {


### PR DESCRIPTION
## Summary

Fix crash when there is not enough RAM. Fixes #726

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
