### PR TITLE
Revise LUT shader code to avoid 1.0 coordinates that some graphics drivers may sample incorrectly.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -26,7 +26,6 @@
 
 - Core: Users can now choose on which screen to run the game, using the new `display_index` option.
 - Music: Add the ability to play a custom `main_menu` music file on the new game screen.
-- Core: Revise LUT shader code to avoid 1.0 coordinates that some graphics drivers may sample incorrectly.
 
 ## FF7
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@
 
 ## Common
 
+- Core: Revise LUT shader code to avoid 1.0 coordinates that some graphics drivers may sample incorrectly.
+
+## Common
+
 - Core: Improve error message on crash and make the link clickable
 
 ## FF7

--- a/Changelog.md
+++ b/Changelog.md
@@ -26,6 +26,7 @@
 
 - Core: Users can now choose on which screen to run the game, using the new `display_index` option.
 - Music: Add the ability to play a custom `main_menu` music file on the new game screen.
+- Core: Revise LUT shader code to avoid 1.0 coordinates that some graphics drivers may sample incorrectly.
 
 ## FF7
 


### PR DESCRIPTION
## Summary

Implement the revisions to LUT shader code discussed in #777 to avoid 1.0 coordinates that some graphics drivers may sample incorrectly.

### Motivation

While #777 turned out to be unrelated to LUT sampling, this change may nevertheless be a good prophylactic against bad graphics drivers that treat 1.0 coord as out-of-bounds and/or don't honor clamp-to-edge.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [no] I did test my code on FF8 - I don't have FF8 installed, but the behavior should be consistent with FF7.
