### PR TITLE
FF7 60FPS: Fix escape magic animation speed to 15FPS

### DIFF
--- a/src/ff7.h
+++ b/src/ff7.h
@@ -3341,6 +3341,7 @@ struct ff7_externals
 	void (*engine_apply_translation_with_delta_662ECC)(vector3<short>*, vector3<int>*, int*);
 	uint32_t run_chocobuckle_main_loop_560C32;
 	uint32_t run_confu_main_loop_5600BE;
+	uint32_t battle_escape_magic_loop_5D602A;
 	uint32_t bomb_blast_black_bg_effect_537427;
 	uint32_t goblin_punch_flash_573291;
 	uint32_t roulette_skill_main_loop_566287;

--- a/src/ff7/battle/animations.cpp
+++ b/src/ff7/battle/animations.cpp
@@ -1371,6 +1371,7 @@ namespace ff7::battle
         one_call_effect100_addresses.insert(ff7_externals.roulette_skill_main_loop_566287);
         one_call_effect100_addresses.insert(ff7_externals.bomb_blast_black_bg_effect_537427);
         one_call_effect100_addresses.insert(ff7_externals.run_confu_main_loop_5600BE);
+        one_call_effect100_addresses.insert(ff7_externals.battle_escape_magic_loop_5D602A);
         one_call_effect100_addresses.insert(ff7_externals.death_kill_sub_loop_5624A5);
         one_call_effect100_addresses.insert(ff7_externals.death_kill_sub_loop_562C60);
         model_thresholds_by_address[ff7_externals.run_alexander_movement_5078D8] = 3000;

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -1084,6 +1084,9 @@ inline void ff7_find_externals(struct ff7_game_obj* game_object)
 	uint32_t handler_confu_magic_sub_55FEF2 = get_absolute_value(battle_handle_chocobuckle_and_confu_sub_55FE9C, 0x36);
 	ff7_externals.run_chocobuckle_main_loop_560C32 = get_absolute_value(handler_chocobuckle_sub_5609DB, 0x6F);
 	ff7_externals.run_confu_main_loop_5600BE = get_absolute_value(handler_confu_magic_sub_55FEF2, 0x6C);
+	uint32_t battle_escape_magic_entrypoint_5D5720 = ff7_externals.magic_effects_fn_table[25];
+	uint32_t battle_escape_magic_sub_5D573F = get_relative_call(battle_escape_magic_entrypoint_5D5720, 0x15);
+	ff7_externals.battle_escape_magic_loop_5D602A = get_absolute_value(battle_escape_magic_sub_5D573F, 0x11);
 	uint32_t bomb_blast_effects_5373D0 = ff7_externals.enemy_atk_effects_fn_table[67];
 	uint32_t bomb_blast_effects_sub_5373E5 = get_relative_call(bomb_blast_effects_5373D0, 0xB);
 	ff7_externals.bomb_blast_black_bg_effect_537427 = get_absolute_value(bomb_blast_effects_sub_5373E5, 0x34);


### PR DESCRIPTION
## Summary

Fix escape magic animation speed to 15 FPS. The logic behind is too complex to try to make those animations run at 60

### Motivation

Fix #794 

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
