### PR TITLE
FF8: Allow to load fs subarchives using direct_path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@
 ## FF8
 
 - External textures: Fix Rinoa battle model that do not get replaced ( https://github.com/julianxhokaxhiu/FFNx/pull/790 )
+- Direct file: field subarchives (mapdata.fs for example) can now be loaded outside field.fs ( https://github.com/julianxhokaxhiu/FFNx/pull/822 )
 
 ## FF8 Steam
 

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1409,6 +1409,9 @@ struct ff8_externals
 	uint32_t read_or_uncompress_fs_data;
 	uint32_t lzs_uncompress;
 	void(*free_file_container)(ff8_file_container *);
+	ff8_file_container*(*archive_open)(char*,char*,char*);
+	void(*sub_archive_get_filename)(const char*,char*);
+	char *temp_fs_path_cache;
 	uint32_t field_get_dialog_string;
 	uint32_t set_window_object;
 	ff8_win_obj *windows;

--- a/src/ff8/file.h
+++ b/src/ff8/file.h
@@ -27,6 +27,8 @@
 #include <stdio.h>
 
 int ff8_fs_archive_search_filename2(const char *fullpath, ff8_file_fi_infos *fi_infos_for_the_path, const ff8_file_container *file_container);
+void ff8_fs_archive_sub_archive_get_filename(const char *filename, char *path);
+ff8_file_container *ff8_fs_archive_open_temp(char *fl_path, char *fs_path, char *fi_path);
 int ff8_fs_archive_search_filename_sub_archive(const char *fullpath, ff8_file_fi_infos *fi_infos_for_the_path, const ff8_file_container *file_container);
 void ff8_fs_archive_free_file_container_sub_archive(ff8_file_container *file_container);
 void ff8_fs_archive_patch_compression(uint32_t compression_type);

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -165,6 +165,9 @@ void ff8_find_externals()
 	ff8_externals.read_or_uncompress_fs_data = get_relative_call(ff8_externals.moriya_filesystem_read, 0x5C);
 	ff8_externals.lzs_uncompress = get_relative_call(ff8_externals.read_or_uncompress_fs_data, 0x1E6);
 	ff8_externals.free_file_container = (void(*)(ff8_file_container*))get_relative_call(ff8_externals.moriya_filesystem_close, 0x1F);
+	ff8_externals.sub_archive_get_filename = (void(*)(const char*,char*))get_relative_call(ff8_externals.moriya_filesystem_open, 0x126);
+	ff8_externals.temp_fs_path_cache = (char *)get_absolute_value(ff8_externals.moriya_filesystem_open, 0x161);
+	ff8_externals.archive_open = (ff8_file_container*(*)(char*,char*,char*))get_relative_call(ff8_externals.moriya_filesystem_open, 0x27D);
 
 	ff8_externals.cdcheck_sub_52F9E0 = get_relative_call(ff8_externals.cdcheck_main_loop, 0x95);
 

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -1417,6 +1417,9 @@ void ff8_init_hooks(struct game_obj *_game_object)
 
 	replace_function(common_externals.open_file, ff8_open_file);
 	replace_call(uint32_t(ff8_externals.fs_archive_search_filename) + 0x10, ff8_fs_archive_search_filename2);
+	replace_call(ff8_externals.moriya_filesystem_open + 0x126, ff8_fs_archive_sub_archive_get_filename);
+	// Open temp.fs/temp.fl/temp.fi
+	replace_call(ff8_externals.moriya_filesystem_open + 0x705, ff8_fs_archive_open_temp);
 	// Search file in temp.fs archive (field)
 	replace_call(ff8_externals.moriya_filesystem_open + 0x776, ff8_fs_archive_search_filename_sub_archive);
 	// Search file in FS archive


### PR DESCRIPTION
## Summary

Currently direct file is not possible for subarchives. In field.fs, there are other *.fs files stored, currently we can only use direct file for files inside the *.fs subarchives, not the *.fs archive itself.

### Motivation

A good use case is when we want to add new field maps in a mod, the game needs *.fs subarchive to exist

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
