### PR TITLE
FF8: Fix non-looping music stop + Fix BGU music resuming

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ## Common
 
 - External movies: Always enable external_movies by default ( https://github.com/julianxhokaxhiu/FFNx/pull/854 )
+- External music: Fix music stopping too soon if the music is not looped ( https://github.com/julianxhokaxhiu/FFNx/pull/889 )
 - Renderer: Skip rendering frame if no draw commands have been submitted previously
 
 ## FF7
@@ -21,6 +22,8 @@
 - Core: Allow to quit game via CTRL+Q everywhere ( https://github.com/julianxhokaxhiu/FFNx/pull/873 )
 - Core: add `ff8_high_res_font` option ( https://github.com/julianxhokaxhiu/FFNx/pull/873 )
 - Direct mode: Fix direct mode for magic.fs archive ( https://github.com/julianxhokaxhiu/FFNx/pull/888 )
+- External music: Fix music resuming in BGU ( https://github.com/julianxhokaxhiu/FFNx/pull/889 )
+- External music: Fix wav music overloading ( https://github.com/julianxhokaxhiu/FFNx/pull/889 )
 - External textures: Fix glitches in field module ( https://github.com/julianxhokaxhiu/FFNx/pull/848 https://github.com/julianxhokaxhiu/FFNx/pull/851 )
 - External textures: Fix Tonberry format when dumping PNGs using `save_textures_legacy` flag ( https://github.com/julianxhokaxhiu/FFNx/pull/848 )
 - External textures: Fix bgroad_6, and some other maps, which cannot be modded ( https://github.com/julianxhokaxhiu/FFNx/pull/857 )

--- a/src/audio.h
+++ b/src/audio.h
@@ -256,7 +256,7 @@ public:
 	bool isMusicDisabled(const char* name);
 	bool playMusic(const char* name, uint32_t id, int channel, MusicOptions options = MusicOptions());
 	void playSynchronizedMusics(const std::vector<std::string>& names, uint32_t id, MusicOptions options = MusicOptions());
-	void swapChannels();
+	void prioritizeMusicRestore(uint32_t id);
 	void stopMusic(double time = 0);
 	void stopMusic(int channel, double time = 0);
 	void pauseMusic(double time = 0);

--- a/src/audio/openpsf/openpsf.cpp
+++ b/src/audio/openpsf/openpsf.cpp
@@ -75,6 +75,11 @@ namespace SoLoud
 
 		mOffset += offset;
 
+		// If the song is looping, just ensure mOffset does not overflow
+		if ((mFlags & AudioSourceInstance::LOOPING) && mOffset >= mParent->mSampleCount) {
+			mOffset = mParent->mSampleCount;
+		}
+
 		return offset;
 	}
 

--- a/src/audio/vgmstream/vgmstream.cpp
+++ b/src/audio/vgmstream/vgmstream.cpp
@@ -53,11 +53,8 @@ namespace SoLoud
 		mOffset += sample_count;
 
 		// If the song is looping, recalculate the offset correctly
-		if (mFlags & AudioSourceInstance::LOOPING) {
-			if (mOffset >= mParent->mStream->loop_end_sample)
-			{
-				mOffset = mOffset - mParent->mSampleCount + mParent->mStream->loop_start_sample;
-			}
+		if ((mFlags & AudioSourceInstance::LOOPING) && mOffset >= mParent->mLoopEndSample) {
+			mOffset = mOffset - mParent->mLoopEndSample + mParent->mStream->loop_start_sample;
 		}
 
 		return sample_count;
@@ -84,11 +81,7 @@ namespace SoLoud
 
 	bool VGMStreamInstance::hasEnded()
 	{
-		if (!(mFlags & AudioSourceInstance::LOOPING) && mOffset >= mParent->mSampleCount)
-		{
-			return 1;
-		}
-		return 0;
+		return !(mFlags & AudioSourceInstance::LOOPING) && mOffset >= mParent->mSampleCount;
 	}
 
 	VGMStream::VGMStream() : mStream(nullptr), mSampleCount(0)
@@ -151,6 +144,8 @@ namespace SoLoud
 		if (mStream->loop_flag) setLooping(true);
 		// If the file has no loop tags, but the users wants to loop, force a basic start to end loop
 		else if (mFlags & AudioSourceInstance::LOOPING) vgmstream_force_loop(mStream, true, 0, mStream->num_samples);
+
+		mLoopEndSample = mStream->loop_end_sample != 0 ? mStream->loop_end_sample : mSampleCount;
 
 		return SO_NO_ERROR;
 	}

--- a/src/audio/vgmstream/vgmstream.h
+++ b/src/audio/vgmstream/vgmstream.h
@@ -41,6 +41,7 @@ namespace SoLoud
 	public:
 		VGMSTREAM* mStream;
 		unsigned int mSampleCount;
+		unsigned int mLoopEndSample;
 
 		sample_t* mData;
 


### PR DESCRIPTION
## Summary

- First Laguna Dream, Julia music stops when using external music with vgmstream.
- BGU music resuming on the balcony after BGU transformation is fixed
- Fix music name in play wav

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
