### PR TITLE
FF8: Fix external texture reload #759

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@
 - Core: Fix crash when `more_debug` option is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/749 )
 - Ambient: Fix missing Battle ID for battles triggered using field opcodes
 - Ambient: Fix Battle ID detection for random encounters in Field
+- External textures: Fix texture not reloaded between fields ( https://github.com/julianxhokaxhiu/FFNx/pull/761 )
 - Modding: Fix blending in external textures ( https://github.com/julianxhokaxhiu/FFNx/pull/749 )
 - Modding: Allow modding card names hardcoded in exe ( https://github.com/julianxhokaxhiu/FFNx/pull/739 )
 - Modding: Add compatibility to LZ4 compression in FS archives ( https://github.com/julianxhokaxhiu/FFNx/pull/741 https://github.com/julianxhokaxhiu/FFNx/pull/743/files )

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@
 
 - Core: Fix loading field lgp files that might have incorrect headers ( https://github.com/julianxhokaxhiu/FFNx/issues/758 )
 
+## FF8
+
+- External textures: Fix texture not reloaded between fields ( https://github.com/julianxhokaxhiu/FFNx/pull/761 )
+
 # 1.21.0
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.20.3...1.21.0
@@ -21,7 +25,6 @@
 - Core: Fix crash when `more_debug` option is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/749 )
 - Ambient: Fix missing Battle ID for battles triggered using field opcodes
 - Ambient: Fix Battle ID detection for random encounters in Field
-- External textures: Fix texture not reloaded between fields ( https://github.com/julianxhokaxhiu/FFNx/pull/761 )
 - Modding: Fix blending in external textures ( https://github.com/julianxhokaxhiu/FFNx/pull/749 )
 - Modding: Allow modding card names hardcoded in exe ( https://github.com/julianxhokaxhiu/FFNx/pull/739 )
 - Modding: Add compatibility to LZ4 compression in FS archives ( https://github.com/julianxhokaxhiu/FFNx/pull/741 https://github.com/julianxhokaxhiu/FFNx/pull/743/files )

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2071,7 +2071,7 @@ uint32_t common_write_palette(uint32_t source_offset, uint32_t size, void *sourc
 			}
 
 			// if there's anything left at this point, reload the affected textures
-			if(palettes && !VREF(texture_set, ogl.external))
+			if(palettes)
 			{
 				for (uint32_t idx = 0; idx < palettes; idx++)
 					newRenderer.deleteTexture(VREF(texture_set, texturehandle[palette_index + idx]));


### PR DESCRIPTION
## Summary

Fix external texture reload when different textures uses the same texture set

### Motivation

https://github.com/julianxhokaxhiu/FFNx/issues/759

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
