### PR TITLE
FF8: Minimize field background width to prevent overrides

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - Core: Fix crashes happening in Non-US versions ( https://github.com/julianxhokaxhiu/FFNx/pull/848 )
 - External textures: Fix glitches in field module ( https://github.com/julianxhokaxhiu/FFNx/pull/848 https://github.com/julianxhokaxhiu/FFNx/pull/851 )
 - External textures: Fix Tonberry format when dumping PNGs using `save_textures_legacy` flag ( https://github.com/julianxhokaxhiu/FFNx/pull/848 )
+- External textures: Fix bgroad_6, and some other maps, which cannot be modded ( https://github.com/julianxhokaxhiu/FFNx/pull/857 )
 - Graphics: Use more precise texture UVs ( https://github.com/julianxhokaxhiu/FFNx/pull/852 )
 
 ## FF8 (2000)

--- a/misc/FF8.reg
+++ b/misc/FF8.reg
@@ -21,6 +21,19 @@ Windows Registry Editor Version 5.00
 #    GNU General Public License for more details.                             #
 #*****************************************************************************#
 
+# Enable 640x480 res + high res font + high res movies
+# enum Graphics {
+#     EnableHighResMovies = 0x1
+#     DisableWorldmapFog = 0x2
+#     DisableWorldmapTexturedAnimation = 0x4
+#     DisableWorldmapPalettedAnimation = 0x8
+#     DisableBilinear = 0x10
+#     HighResFont = 0x20
+#     GfxDriverOptions1 = 0x00F00000 // If != 0 then 640x480 resolution else 320x240
+#     GfxDriverOptions2 = 0x0F000000 // ???
+#     CurrentGfxDriver = 0xF0000000 // If != 0 then directX 5.0 else software (no other values from the register)
+# }
+
 [HKEY_LOCAL_MACHINE\SOFTWARE\Square Soft, Inc\FINAL FANTASY VIII\1.00]
 "Graphics"=dword:00100021
 

--- a/src/ff8/texture_packer.cpp
+++ b/src/ff8/texture_packer.cpp
@@ -190,7 +190,15 @@ bool TexturePacker::setTextureBackground(const char *name, int x, int y, int w, 
 	if (trace_all || trace_vram) ffnx_trace("TexturePacker::%s %s x=%d y=%d w=%d h=%d tileCount=%d\n", __func__, name, x, y, w, h, mapTiles.size());
 
 	ModdedTextureId textureId = makeTextureId(x, y);
-	setVramTextureId(textureId, x, y, w, h);
+	// Adjust width with actual texture usage
+	int maxW = 0;
+	for (const Tile &tile: mapTiles) {
+		int maxX = ((tile.texID + 1) & 0xF) * TEXTURE_WIDTH_BPP16;
+		if (maxX > maxW) {
+			maxW = maxX;
+		}
+	}
+	setVramTextureId(textureId, x, y, maxW, h);
 
 	IdentifiedTexture tex(name, TextureInfos(x, y, w, h, Tim::Bpp16, true));
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1726,7 +1726,7 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
     scissorHeight = getInternalCoordY(height);
 
     // This removes the black bars on the top and bottom of the screen
-    if (enable_uncrop)
+    if (enable_uncrop && !ff8)
     {
         bool is_movie_playing = *ff7_externals.word_CC1638 && !ff7_externals.modules_global_object->BGMOVIE_flag;
         if(!(is_movie_playing && widescreen.getMovieMode() == WM_DISABLED))


### PR DESCRIPTION
## Summary

bgroad_6 cannot be modded (using the FFNx method) because the mod is overridden by another texture upload on the right of the texture.

Background textures (mim files) are always 3328 bytes wide, but not everything is used by the tiles (map files)
The solution is to check in the tiles what is really used and limit the background texture width.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
