### PR TITLE
FF7: Fixed crash when using advanced lighting

### DIFF
--- a/src/gl/deferred.cpp
+++ b/src/gl/deferred.cpp
@@ -676,10 +676,9 @@ void gl_draw_deferred(draw_field_shadow_callback shadow_callback)
 			isFieldShadowDrawn = true;
 		}
 
-		gl_load_state(&deferred_draws[i].state);
-
 		if(deferred_draws[i].draw_call_type == DCT_EXTERNAL_MESH)
 		{
+			gl_load_state(&deferred_draws[i].state);
 			gl_draw_external_mesh(deferred_draws[i].external_mesh, deferred_draws[i].lightdata);
 			continue;
 		}
@@ -689,6 +688,8 @@ void gl_draw_deferred(draw_field_shadow_callback shadow_callback)
 			{
 				continue;
 			}
+
+			gl_load_state(&deferred_draws[i].state);
 
 			gl_draw_indexed_primitive(deferred_draws[i].primitivetype,
 				deferred_draws[i].vertextype,


### PR DESCRIPTION
## Summary

Fixed crash when using advanced lighting combined with SAC

### Motivation

Clean my mess

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
