### PR TITLE
FF8: Allow any field map to contains up to 16 visible models

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ## FF8
 
 - Core: Fix crashes happening in Non-US versions ( https://github.com/julianxhokaxhiu/FFNx/pull/848 )
+- Core: Fix the game engine to show up to 16 high res field models without crashes or texture glitches ( https://github.com/julianxhokaxhiu/FFNx/pull/860 )
 - External textures: Fix glitches in field module ( https://github.com/julianxhokaxhiu/FFNx/pull/848 https://github.com/julianxhokaxhiu/FFNx/pull/851 )
 - External textures: Fix Tonberry format when dumping PNGs using `save_textures_legacy` flag ( https://github.com/julianxhokaxhiu/FFNx/pull/848 )
 - External textures: Fix bgroad_6, and some other maps, which cannot be modded ( https://github.com/julianxhokaxhiu/FFNx/pull/857 )

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1641,6 +1641,7 @@ struct ff8_externals
 	int32_t *current_viewport_y_dword_1A77648;
 	int32_t *current_viewport_width_dword_1A77654;
 	int32_t *current_viewport_height_dword_1A77650;
+	uint32_t set_render_to_vram_current_screen_flag_before_battle;
 };
 
 void ff8gl_field_78(struct ff8_polygon_set *polygon_set, struct ff8_game_obj *game_object);

--- a/src/ff8/field/background.cpp
+++ b/src/ff8/field/background.cpp
@@ -37,9 +37,11 @@ bool ff8_background_tiles_looks_alike(const Tile &tile, const Tile &other)
 		&& tile.blendType == other.blendType;
 }
 
-std::vector<Tile> ff8_background_parse_tiles(const uint8_t *map_data)
+std::vector<Tile> ff8_background_parse_tiles(const uint8_t *map_data, int *maxW)
 {
 	std::vector<Tile> tiles;
+
+	*maxW = 0;
 
 	while (true) {
 		Tile tile;
@@ -51,10 +53,17 @@ std::vector<Tile> ff8_background_parse_tiles(const uint8_t *map_data)
 		}
 
 		uint8_t texture_id = tile.texID & 0xF;
-		Tim::Bpp bpp = Tim::Bpp((tile.texID >> 7) & 3);
-		uint8_t pal_id = (tile.palID >> 6) & 0xF;
+		int maxX = (texture_id + 1) * TEXTURE_WIDTH_BPP16;
+		if (maxX > *maxW) {
+			*maxW = maxX;
+		}
 
-		if (trace_all || trace_vram) ffnx_info("tile %d dst %d %d %d src %d %d texid %d bpp %d palId %d blendType %d param %d %d\n", tiles.size(), tile.x, tile.y, tile.z, tile.srcX, tile.srcY, texture_id, int(bpp), pal_id, tile.blendType, tile.parameter, tile.state);
+		if (trace_all || trace_vram) {
+			Tim::Bpp bpp = Tim::Bpp((tile.texID >> 7) & 3);
+			uint8_t pal_id = (tile.palID >> 6) & 0xF;
+
+			ffnx_info("tile %d dst %d %d %d src %d %d texid %d bpp %d palId %d blendType %d param %d %d\n", tiles.size(), tile.x, tile.y, tile.z, tile.srcX, tile.srcY, texture_id, int(bpp), pal_id, tile.blendType, tile.parameter, tile.state);
+		}
 
 		tiles.push_back(tile);
 

--- a/src/ff8/field/background.h
+++ b/src/ff8/field/background.h
@@ -49,7 +49,7 @@ struct Tile {
 // A tile looks like another if it uses the same texture with the same palette and uses the same blending
 bool ff8_background_tiles_looks_alike(const Tile &tile, const Tile &other);
 
-std::vector<Tile> ff8_background_parse_tiles(const uint8_t *map_data);
+std::vector<Tile> ff8_background_parse_tiles(const uint8_t *map_data, int *maxW);
 void ff8_background_tiles_to_map(const std::vector<Tile> &tiles, uint8_t *map_data);
 bool ff8_background_save_textures(const std::vector<Tile> &tiles, const uint8_t *mim_data, const char *filename);
 bool ff8_background_save_textures_legacy(const std::vector<Tile> &tiles, const uint8_t *mim_data, const char *filename);

--- a/src/ff8/texture_packer.cpp
+++ b/src/ff8/texture_packer.cpp
@@ -185,19 +185,11 @@ bool TexturePacker::setTexture(const char *name, const TextureInfos &texture, co
 	return tex.mod() != nullptr;
 }
 
-bool TexturePacker::setTextureBackground(const char *name, int x, int y, int w, int h, const std::vector<Tile> &mapTiles, const char *extension, char *found_extension)
+bool TexturePacker::setTextureBackground(const char *name, int x, int y, int w, int h, int maxW, const std::vector<Tile> &mapTiles, const char *extension, char *found_extension)
 {
 	if (trace_all || trace_vram) ffnx_trace("TexturePacker::%s %s x=%d y=%d w=%d h=%d tileCount=%d\n", __func__, name, x, y, w, h, mapTiles.size());
 
 	ModdedTextureId textureId = makeTextureId(x, y);
-	// Adjust width with actual texture usage
-	int maxW = 0;
-	for (const Tile &tile: mapTiles) {
-		int maxX = ((tile.texID + 1) & 0xF) * TEXTURE_WIDTH_BPP16;
-		if (maxX > maxW) {
-			maxW = maxX;
-		}
-	}
 	setVramTextureId(textureId, x, y, maxW, h);
 
 	IdentifiedTexture tex(name, TextureInfos(x, y, w, h, Tim::Bpp16, true));

--- a/src/ff8/texture_packer.h
+++ b/src/ff8/texture_packer.h
@@ -156,7 +156,7 @@ public:
 
 	explicit TexturePacker();
 	bool setTexture(const char *name, const TextureInfos &texture, const TextureInfos &palette = TextureInfos(), int textureCount = -1, bool clearOldTexture = true);
-	bool setTextureBackground(const char *name, int x, int y, int w, int h, const std::vector<Tile> &mapTiles, const char *extension = nullptr, char *found_extension = nullptr);
+	bool setTextureBackground(const char *name, int x, int y, int w, int h, int maxW, const std::vector<Tile> &mapTiles, const char *extension = nullptr, char *found_extension = nullptr);
 	// Override a part of the VRAM from another part of the VRAM, typically with biggest textures (Worldmap)
 	bool setTextureRedirection(const char *name, const TextureInfos &oldTexture, const TextureInfos &newTexture, const Tim &tim);
 	void animateTextureByCopy(int sourceXBpp2, int y, int sourceWBpp2, int sourceH, int targetXBpp2, int targetY);

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -714,6 +714,7 @@ void ff8_find_externals()
 		ff8_externals.sub_543CB0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0xA55);
 		ff8_externals.worldmap_update_steps_sub_6519D0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0x8DB);
 		ff8_externals.set_drawpoint_state_521D90 = (void(*)(uint8_t, char))get_relative_call(ff8_externals.sub_54E9B0, 0x845);
+		ff8_externals.set_render_to_vram_current_screen_flag_before_battle = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, 0xB3C);
 
 		ff8_externals.sub_545F10 = get_relative_call(ff8_externals.sub_545EA0, 0x20);
 
@@ -794,6 +795,7 @@ void ff8_find_externals()
 		ff8_externals.sub_543CB0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, JP_VERSION ? 0xA3C : 0xA47);
 		ff8_externals.worldmap_update_steps_sub_6519D0 = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, JP_VERSION ? 0x8C4 : 0x8CD);
 		ff8_externals.set_drawpoint_state_521D90 = (void(*)(uint8_t, char))get_relative_call(ff8_externals.sub_54E9B0, 0x85F);
+		ff8_externals.set_render_to_vram_current_screen_flag_before_battle = get_relative_call(ff8_externals.worldmap_with_fog_sub_53FAC0, JP_VERSION ? 0xB24 : 0xB2F);
 
 		ff8_externals.sub_545F10 = get_relative_call(ff8_externals.sub_545EA0, 0x1C);
 


### PR DESCRIPTION
## Summary

- Prevent crash when the sum of mch (3D model) file size is high.
- Reorganize dynamically 3D model textures to prevent overrides between 3D models and background and particles effects

### Motivation

Modders are struggle with the game limitations:
- Create a 3D model with more vertices uses more memory and can crash the game
  - I added 16 MB of memory, the same way the Remastered did.
- When you replace every party members models by the high res version (the game already has several versions for the same model), on some maps the game can override the background texture in the emulated VRAM
  - The PC game does not use all the emulated VRAM, because menus and the screen buffers are outside the emulated VRAM. So I added new places for 3D models there, and created a dynamic algorithm to avoid overrides with background or particles effect textures that still are in VRAM

Please note that despite my efforts, the game is still limited to 16 3D models displayed on screen max, like FF7.

<img width="640" height="448" alt="This place is crowded" title="This place is crowded" src="https://github.com/user-attachments/assets/ecc493f9-479b-49d2-a9e1-18657f84717c" />
<img width="640" height="448" alt="Even with lot of high res models, it works" title="Even with lot of high res models, it works" src="https://github.com/user-attachments/assets/0dc932c5-ba1a-4ae7-aef1-3713d49e0d73" />
<img width="1024" height="512" alt="2025-12-02 22_45_28-SSIGPU - VRAM Display" src="https://github.com/user-attachments/assets/69aadca8-1a9f-429f-af6e-a953a926bbae" />

- In green: 3D model textures
- In purple: main locations of particles textures
- In blue: background textures
- In turquoise: 3D model textures in the area of background textures (works only on fields with a simple background)
- In black: most of locations are unused and can be allocated for 3D models


### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
