### PR TITLE
FF8: Fix GF boost icons when ff8_use_gamepad_icons is enabled

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 
 ## FF8
 
+- Rendering: Fix red cross not showing in GF boost ability when ff8_use_gamepad_icons is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/784 )
 - Modding: Allow modding card texts hardcoded in exe ( https://github.com/julianxhokaxhiu/FFNx/pull/774 )
 - Modding: Allow modding draw texts hardcoded in exe ( https://github.com/julianxhokaxhiu/FFNx/pull/774 )
 - SFX: Fix incorrect volume assignment when playing sfx effects using the external layer

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1389,6 +1389,7 @@ struct ff8_externals
 	uint32_t ff8_draw_icon_or_key4;
 	uint32_t ff8_draw_icon_or_key5;
 	uint32_t ff8_draw_icon_or_key6;
+	uint8_t *battle_boost_cross_icon_display_1D76604;
 	int(*pause_menu)(int);
 	uint32_t init_pause_menu;
 	uint32_t sub_49BB30;

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -767,6 +767,7 @@ void ff8_find_externals()
 	ff8_externals.ff8_draw_icon_or_key4 = ff8_externals.ff8_draw_icon_or_key3 + 0xF0;
 	ff8_externals.ff8_draw_icon_or_key5 = ff8_externals.ff8_draw_icon_or_key4 + 0x120;
 	ff8_externals.ff8_draw_icon_or_key6 = ff8_externals.ff8_draw_icon_or_key5 + 0x110;
+	ff8_externals.battle_boost_cross_icon_display_1D76604 = (uint8_t *)get_absolute_value(ff8_externals.ff8_draw_icon_or_key5, 0xD5);
 	ff8_externals.sub_49FE60 = get_relative_call(ff8_externals.ff8_draw_icon_or_key6, 0xC9);
 	ff8_externals.sub_4A0C00 = get_absolute_value(ff8_externals.sub_4A0880, 0x33);
 	ff8_externals.show_dialog = (char(*)(int32_t, uint32_t, int16_t))get_relative_call(ff8_externals.sub_4A0C00, 0x5F);

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -615,8 +615,9 @@ unsigned int *ff8_draw_icon_get_icon_sp1_infos(int icon_id, int &states_count)
 ff8_draw_menu_sprite_texture_infos *ff8_draw_icon_or_key(
 	int a1, ff8_draw_menu_sprite_texture_infos *draw_infos,
 	int icon_id, uint16_t x, uint16_t y, int a6, int field10_modifier = 0,
-	bool noA6Mask = false,
-	bool override_field4_8_with_a6 = false
+	bool no_a6_mask = false,
+	bool override_field4_8_with_a6 = false,
+	bool yfix = false
 ) {
 	icon_id = ff8_draw_gamepad_icon_or_keyboard_key(a1, draw_infos, icon_id, x, y);
 	if (icon_id < 0)
@@ -643,14 +644,19 @@ ff8_draw_menu_sprite_texture_infos *ff8_draw_icon_or_key(
 		}
 		else
 		{
-			draw_infos->field_8 = noA6Mask ? a6 | (((sp1_section_data[0] >> 26) & 2) << 24) : (a6 & 0x3FFFFFF) | (((sp1_section_data[0] >> 26) & 2 | 0x64) << 24);
+			draw_infos->field_8 = no_a6_mask ? a6 | (((sp1_section_data[0] >> 26) & 2) << 24) : (a6 & 0x3FFFFFF) | (((sp1_section_data[0] >> 26) & 2 | 0x64) << 24);
 			draw_infos->field_4 = (sp1_section_data[0] >> 25) & 0x60 | 0xE100041E;
 		}
 		draw_infos->field_14 = sp1_section_data[1] & 0xFF00FF;
 		draw_infos->x_related = x + (int16_t(sp1_section_data[1]) >> 8);
-		draw_infos->y_related = y + (sp1_section_data[1] >> 24);
+		draw_infos->y_related = y + (int32_t(sp1_section_data[1]) >> 24);
+		if (yfix && *ff8_externals.battle_boost_cross_icon_display_1D76604) {
+			*((uint8_t *)draw_infos + 11) |= 2u;
+		}
 		((void(*)(int, ff8_draw_menu_sprite_texture_infos*))ff8_externals.sub_49BB30)(a1, draw_infos);
-		draw_infos += 1;
+		if (!no_a6_mask) {
+			draw_infos += 1;
+		}
 		sp1_section_data += 2;
 	}
 
@@ -679,7 +685,7 @@ ff8_draw_menu_sprite_texture_infos *ff8_draw_icon_or_key4(int a1, ff8_draw_menu_
 
 ff8_draw_menu_sprite_texture_infos *ff8_draw_icon_or_key5(int a1, ff8_draw_menu_sprite_texture_infos *draw_infos, int icon_id, uint16_t x, uint16_t y, int a6, int a7)
 {
-	return ff8_draw_icon_or_key(a1, draw_infos, icon_id, x, y, a6, a7, true);
+	return ff8_draw_icon_or_key(a1, draw_infos, icon_id, x, y, a6, a7, true, false, true);
 }
 
 ff8_draw_menu_sprite_texture_infos_short *ff8_draw_icon_or_key6(int a1, ff8_draw_menu_sprite_texture_infos_short *draw_infos, int icon_id, uint16_t x, uint16_t y, int a6, int a7) {


### PR DESCRIPTION
## Summary

When ff8_use_gamepad_icons is enabled, the red cross is not visible in gf boost ability

![2025-03-14 23_26_41-Final Fantasy VIII _ FPS_ 15,0](https://github.com/user-attachments/assets/21efc1b5-3705-4511-ad74-2492927d7f57)


### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
