### PR TITLE
FF8: Fix texture modding for Rinoa battle model

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.22.0...master
 
+## FF8
+
+- External textures: Fix Rinoa battle model that do not get replaced ( https://github.com/julianxhokaxhiu/FFNx/pull/790 )
+
 # 1.22.0
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.21.3...1.22.0

--- a/src/ff8/texture_packer.h
+++ b/src/ff8/texture_packer.h
@@ -196,7 +196,7 @@ private:
 	uint8_t getMaxScale(const TiledTex &tiledTex) const;
 	TextureTypes drawTextures(const std::list<IdentifiedTexture> &textures, const TiledTex &tiledTex, const TextureInfos &palette, uint32_t *target, int w, int h, uint8_t scale) const;
 	void cleanVramTextureIds(const TextureInfos &texture);
-	void cleanTextures(ModdedTextureId textureId);
+	void cleanTextures(ModdedTextureId textureId, int xBpp2, int y, int wBpp2, int h);
 
 	// Link between texture data pointer sent to the graphic driver and VRAM coordinates
 	std::unordered_map<const uint8_t *, TiledTex> _tiledTexs;


### PR DESCRIPTION
## Summary

Rinoa battle texture is 97 px height instead of 96, and get removed from the modding grid when another texture (Rinoa's weapon) is uploaded below this texture.

I added a tolerance for this special case to not clear a texture (at least 10x10 px) that get overlapped with only 1 px.

### Motivation

To mod Rinoa's model in battle

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
