### PR TITLE
FF7: Fix field chunk size calculation for the chunk number 9

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## FF7
+
+- Core: Fix crash when loading gameplay mods such as SAC and New Threat caused by my previous commit.
+
 # Next
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.21.1...master

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,10 @@
-## FF7
-
-- Core: Fix crash when loading gameplay mods such as SAC and New Threat caused by my previous commit.
-
 # Next
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.21.1...master
+
+## FF7
+
+- Core: Fix field chunk size calculation for the chunk number 9 ( https://github.com/julianxhokaxhiu/FFNx/pull/763 )
 
 # 1.21.1
 

--- a/src/ff7/file.cpp
+++ b/src/ff7/file.cpp
@@ -670,9 +670,9 @@ int ff7_read_field_file(char* path)
 			}
 			else
 			{
-          // there is no section after, so we have to trust it.
-          data_len = *(uint32_t*)(original_field_data + data_ptr);
-      }
+				// there is no section after, so we have to trust it.
+				data_len = *(uint32_t*)(original_field_data + data_ptr);
+			}
 
 			ff7_field_file_chunked[n].size = data_len;
 			ff7_field_file_chunked[n].data = new byte[ff7_field_file_chunked[n].size];

--- a/src/ff7/file.cpp
+++ b/src/ff7/file.cpp
@@ -670,9 +670,9 @@ int ff7_read_field_file(char* path)
 			}
 			else
 			{
-				//there is no section after, so we use known_field_buffer_size.
-				data_len = *ff7_externals.known_field_buffer_size - data_ptr - 0x4;
-			}
+          // there is no section after, so we have to trust it.
+          data_len = *(uint32_t*)(original_field_data + data_ptr);
+      }
 
 			ff7_field_file_chunked[n].size = data_len;
 			ff7_field_file_chunked[n].data = new byte[ff7_field_file_chunked[n].size];


### PR DESCRIPTION
## Summary

So since i don't typically run gameplay mods, i missed a crash i caused by trying to use known_field_buffer_size to calculate the actual size of chunk 11.  Even trying to do this causes stuff to be written outside the buffer, which is bad.  Since ffnx doesn't have it's own decompressor, i can't get the real size. so I have no choice but to trust the section header.

### Motivation

Fixing what I broke.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
