### PR TITLE
FF8: Fix triple triad card index issue and achievements stuff

### DIFF
--- a/src/ff8/save_data.h
+++ b/src/ff8/save_data.h
@@ -233,7 +233,7 @@ struct savemap_ff8_field {
 	uint8_t tt_bgu_victory_count;
 	uint8_t unk3[137];
 	uint8_t chocobo_affinity[7]; // fourth element is for chocobo garden (value 128 means chocobo found)
-	uint8_t unk4[658];
+	uint8_t unk4[657];
 };
 
 struct savemap_ff8_worldmap {

--- a/src/movies.cpp
+++ b/src/movies.cpp
@@ -237,10 +237,12 @@ void ff8_prepare_movie(uint8_t disc, uint32_t movie)
 
 	if(trace_all || trace_movies) ffnx_trace("prepare_movie %s disc=%d movie=%d\n", newFmvName, disc, movie);
 
-	if (disc == 3 && movie == 4) // game ending movie
-	{
-		int squall_lvl = ff8_externals.get_char_level_4961D0(ff8_externals.savemap->chars[0].exp, 0);
-		g_FF8SteamAchievements->unlockEndOfGameAchievement(squall_lvl);
+	if (steam_edition || enable_steam_achievements) {
+		if (disc == 3 && movie == 4) // game ending movie
+		{
+			int squall_lvl = ff8_externals.get_char_level_4961D0(ff8_externals.savemap->chars[0].exp, 0);
+			g_FF8SteamAchievements->unlockEndOfGameAchievement(squall_lvl);
+		}
 	}
 
 	ff8_movie_frames = ffmpeg_prepare_movie(newFmvName);

--- a/src/voice.cpp
+++ b/src/voice.cpp
@@ -1133,15 +1133,18 @@ int ff8_opcode_voice_aask(int unk)
 		opcode_ask_current_option = win->current_choice_question;
 
 	int ret = ff8_opcode_old_aask(unk);
-	if (ret == 3) // aask exit
-	{
-		// --- Only for unlocking chocobo achievement (only way to implement it) ---
-		int chosen_option = *(DWORD*)(unk + 240);
-		WORD field_id = *common_externals.current_field_id;
-		bool is_field_chocobo_forest = field_id >= 287 && field_id <= 293 && field_id != 290;
-		if (is_field_chocobo_forest && dialog_id == 56 && chosen_option == 0) // capture chocobo
+
+	if (steam_edition || enable_steam_achievements) {
+		if (ret == 3) // aask exit
 		{
-			g_FF8SteamAchievements->unlockChocoboAchievement();
+			// --- Only for unlocking chocobo achievement (only way to implement it) ---
+			int chosen_option = *(DWORD*)(unk + 240);
+			WORD field_id = *common_externals.current_field_id;
+			bool is_field_chocobo_forest = field_id >= 287 && field_id <= 293 && field_id != 290;
+			if (is_field_chocobo_forest && dialog_id == 56 && chosen_option == 0) // capture chocobo
+			{
+				g_FF8SteamAchievements->unlockChocoboAchievement();
+			}
 		}
 	}
 	return ret;


### PR DESCRIPTION
## Summary

Fix issue of triple triad where selecting a card would select another one or when obtaining a card

### Motivation

Bug

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [x] I did test my code on FF8
