### PR TITLE
FF7: Fix movies being clipped when uncrop option is enabled

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -914,7 +914,7 @@ int common_create_window(HINSTANCE hInstance, struct game_obj* game_object)
 				replace_function((uint32_t)common_externals.assert_calloc, ext_calloc);
 #endif
 
-				if (widescreen_enabled) widescreen.init();
+				if (widescreen_enabled || enable_uncrop) widescreen.init();
 
 				// Init renderer
 				newRenderer.init();

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1726,15 +1726,13 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
     if (enable_uncrop)
     {
         bool is_movie_playing = *ff7_externals.word_CC1638 && !ff7_externals.modules_global_object->BGMOVIE_flag;
-        if((is_movie_playing && widescreen.getMovieMode() == WM_DISABLED))
+        if(!(is_movie_playing && widescreen.getMovieMode() == WM_DISABLED))
         {
-            return;
-        }
-
-        if(y == 16 && height == 448)
-        {
-            scissorOffsetY = getInternalCoordY(0.0);
-            scissorHeight = getInternalCoordY(480);
+            if(y == 16 && height == 448)
+            {
+                scissorOffsetY = getInternalCoordY(0.0);
+                scissorHeight = getInternalCoordY(480);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixed right side of screen being clipped during movies when uncrop option is enabled. 

### Motivation

To fix a bug reported by a user.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
