### PR TITLE
FF8: Add Triple Triad and draw spell texts to exe data feature

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,8 @@
 
 ## FF8
 
+- Modding: Allow modding card texts hardcoded in exe ( https://github.com/julianxhokaxhiu/FFNx/pull/774 )
+- Modding: Allow modding draw texts hardcoded in exe ( https://github.com/julianxhokaxhiu/FFNx/pull/774 )
 - SFX: Fix incorrect volume assignment when playing sfx effects using the external layer
 
 # 1.21.3

--- a/docs/mods/exe_data.md
+++ b/docs/mods/exe_data.md
@@ -19,3 +19,7 @@ And then FFNx will look for those files directly instead of data from the EXE.
 - `card_names.msd`: Card names. Note: this is not exactly the same
   format in the EXE, the msd format is used because it is a well documented format
   of FF8.
+- `card_texts.msd`: Card module texts. Note: this is not exactly the same
+  format in the EXE, the msd format is used because it is a well documented format
+  of FF8.
+- `draw_point.msd`: Draw point and Disc error messages

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1124,6 +1124,8 @@ struct ff8_externals
 	uint32_t sub_4BDB30;
 	ff8_menu_callback *menu_callbacks;
 	uint32_t menu_cards_render;
+	uint32_t sub_534AD0;
+	uint8_t **card_texts_off_B96504;
 	uint32_t sub_4EFC00;
 	uint32_t sub_4EFCD0;
 	uint32_t menu_config_controller;
@@ -1412,6 +1414,8 @@ struct ff8_externals
 	uint32_t sub_534560;
 	uint32_t sub_536C30;
 	uint32_t sub_535640;
+	uint32_t sub_536CB0;
+	uint8_t **card_texts_off_B96968;
 	uint32_t sub_536C80;
 	uint32_t sub_5366D0;
 	uint32_t sub_539500;
@@ -1532,6 +1536,7 @@ struct ff8_externals
 	uint32_t field_vars_stack_1CFE9B8;
 	uint32_t get_card_name;
 	uint32_t card_name_positions;
+	uint32_t drawpoint_messages;
 };
 
 void ff8gl_field_78(struct ff8_polygon_set *polygon_set, struct ff8_game_obj *game_object);

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -181,6 +181,8 @@ void ff8_find_externals()
 	ff8_externals.cardgame_funcs = (uint32_t *)get_absolute_value(ff8_externals.sub_534560, 0x5D);
 	ff8_externals.sub_536C30 = ff8_externals.cardgame_funcs[1];
 	ff8_externals.sub_535640 = ff8_externals.cardgame_funcs[3];
+	ff8_externals.sub_536CB0 = get_absolute_value(ff8_externals.sub_536C30, 0x14);
+	ff8_externals.card_texts_off_B96968 = (uint8_t **)get_absolute_value(ff8_externals.sub_536CB0, 0x59);
 	ff8_externals.sub_536C80 = get_absolute_value(ff8_externals.sub_536C30, 0x25);
 	ff8_externals.sub_5366D0 = get_absolute_value(ff8_externals.sub_535640, 0x42);
 	ff8_externals.cardgame_tim_texture_intro = (uint8_t *)get_absolute_value(ff8_externals.sub_536C80, 0x3);
@@ -317,6 +319,8 @@ void ff8_find_externals()
 	common_externals.stop_movie = get_relative_call(common_externals.update_movie_sample, 0x3E2);
 	ff8_externals.movie_object = (ff8_movie_obj *)get_absolute_value(common_externals.prepare_movie, 0xDB);
 
+	ff8_externals.drawpoint_messages = get_absolute_value(ff8_externals.opcode_drawpoint, 0xD6);
+
 	common_externals.debug_print = get_relative_call(common_externals.update_movie_sample, 0x141);
 
 	ff8_externals._load_texture = get_relative_call(ff8_externals.load_fonts, JP_VERSION ? 0x31B : 0x197);
@@ -412,6 +416,8 @@ void ff8_find_externals()
 	ff8_externals.sub_4BDB30 = get_relative_call(ff8_externals.sub_4B3140, 0x4);
 	ff8_externals.menu_callbacks = (ff8_menu_callback *)get_absolute_value(ff8_externals.sub_4BDB30, 0x11);
 	ff8_externals.menu_cards_render = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[7].func), 0x5);
+	ff8_externals.sub_534AD0 = get_relative_call(ff8_externals.menu_cards_render, 0x76);
+	ff8_externals.card_texts_off_B96504 = (uint8_t **)get_absolute_value(ff8_externals.sub_534AD0, 0xB1);
 	ff8_externals.sub_4EFC00 = get_relative_call(ff8_externals.menu_cards_render, 0x2B6);
 	ff8_externals.sub_4EFCD0 = get_absolute_value(ff8_externals.sub_4EFC00, 0xB0);
 	ff8_externals.menu_config_render = get_absolute_value(uint32_t(ff8_externals.menu_callbacks[8].func), 0x3);


### PR DESCRIPTION
## Summary

Add Triple Triad texts and draw spell texts to exe data feature

### Motivation

Helping translating the game

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
