### PR TITLE
FF7: Relax trigger battles in woa_* maps for 60FPS

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 ## FF7
 
 - 60FPS: Fix battle swirl fading effect and speed
+- 60FPS: Fix field `woa_*` trigger battles by relaxing max battle count to 3
 - Core: Fix KAWAI opcode behavior ( https://github.com/julianxhokaxhiu/FFNx/issues/809 + https://github.com/julianxhokaxhiu/FFNx/issues/874 )
 - Core: Fix fr_e field blend mode
 - Graphics: Implemented smooth skinning for gltf 3d models ( https://github.com/julianxhokaxhiu/FFNx/pull/882 )

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -3017,6 +3017,7 @@ struct ff7_externals
 	uint32_t opcode_canm1_canm2;
 	uint32_t opcode_fade;
 	uint32_t opcode_shake;
+	int (*field_opcode_14_sub_6117CB)();
 	uint32_t field_opcode_08_sub_61D0D4;
 	void (*field_opcode_08_09_set_rotation_61DB2C)(short, byte, byte);
 	uint32_t field_opcode_AA_2A_sub_616476;
@@ -3035,6 +3036,7 @@ struct ff7_externals
 	uint32_t opcode_tutor;
 	uint32_t opcode_pc;
 	uint32_t opcode_kawai;
+	uint32_t opcode_ifub;
 	uint32_t *sfx_initialized;
 	uint32_t sfx_play_summon;
 	uint32_t sfx_load_and_play_with_speed;

--- a/src/ff7/field/enter.h
+++ b/src/ff7/field/enter.h
@@ -25,6 +25,7 @@
 
 #include "model.h"
 #include "background.h"
+#include "opcode.h"
 #include "../widescreen.h"
 
 namespace ff7::field
@@ -47,6 +48,14 @@ namespace ff7::field
             external_data.prevCollisionRadius = 0;
 
             external_data.blinkFrameIndex = BLINKING_FRAMES;
+        }
+
+        // reset woa_* battle count at field enter
+        if(*common_externals.current_field_id != last_woa_field_map) {
+            last_woa_field_map = 0;
+            woa_battle_count[0] = 0;
+            woa_battle_count[1] = 0;
+            woa_battle_count[2] = 0;
         }
 
         if(widescreen_enabled || enable_uncrop) widescreen.initParamsFromConfig();

--- a/src/ff7/field/field.cpp
+++ b/src/ff7/field/field.cpp
@@ -327,6 +327,9 @@ namespace ff7::field
                 patch_divide_code<short>(ff7_externals.field_initialize_variables + 0x123, common_frame_multiplier);
                 patch_code_byte(ff7_externals.field_handle_screen_fading + 0x210, 25 * common_frame_multiplier);
                 patch_code_int(ff7_externals.field_handle_screen_fading + 0x240, 25 * common_frame_multiplier - 1);
+
+                // Relax woa_* trigger battle condition
+                patch_code_dword((uint32_t)&common_externals.execute_opcode_table[IFUB], (DWORD)&opcode_script_IFUB_60fps);
             }
 
             // Smooth background movement for both 30 fps mode and 60 fps mode

--- a/src/ff7/field/opcode.cpp
+++ b/src/ff7/field/opcode.cpp
@@ -279,5 +279,46 @@ namespace ff7::field
 
         return ret;
     }
