### PR TITLE
Feature/ff8 external movie cam

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,10 @@
 - External textures: Fix Tonberry format when dumping PNGs using `save_textures_legacy` flag ( https://github.com/julianxhokaxhiu/FFNx/pull/848 )
 - Graphics: Use more precise texture UVs ( https://github.com/julianxhokaxhiu/FFNx/pull/852 )
 
+## FF8 (2000)
+
+- External movies: load cam files from disks by default when external movies is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/853 )
+
 # 1.23.0
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.22.0...1.23.0

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -131,6 +131,14 @@ struct sprite_viewport
 	float offset_y;
 };
 
+struct pak_pointers_entry
+{
+	uint32_t cam_offset;
+	uint32_t bik_offset;
+	uint32_t bik_lowres_offset;
+	uint32_t flag;
+};
+
 struct font_object
 {
 	uint32_t dummy1[0x12];
@@ -1072,6 +1080,7 @@ struct ff8_externals
 	uint32_t get_disk_number;
 	char* disk_data_path;
 	const char *app_path;
+	const char *data_drive_path;
 	uint32_t swirl_enter;
 	uint32_t swirl_main_loop;
 	uint32_t sub_460B60;
@@ -1241,6 +1250,8 @@ struct ff8_externals
 	DWORD* engine_mapped_buttons;
 	uint32_t draw_movie_frame;
 	struct ff8_movie_obj *movie_object;
+	char **disc_pak_filenames;
+	pak_pointers_entry **disc_pak_offsets;
 	int (*sub_5304B0)();
 	uint32_t *enable_framelimiter;
 	unsigned char *byte_1CE4907;

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -111,6 +111,7 @@ void ff8_find_externals()
 		ff8_externals.set_game_paths = (void (*)(int, char*, const char*))get_relative_call(uint32_t(ff8_externals.set_game_paths), 0x0);
 	}
 	ff8_externals.app_path = (const char*)get_absolute_value(uint32_t(ff8_externals.set_game_paths), 0x9A);
+	ff8_externals.data_drive_path = (const char*)get_absolute_value(uint32_t(ff8_externals.set_game_paths), 0x275);
 
 	ff8_externals.savemap = (savemap_ff8*)get_absolute_value(ff8_externals.pubintro_enter_main, 0x9);
 	ff8_externals.savemap_field = (savemap_ff8_field_h**)get_absolute_value(ff8_externals.main_loop, 0x21);
@@ -357,6 +358,8 @@ void ff8_find_externals()
 	ff8_externals.draw_movie_frame = get_relative_call(ff8_externals.opcode_moviesync, 0x1C);
 	common_externals.stop_movie = get_relative_call(common_externals.update_movie_sample, 0x3E2);
 	ff8_externals.movie_object = (ff8_movie_obj *)get_absolute_value(common_externals.prepare_movie, 0xDB);
+	ff8_externals.disc_pak_filenames = (char **)get_absolute_value(common_externals.prepare_movie, 0xB2);
+	ff8_externals.disc_pak_offsets = (pak_pointers_entry **)get_absolute_value(common_externals.prepare_movie, 0x20D);
 
 	ff8_externals.opcode_drawpoint_sub_4A0850 = (int(*)(int, int))get_relative_call(ff8_externals.opcode_drawpoint, 0x6B7);
 	ff8_externals.drawpoint_messages = get_absolute_value(ff8_externals.opcode_drawpoint, 0xD6);


### PR DESCRIPTION
## Summary

Open movie cam file from pak files on FF8-2000 when external movie is enabled.

### Motivation

Cam files and avi files are needed when external_movies feature is on.

FF8 PC 2000 does not have those files, so modders should provide them.
For avi files, that's not crazy, we can just ask modders to mod all video. For cam files it seems a useless difficulty.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
