### PR TITLE
FF7: Fixed additional crashes when using advanced lighting

### DIFF
--- a/src/gl.h
+++ b/src/gl.h
@@ -127,7 +127,7 @@ typedef void (*draw_field_shadow_callback)(void);
 
 void gl_draw_movie_quad(uint32_t width, uint32_t height);
 void gl_save_state(struct driver_state *dest);
-void gl_load_state(struct driver_state *src);
+void gl_load_state(struct driver_state *src, bool bind_textures = true);
 uint32_t gl_defer_draw(uint32_t primitivetype, uint32_t vertextype, struct nvertex* vertices, struct vector3<float>* normals, uint32_t vertexcount, WORD* indices, uint32_t count, struct boundingbox* boundingbox, struct light_data* lightdata, uint32_t clip, uint32_t mipmap);
 uint32_t gl_defer_sorted_draw(uint32_t primitivetype, uint32_t vertextype, struct nvertex *vertices, uint32_t vertexcount, WORD *indices, uint32_t count, uint32_t clip, uint32_t mipmap, uint32_t force_defer);
 uint32_t gl_defer_blit_framebuffer(struct texture_set *texture_set, struct tex_header *tex_header);

--- a/src/gl/deferred.cpp
+++ b/src/gl/deferred.cpp
@@ -667,6 +667,11 @@ void gl_draw_deferred(draw_field_shadow_callback shadow_callback)
 			continue;
 		}
 
+		if (deferred_draws[i].vertices == nullptr && deferred_draws[i].draw_call_type != DCT_EXTERNAL_MESH)
+		{
+			continue;
+		}
+
 		if (shadow_callback != nullptr && !isFieldShadowDrawn && deferred_draws[i].vertextype != TLVERTEX)
 		{
 			newRenderer.setD3DProjection(&deferred_draws[i].state.d3dprojection_matrix);
@@ -678,19 +683,13 @@ void gl_draw_deferred(draw_field_shadow_callback shadow_callback)
 
 		if(deferred_draws[i].draw_call_type == DCT_EXTERNAL_MESH)
 		{
-			gl_load_state(&deferred_draws[i].state);
+			gl_load_state(&deferred_draws[i].state, false);
 			gl_draw_external_mesh(deferred_draws[i].external_mesh, deferred_draws[i].lightdata);
 			continue;
 		}
 		else
 		{
-			if (deferred_draws[i].vertices == nullptr)
-			{
-				continue;
-			}
-
 			gl_load_state(&deferred_draws[i].state);
-
 			gl_draw_indexed_primitive(deferred_draws[i].primitivetype,
 				deferred_draws[i].vertextype,
 				deferred_draws[i].vertices,

--- a/src/gl/gl.cpp
+++ b/src/gl/gl.cpp
@@ -165,15 +165,19 @@ void gl_save_state(struct driver_state *dest)
 }
 
 // restore complete rendering state from memory
-void gl_load_state(struct driver_state *src)
+void gl_load_state(struct driver_state *src, bool bind_textures)
 {
-	VOBJ(texture_set, texture_set, src->texture_set);
+	if (bind_textures)
+	{
+		VOBJ(texture_set, texture_set, src->texture_set);
 
-	memcpy(&current_state, src, sizeof(current_state));
+		memcpy(&current_state, src, sizeof(current_state));
 
-	gl_bind_texture_set(src->texture_set);
-	gl_set_texture(src->texture_handle, src->texture_set ? VREF(texture_set, ogl.gl_set) : NULL);
-	current_state.texture_set = src->texture_set;
+		gl_bind_texture_set(src->texture_set);
+		gl_set_texture(src->texture_handle, src->texture_set ? VREF(texture_set, ogl.gl_set) : NULL);
+		current_state.texture_set = src->texture_set;
+	}
+
 	common_setviewport(src->viewport[0], src->viewport[1], src->viewport[2], src->viewport[3], 0);
 	gl_set_blend_func(src->blend_mode);
 	internal_set_renderstate(V_WIREFRAME, src->wireframe, 0);


### PR DESCRIPTION
## Summary

Fixed additional crashes when using advanced lighting when using in combination with SAC (the previous PR did not fully fix the problem).

### Motivation

To fix my mess once more.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
