### PR TITLE
FF8: Fix Selphie texture in worldmap

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
 - External textures: Fix Tonberry format when dumping PNGs using `save_textures_legacy` flag ( https://github.com/julianxhokaxhiu/FFNx/pull/848 )
 - External textures: Fix bgroad_6, and some other maps, which cannot be modded ( https://github.com/julianxhokaxhiu/FFNx/pull/857 )
 - Graphics: Use more precise texture UVs ( https://github.com/julianxhokaxhiu/FFNx/pull/852 )
+- Graphics: Fix Selphie texture on worldmap ( https://github.com/julianxhokaxhiu/FFNx/pull/878 )
 - Renderer: Fix wrong alpha rendering for battle swirls
 
 ## FF8 (2000)

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1049,6 +1049,47 @@ struct ff8_menu_callback {
 	uint32_t field_4;
 };
 
+struct TexCoord {
+	uint8_t u, v;
+};
+
+struct SsigpuExecutionInstructionTriangle52 {
+	uint32_t field_0;
+	uint8_t r, g, b, func_id;
+	uint32_t vertex_a;
+	TexCoord tex_coord_a;
+	uint16_t tex_pos_x6_y9;
+	uint32_t field_10;
+	uint32_t vertex_b;
+	TexCoord tex_coord_b;
+	uint16_t tex_header;
+	uint32_t field_1C;
+	uint32_t vertex_c;
+	TexCoord tex_coord_c;
+	uint16_t field_26;
+};
+
+struct SsigpuExecutionInstructionTriangle36 {
+	uint32_t field_0;
+	uint8_t r, g, b, func_id;
+	uint32_t vertex_a;
+	TexCoord tex_coord_a;
+	uint16_t tex_pos_x6_y9;
+	uint32_t vertex_b;
+	TexCoord tex_coord_b;
+	uint16_t tex_header;
+	uint32_t vertex_c;
+	TexCoord tex_coord_c;
+	uint16_t alpha;
+};
+
+struct SsigpuExecutionInstructionRect44 {
+	SsigpuExecutionInstructionTriangle36 parent;
+	uint32_t vertex_d;
+	TexCoord tex_coord_d;
+	uint16_t field26;
+};
+
 // --------------- end of FF8 imports ---------------
 
 // memory addresses and function pointers from FF8.exe
@@ -1229,6 +1270,8 @@ struct ff8_externals
 	uint32_t worldmap_alter_uv_sub_553B40;
 	uint32_t worldmap_sub_545E20;
 	uint32_t worldmap_chara_one;
+	uint32_t wm_chara_one_push_polygons_sub_6528D0;
+	uint32_t dword_24FEE48;
 	int32_t (*open_file_world)(const char*, int32_t, uint32_t, void *);
 	uint32_t open_file_world_sub_52D670_texl_call1;
 	uint32_t open_file_world_sub_52D670_texl_call2;

--- a/src/ff8/uv_patch.cpp
+++ b/src/ff8/uv_patch.cpp
@@ -28,10 +28,6 @@
 
 #include "uv_patch.h"
 
-struct TexCoord {
-	uint8_t x, y;
-};
-
 struct MapBlockPolygon
 {
 	uint8_t vi[3];
@@ -39,22 +35,6 @@ struct MapBlockPolygon
 	TexCoord pos[3];
 	uint8_t texi, groundType;
 	uint16_t flags;
-};
-
-struct SsigpuExecutionInstruction {
-	uint32_t field_0;
-	uint8_t r, g, b, func_id;
-	uint32_t vertex_a;
-	TexCoord tex_coord_a;
-	uint16_t tex_pos_x6_y9;
-	uint32_t field_10;
-	uint32_t vertex_b;
-	TexCoord tex_coord_b;
-	uint16_t tex_header;
-	uint32_t field_1C;
-	uint32_t vertex_c;
-	TexCoord tex_coord_c;
-	uint16_t field_26;
 };
 
 int current_polygon = -1;
@@ -114,30 +94,30 @@ void sub_45DF20(int a1, int a2, int a3)
 	((void(*)(int,int,int))ff8_externals.worldmap_sub_45DF20)(a1, a2, a3);
 }
 
-void enrich_tex_coords_sub_45E3A0(SsigpuExecutionInstruction *a1)
+void enrich_tex_coords_sub_45E3A0(SsigpuExecutionInstructionTriangle52 *a1)
 {
 	MapBlockPolygon *polygon = (MapBlockPolygon *)(current_block_data_start + 4 + current_polygon * sizeof(MapBlockPolygon));
 	// Save the last bit of texture coordinates in field_26
-	a1->field_26 = ((polygon->pos[0].x & 1) << 0) | ((polygon->pos[0].y & 1) << 1)
-		| ((polygon->pos[1].x & 1) << 2) | ((polygon->pos[1].y & 1) << 3)
-		| ((polygon->pos[2].x & 1) << 4) | ((polygon->pos[2].y & 1) << 5);
+	a1->field_26 = ((polygon->pos[0].u & 1) << 0) | ((polygon->pos[0].v & 1) << 1)
+		| ((polygon->pos[1].u & 1) << 2) | ((polygon->pos[1].v & 1) << 3)
+		| ((polygon->pos[2].u & 1) << 4) | ((polygon->pos[2].v & 1) << 5);
 
-	((void(*)(SsigpuExecutionInstruction*))ff8_externals.sub_45E3A0)(a1);
+	((void(*)(SsigpuExecutionInstructionTriangle52*))ff8_externals.sub_45E3A0)(a1);
 }
 
-void ssigpu_callback_sub_461E00(SsigpuExecutionInstruction *a1)
+void ssigpu_callback_sub_461E00(SsigpuExecutionInstructionTriangle52 *a1)
 {
 	uint8_t lost_bits = a1->field_26;
 
-	((void(*)(SsigpuExecutionInstruction*))ff8_externals.sub_461E00)(a1);
+	((void(*)(SsigpuExecutionInstructionTriangle52*))ff8_externals.sub_461E00)(a1);
 
 	if (!(*(int *)ff8_externals.dword_1CA8848) && maybe_hundred_bak != nullptr) {
-		maybe_hundred_bak[6] = psx_floats512[uint32_t(a1->tex_coord_a.x) * 2 + ((lost_bits >> 0) & 1)];
-		maybe_hundred_bak[7] = psx_floats512[uint32_t(a1->tex_coord_a.y) * 2 + ((lost_bits >> 1) & 1)];
-		maybe_hundred_bak[14] = psx_floats512[uint32_t(a1->tex_coord_b.x) * 2 + ((lost_bits >> 2) & 1)];
-		maybe_hundred_bak[15] = psx_floats512[uint32_t(a1->tex_coord_b.y) * 2 + ((lost_bits >> 3) & 1)];
-		maybe_hundred_bak[22] = psx_floats512[uint32_t(a1->tex_coord_c.x) * 2 + ((lost_bits >> 4) & 1)];
-		maybe_hundred_bak[23] = psx_floats512[uint32_t(a1->tex_coord_c.y) * 2 + ((lost_bits >> 5) & 1)];
+		maybe_hundred_bak[6] = psx_floats512[uint32_t(a1->tex_coord_a.u) * 2 + ((lost_bits >> 0) & 1)];
+		maybe_hundred_bak[7] = psx_floats512[uint32_t(a1->tex_coord_a.v) * 2 + ((lost_bits >> 1) & 1)];
+		maybe_hundred_bak[14] = psx_floats512[uint32_t(a1->tex_coord_b.u) * 2 + ((lost_bits >> 2) & 1)];
+		maybe_hundred_bak[15] = psx_floats512[uint32_t(a1->tex_coord_b.v) * 2 + ((lost_bits >> 3) & 1)];
+		maybe_hundred_bak[22] = psx_floats512[uint32_t(a1->tex_coord_c.u) * 2 + ((lost_bits >> 4) & 1)];
+		maybe_hundred_bak[23] = psx_floats512[uint32_t(a1->tex_coord_c.v) * 2 + ((lost_bits >> 5) & 1)];
 
 		maybe_hundred_bak = nullptr;
 	}

--- a/src/ff8/world/chara_one.cpp
+++ b/src/ff8/world/chara_one.cpp
@@ -45,7 +45,7 @@ std::vector<CharaOneModelTextures> ff8_world_chara_one_parse_models(const uint8_
 			cur -= 4;
 			memcpy(&tim_offset, cur, 4);
 
-			if (tim_offset == 0xFFFFFFFF) {
+			if (int32_t(tim_offset) < 0) {
 				break;
 			}
 

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -825,6 +825,9 @@ void ff8_find_externals()
 		ff8_externals.battle_trigger_worldmap = ff8_externals.worldmap_with_fog_sub_53FAC0 + 0x4EA;
 	}
 
+	ff8_externals.wm_chara_one_push_polygons_sub_6528D0 = get_relative_call(ff8_externals.worldmap_chara_one, 0x675);
+	ff8_externals.dword_24FEE48 = get_absolute_value(ff8_externals.wm_chara_one_push_polygons_sub_6528D0, 0x2A);
+
 	ff8_externals.worldmap_update_seed_level_651C10 = get_relative_call(ff8_externals.worldmap_update_steps_sub_6519D0, 0x152);
 	ff8_externals.worldmap_windows_idx_map = (char*)get_absolute_value((uint32_t)ff8_externals.world_dialog_assign_text_sub_543790, 0x3B);
 


### PR DESCRIPTION
## Summary

Auto-detect and fix texture overlap for Selphie in worldmap

### Motivation

See #877

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
- [X] I did test my code on FF8 US
- [X] I did test my code on FF8 JP
