### PR TITLE
FF7: Use equipped Attack behavior when using auto-attack shortcut

### DIFF
--- a/src/ff7/menu.cpp
+++ b/src/ff7/menu.cpp
@@ -136,7 +136,9 @@ uint32_t ff7_menu_decrease_item_quantity(uint32_t item_used)
 }
 
 void dispatchAttackCommand(){
-    *ff7_externals.issued_command_id = 0x01;
+    char* character = (char*)ff7_externals.menu_objects + 0x2CBC; //Character attacking
+    char* attack = (char*)ff7_externals.gamepad_status + 0xCA8 + (*character * 6); //Their equipped attack
+    *ff7_externals.issued_command_id = *attack;
     *ff7_externals.issued_action_target_type = 0;
     *ff7_externals.issued_action_target_index = 4;
     ((void(*)())ff7_externals.dispatch_chosen_battle_action)();


### PR DESCRIPTION


## Summary

Brief explanation of the pull request.

Make Auto Attack use equipped commands like 4x cut or slash-all.

### Motivation

Why are you doing this? What use cases does it support? What is the expected outcome?

Someone asked me to. It makes auto attack more useful. It also brings functionality in line with berserk, which respects your equipped attack command.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [ ] I did test my code on FF8
