### PR TITLE
FF8: More UV fixes for 3D models (battle, field, worldmap)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Core: Fix crashes happening in Non-US versions ( https://github.com/julianxhokaxhiu/FFNx/pull/848 )
 - External textures: Fix glitches in field module ( https://github.com/julianxhokaxhiu/FFNx/pull/848 https://github.com/julianxhokaxhiu/FFNx/pull/851 )
 - External textures: Fix Tonberry format when dumping PNGs using `save_textures_legacy` flag ( https://github.com/julianxhokaxhiu/FFNx/pull/848 )
+- Graphics: Use more precise texture UVs ( https://github.com/julianxhokaxhiu/FFNx/pull/852 )
 
 # 1.23.0
 

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1251,6 +1251,8 @@ struct ff8_externals
 	uint32_t ssigpu_init;
 	uint32_t *sub_blending_capability;
 	uint32_t *d3dcaps;
+	uint32_t loc_460BB0;
+	float *psx_floats1;
 	uint32_t sub_53BB90;
 	uint32_t worldmap_fog_filter_polygons_in_block_1;
 	uint32_t worldmap_polygon_condition_2045C8C;

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -638,7 +638,9 @@ void ff8_find_externals()
 	ff8_externals.sub_45B460 = get_relative_call(ff8_externals.sub_45B310, 0x0);
 	ff8_externals.ssigpu_init = get_relative_call(ff8_externals.sub_45B460, 0x26);
 	ff8_externals.sub_blending_capability = (uint32_t *)get_absolute_value(ff8_externals.sub_45B460, 0x19);
+	ff8_externals.loc_460BB0 = get_relative_call(ff8_externals.sub_45B460, 0x47);
 	ff8_externals.d3dcaps = (uint32_t *)get_absolute_value(ff8_externals.ssigpu_init, 0x6C);
+	ff8_externals.psx_floats1 = (float *)get_absolute_value(ff8_externals.loc_460BB0, 0x3);
 
 	if(FF8_US_VERSION)
 	{


### PR DESCRIPTION
## Summary

UV adjustments.  In ff8 data, UVs are (x, y) coordinates with x and y = range 0 -> 255
FF8 PC uses a mapping between this and floating values from 0.0 to 1.0.
For some reason, this mapping is built like this:

```
mapping[n] = n / 256.0f
mapping[0] = mapping[1];
mapping[255] = mapping[254];
```

[0] and [255] are altered to fix some potential issues we seems to don't have in FFNx.
Worst, the division by 256 seems wrong, because it results to values between 0.0f and 0.992188f (255.0f / 256.0f), and not between 0 to 1.

By changing this mapping to:

```
mapping[n] = n / 255.0f
```

Worldmap seems now completely fixed, battle backgrounds repeat seems more consistent, 3D models looks better I think (it is hard to tell), etc...


<img width="230" height="118" alt="Seifer uv change (left original game, right FFNx)" src="https://github.com/user-attachments/assets/9011f9dc-a49c-4b7f-88d6-2ef63023db91" /><br>
Seifer uv change (left original game, right FFNx with this PR)<br>

<img width="128" height="128" alt="original seifer texture high res, proof that the red symbol is thin" src="https://github.com/user-attachments/assets/fa792021-b9fa-42c6-8ee7-519aca87a219" /><br>
original seifer texture high res, proof that the red symbol should be thin

<img width="684" height="277" alt="uv-worldmap" src="https://github.com/user-attachments/assets/5601cbfd-2663-4f69-913a-68c15ddc93ff" /><br>
The difference is really subtle in worldmap, because most of the fixes was already done

<img width="609" height="710" alt="uv-worldmap2" src="https://github.com/user-attachments/assets/81b51858-29d0-4ca7-b469-2107e053279f" /><br>
Some glitches are gone inside the tunnel. Also, the textures moved a bit.


<img width="387" height="246" alt="uv-battle" src="https://github.com/user-attachments/assets/4ea1f22b-dbf3-4a3f-988f-d4d8aa78fdde" /><br>
It is again hard to see, but image on the bottom has a wider mountain texture and sky

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