+
+    int opcode_script_IFUB_60fps()
+    {
+        // Relax trigger battles in woa_* field maps for 60 FPS
+        if ((*common_externals.current_field_id == 709) ||
+            (*common_externals.current_field_id == 710) ||
+            (*common_externals.current_field_id == 711))
+        {
+            last_woa_field_map = *common_externals.current_field_id;
+            byte first_mem_bank = (get_field_parameter<byte>(0) >> 4) & 0xF;
+            byte second_mem_bank = get_field_parameter<byte>(0) & 0xF;
+            byte address = get_field_parameter<byte>(1);
+            byte value = get_field_parameter<byte>(2);
+            byte op_comparison = get_field_parameter<byte>(3);
+            bool is_trigger_battle_cond = false;
+            switch(*common_externals.current_field_id) {
+            case 709:
+                is_trigger_battle_cond = first_mem_bank == 5 && second_mem_bank == 0 && address == 4 && value == 0 && op_comparison == 0;
+                break;
+            case 710:
+                is_trigger_battle_cond = first_mem_bank == 5 && second_mem_bank == 0 && address == 18 && value == 0 && op_comparison == 0;
+                break;
+            case 711:
+                is_trigger_battle_cond = first_mem_bank == 5 && second_mem_bank == 0 && address == 7 && value == 0 && op_comparison == 0;
+                break;
+            default:
+                break;
+            }
+            if (is_trigger_battle_cond) {
+                if (woa_battle_count[*common_externals.current_field_id - 709] >= 3) {
+                    // jump script position to defined offset as if the IF condition is failed
+                    ff7_externals.field_curr_script_position[*ff7_externals.current_entity_id] += get_field_parameter<byte>(4) + 5;
+                    return 0;
+                }
+                if (ff7_externals.field_opcode_14_sub_6117CB()) {
+                    woa_battle_count[*common_externals.current_field_id - 709] += 1;
+                }
+            }
+        }
+        return call_original_opcode_function(IFUB);
+    }
 }
 

--- a/src/ff7/field/opcode.h
+++ b/src/ff7/field/opcode.h
@@ -51,6 +51,9 @@ namespace ff7::field
 
     std::array<uint32_t, 256> original_opcode_table {0};
 
+    WORD last_woa_field_map = 0;
+    int woa_battle_count[3] = {0, 0, 0};
+
     short ff7_opcode_multiply_get_bank_value(short bank, short address);
     short ff7_opcode_divide_get_bank_value(short bank, short address);
     int opcode_script_partial_animation_wrapper();
@@ -61,6 +64,7 @@ namespace ff7::field
     uint8_t opcode_IFSW_compare_sub();
     int opcode_script_FADE();
     int opcode_script_IFKEY();
+    int opcode_script_IFUB_60fps();
 
     // Thanks for myst6re https://github.com/myst6re/makoureactor/blob/5231723307901043941356ad1e42d26725305edf/core/field/Opcode.h#L71
     enum FieldOpcode {

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -518,7 +518,9 @@ inline void ff7_find_externals(struct ff7_game_obj* game_object)
 	ff7_externals.opcode_biton = common_externals.execute_opcode_table[0x82];
 	ff7_externals.opcode_pc = common_externals.execute_opcode_table[0xA0];
 	ff7_externals.opcode_kawai = common_externals.execute_opcode_table[0x28];
+	ff7_externals.opcode_ifub = common_externals.execute_opcode_table[0x14];
 
+	ff7_externals.field_opcode_14_sub_6117CB = (int(*)())get_relative_call(common_externals.execute_opcode_table[0x14], 0x4);
 	ff7_externals.field_opcode_08_sub_61D0D4 = get_relative_call(common_externals.execute_opcode_table[0x08], 0x5A);
 	ff7_externals.field_opcode_08_09_set_rotation_61DB2C = (void(*)(short, byte, byte))get_relative_call(ff7_externals.field_opcode_08_sub_61D0D4, 0x196);
 	ff7_externals.field_opcode_AA_2A_sub_616476 = get_relative_call(common_externals.execute_opcode_table[0xAA], 0x26);


### PR DESCRIPTION
## Summary

Fix fields woa_* annoyance of wind walls by relaxing the condition only in 60 fps. After 3 times the player gets blocked by the wall, the wall will not trigger anymore and the player can go easily to the other side. This trigger count is reset each time the player changes to a different field map. 

Tested with original flevel, new threat 1.5 and new threat 2.0

### Motivation

Simplify the life of players https://github.com/julianxhokaxhiu/FFNx/issues/797

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
