### PR TITLE
FF8: Preliminary support for true widescreen

### DIFF
--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -502,9 +502,6 @@ void read_cfg()
 	else
 		external_vibrate_path += "/ff7";
 
-	// WIDESCREEN
-	if (ff8 && aspect_ratio > AR_STRETCH) aspect_ratio = AR_ORIGINAL;
-
 	// VOLUME
 	if (external_music_volume > 100) external_music_volume = 100;
 	if (external_sfx_volume > 100) external_sfx_volume = 100;

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1736,10 +1736,15 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
         case MODE_FIELD:
             {
                 // Keep the default scissor for widescreen disabled movies and fields
-                bool is_movie_playing = *ff7_externals.word_CC1638 && !ff7_externals.modules_global_object->BGMOVIE_flag;
-                if((is_movie_playing && widescreen.getMovieMode() == WM_DISABLED) || widescreen.getMode() == WM_DISABLED)
+                bool isKeepDefaultScissor = false;
+                if (!ff8)
                 {
-                    scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
+                     bool is_movie_playing = *ff7_externals.word_CC1638 && !ff7_externals.modules_global_object->BGMOVIE_flag;
+                     isKeepDefaultScissor = (is_movie_playing && widescreen.getMovieMode() == WM_DISABLED) || widescreen.getMode() == WM_DISABLED;
+                }
+
+                if (isKeepDefaultScissor)
+                {
                     return;
                 }
 
@@ -1779,6 +1784,16 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
                     scissorWidth = getInternalCoordX(wide_viewport_width);
                 else if(internalState.bIsTLVertex)
                     scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
+
+                if (ff8)
+                {
+                    // This removes the black bars on the top and bottom of the screen
+                    if(y == 24 && height == 432)
+                    {
+                        scissorOffsetY = getInternalCoordY(0.0);
+                        scissorHeight = getInternalCoordY(480);
+                    }
+                }
             }
             break;
         default:
@@ -1788,6 +1803,16 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
                     scissorWidth = getInternalCoordX(wide_viewport_width);
                 else
                     scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
+
+                if (ff8)
+                {
+                    // This removes the black bars on the top and bottom of the screen
+                    if(y == 16 && height == 448)
+                    {
+                        scissorOffsetY = getInternalCoordY(0.0);
+                        scissorHeight = getInternalCoordY(480);
+                    }
+                }
             }
             break;
     }


### PR DESCRIPTION
## Summary

Enabled preliminary support for true widescreen in FF8.

### Motivation

I heard there is a witch that needs to be stopped.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [x] I did test my code on FF8
