### PR TITLE
FF8: Add chunk feature for battle ennemies c0mXXX.dat files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,9 @@
 
 ## FF8
 
+- Direct mode: Optionally add the language prefix to the path for multi-language mods ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
+- Direct mode: Add the chunk feature for c0mXXX.dat files ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
+- Exe data: Ensure files loaded only once ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
 - External textures: Disable texture filtering in worldmap when filtering is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/954 )
 
 # 1.24.3

--- a/docs/mods/direct_mode.md
+++ b/docs/mods/direct_mode.md
@@ -4,8 +4,9 @@ The Direct mode allows modders to bypass game archives
 (LGP for FF7 or FS/FI/FL for FF8) and read files directly from the directory
 pointed by the `direct_mode_path` configuration entry.
 
-For example: if FF7 is looking for aaab.rsd in char.lgp, this mode will make it open direct/char/aaab.rsd first,
+For example: if FF7 is looking for aaab.rsd in char.lgp, this mode will make it open `direct/char/aaab.rsd` first,
 If this file doesn't exist it will look for the original in the LGP archive
-Another example: if FF8 is looking for c:/data/en/FIELD/mapdata/bc/bccent12/bccent12.msd in field.fs,
-this mode will make it open direct/FIELD/mapdata/bc/bccent12/bccent12.msd if it exists.
+Another example: if FF8 is looking for `c:/data/en/FIELD/mapdata/bc/bccent12/bccent12.msd` in field.fs,
+this mode will make it open `direct/en/FIELD/mapdata/bc/bccent12/bccent12.msd` if it exists.
+If it does not exist, it will retry without the lang directory `direct/FIELD/mapdata/bc/bccent12/bccent12.msd`
 

--- a/docs/mods/external_textures.md
+++ b/docs/mods/external_textures.md
@@ -1,7 +1,7 @@
 # External textures
 
 You can override game's textures with images in DDS (recommended) or PNG format.
-To know where to put your custom textures, set the option `trace_loaders` to `true` and look at the content of FFNx.log
+To know where to put your custom textures, set the options `trace_loaders` and `show_missing_textures` to `true` and look at the content of FFNx.log
 when the game is running.
 
 It is also possible to dump textures on runtime in PNG format by setting the option `save_textures` to true.

--- a/src/exe_data.cpp
+++ b/src/exe_data.cpp
@@ -24,18 +24,42 @@
 #include "utils.h"
 #include "patch.h"
 #include "saveload.h"
+#include "ff8/file.h"
 
 uint8_t *ff8_exe_scan_texts = nullptr;
+bool ff8_exe_scan_texts_file_absent = false;
 uint8_t *ff8_exe_card_names = nullptr;
+bool ff8_exe_card_names_file_absent = false;
 uint8_t *ff8_exe_draw_point = nullptr;
+bool ff8_exe_draw_point_file_absent = false;
 uint8_t *ff8_exe_card_texts = nullptr;
+bool ff8_exe_card_texts_file_absent = false;
 
 bool ff8_get_exe_path(const char *name, char *target_filename)
 {
+    char langPath[16] = "";
+    ff8_fs_lang_string(langPath);
+
+    snprintf(target_filename, MAX_PATH, "%s/%s/%s/exe/%s.msd", basedir, direct_mode_path.c_str(), langPath, name);
+    normalize_path(target_filename);
+
+    if (fileExists(target_filename)) {
+        return true;
+    }
+
+    if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", target_filename);
+
+    // Retry without lang
     snprintf(target_filename, MAX_PATH, "%s/%s/exe/%s.msd", basedir, direct_mode_path.c_str(), name);
     normalize_path(target_filename);
 
-    return fileExists(target_filename);
+    if (fileExists(target_filename)) {
+        return true;
+    }
+
+    if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", target_filename);
+
+    return false;
 }
 
 bool ff8_get_battle_scan_texts_filename(char *filename)
@@ -247,13 +271,13 @@ uint8_t *ff8_open_msd(char *filename, int *data_size = nullptr)
 
 uint8_t *ff8_override_battle_scans()
 {
-    if (ff8_exe_scan_texts != nullptr) {
+    if (ff8_exe_scan_texts != nullptr || ff8_exe_scan_texts_file_absent) {
         return ff8_exe_scan_texts;
     }
 
     char filename[MAX_PATH] = {};
     if (! ff8_get_battle_scan_texts_filename(filename)) {
-        if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", filename);
+        ff8_exe_scan_texts_file_absent = true;
 
         return nullptr;
     }
@@ -265,13 +289,13 @@ uint8_t *ff8_override_battle_scans()
 
 uint8_t *ff8_override_card_names()
 {
-    if (ff8_exe_card_names != nullptr) {
+    if (ff8_exe_card_names != nullptr || ff8_exe_card_names_file_absent) {
         return ff8_exe_card_names;
     }
 
     char filename[MAX_PATH] = {};
     if (! ff8_get_card_names_filename(filename)) {
-        if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", filename);
+        ff8_exe_card_names_file_absent = true;
 
         return nullptr;
     }
@@ -283,13 +307,13 @@ uint8_t *ff8_override_card_names()
 
 uint8_t *ff8_override_draw_point()
 {
-    if (ff8_exe_draw_point != nullptr) {
+    if (ff8_exe_draw_point != nullptr || ff8_exe_draw_point_file_absent) {
         return ff8_exe_draw_point;
     }
 
     char filename[MAX_PATH] = {};
     if (! ff8_get_draw_point_filename(filename)) {
-        if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", filename);
+        ff8_exe_draw_point_file_absent = true;
 
         return nullptr;
     }
@@ -301,13 +325,13 @@ uint8_t *ff8_override_draw_point()
 
 uint8_t *ff8_override_card_texts()
 {
-    if (ff8_exe_card_texts != nullptr) {
+    if (ff8_exe_card_texts != nullptr || ff8_exe_card_texts_file_absent) {
         return ff8_exe_card_texts;
     }
 
     char filename[MAX_PATH] = {};
     if (! ff8_get_card_texts_filename(filename)) {
-        if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", filename);
+        ff8_exe_card_texts_file_absent = true;
 
         return nullptr;
     }

--- a/src/ff8/file.cpp
+++ b/src/ff8/file.cpp
@@ -52,6 +52,13 @@ bool set_direct_path(const char *fullpath, char *output, size_t output_size)
 	{
 		_snprintf(output, output_size, "%s/%s/%s", basedir, direct_mode_path.c_str(), fullpath + get_fl_prefix_size(false));
 
+		if (!fileExists(output))
+		{
+			if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", output);
+
+			return false;
+		}
+
 		return true;
 	}
 
@@ -62,7 +69,23 @@ bool set_direct_path(const char *fullpath, char *output, size_t output_size)
 		return false;
 	}
 
-	_snprintf(output, output_size, "%s/%s/%s", basedir, direct_mode_path.c_str(), fullpath + get_fl_prefix_size());
+	// Try with the lang prefix
+	_snprintf(output, output_size, "%s/%s/%s", basedir, direct_mode_path.c_str(), fullpath + get_fl_prefix_size(false));
+
+	if (!fileExists(output))
+	{
+		if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", output);
+
+		// Retry without the lang prefix
+		_snprintf(output, output_size, "%s/%s/%s", basedir, direct_mode_path.c_str(), fullpath + get_fl_prefix_size());
+
+		if (!fileExists(output))
+		{
+			if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", output);
+
+			return false;
+		}
+	}
 
 	return true;
 }
@@ -73,9 +96,7 @@ bool check_direct_sub_archive_exists(const char *ext, const char *path_without_e
 
 	sprintf(archive_path, "%s.%s", path_without_ext, ext);
 
-	set_direct_path(archive_path, direct_path, sizeof(direct_path));
-
-	return fileExists(direct_path);
+	return set_direct_path(archive_path, direct_path, sizeof(direct_path));
 }
 
 void ff8_fs_archive_sub_archive_get_filename(const char *filename, char *dirname)
@@ -101,8 +122,6 @@ void ff8_fs_archive_sub_archive_get_filename(const char *filename, char *dirname
 		// Bypass subarchive opening
 		strncpy(ff8_externals.temp_fs_path_cache, cleaned_dirname + 2, path_strlen);
 	} else {
-		if (trace_all || trace_direct) ffnx_warning("Direct files not found %s.fs, .fl and .fi\n", cleaned_dirname);
-
 		next_direct_file[0] = '\0';
 	}
 
@@ -163,17 +182,11 @@ int ff8_fs_archive_search_filename_sub_archive(const char *fullpath, ff8_file_fi
 
 	char direct_path[MAX_PATH];
 
-	set_direct_path(fullpath, direct_path, sizeof(direct_path));
-
-	if (fileExists(direct_path))
+	if (set_direct_path(fullpath, direct_path, sizeof(direct_path)))
 	{
 		strncpy(next_direct_file, direct_path, sizeof(next_direct_file));
 
 		return 0; // Bypass Moriya filesystem
-	}
-	else
-	{
-		if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", direct_path);
 	}
 
 	return ff8_fs_archive_search_filename2(fullpath, fi_infos_for_the_path, file_container);
@@ -379,20 +392,16 @@ ff8_file *ff8_open_file(ff8_file_context *infos, const char *fs_path)
 
 			if (infos->file_container != nullptr)
 			{
-				char direct_path[MAX_PATH];
+				char direct_path[MAX_PATH] = "";
 
-				set_direct_path(fullpath, direct_path, sizeof(direct_path));
-
-				file->fd = ff8_externals._sopen(direct_path, oflag, shflag, pmode);
-
-				if (file->fd != -1)
+				if (set_direct_path(fullpath, direct_path, sizeof(direct_path)))
 				{
+					file->fd = ff8_externals._sopen(direct_path, oflag, shflag, pmode);
+
 					if (trace_all || trace_direct) ffnx_info("Direct file using %s\n", direct_path);
 				}
 				else
 				{
-					if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", direct_path);
-
 					if (ff8_externals.fs_archive_search_filename(fullpath, &file->fi_infos, infos->file_container))
 					{
 						file->fd = 0;
@@ -402,7 +411,7 @@ ff8_file *ff8_open_file(ff8_file_context *infos, const char *fs_path)
 			}
 			else
 			{
-				char _filename[256]{ 0 };
+				char _filename[MAX_PATH]{ 0 };
 				bool is_redirected = ff8_attempt_redirection(fullpath, _filename, sizeof(_filename));
 
 				last_fopen_is_redirected = is_redirected;

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -34,6 +34,7 @@
 #include "world/chara_one.h"
 #include "world/wmset.h"
 #include "battle/stage.h"
+#include "./file.h"
 
 #include <shlwapi.h>
 #include <unordered_map>
@@ -1411,7 +1412,7 @@ int battle_get_texture_file_name_index(void *texture_buffer)
 
 int16_t ff8_battle_open_and_read_file(int fileId, void *data, int a3, int callback)
 {
-	if (trace_all || trace_vram) ffnx_trace("%s: %d => %s\n", __func__, fileId, ff8_externals.battle_filenames[fileId]);
+	if (trace_all || trace_files) ffnx_trace("%s: %d => %s\n", __func__, fileId, ff8_externals.battle_filenames[fileId]);
 
 	battle_texture_id = 0;
 	if (stricmp(ff8_externals.battle_filenames[fileId], "B0WAVE.DAT") == 0) {
@@ -1439,7 +1440,88 @@ int16_t ff8_battle_open_and_read_file(int fileId, void *data, int a3, int callba
 		battle_texture_data_list[index] = tex;
 	}
 
-	return ((int16_t(*)(int,void*,int,int))ff8_externals.battle_open_file)(fileId, data, a3, callback);
+	int16_t ret = ((int16_t(*)(int,void*,int,int))ff8_externals.battle_open_file)(fileId, data, a3, callback);
+
+	// c0mXXX.dat files (battle ennemies)
+	if (fileId >= 166 && fileId <= 309 && *(uint32_t *)data == 11)
+	{
+		char chunk_file[1024]{0};
+		byte *chunks_data[11]{nullptr};
+		long chunks_size[11]{0};
+		bool has_chunk = false;
+		char langPath[16] = "/";
+
+		ff8_fs_lang_string(langPath + 1);
+
+		for (int chunkId = 0; chunkId < 11; ++chunkId)
+		{
+			for (uint8_t lang = 0; lang < 2; lang++)
+			{
+				_snprintf(chunk_file, sizeof(chunk_file), "%s/%s%s/battle/%s.chunk.%i", basedir, direct_mode_path.c_str(), langPath, ff8_externals.battle_filenames[fileId], chunkId + 1);
+
+				FILE *fd = fopen(chunk_file, "rb");
+
+				if (fd != nullptr)
+				{
+					if (trace_all || trace_direct) ffnx_info("Direct file using %s\n", chunk_file);
+
+					fseek(fd, 0L, SEEK_END);
+					long chunk_size = ftell(fd);
+					fseek(fd, 0L, SEEK_SET);
+
+					byte *chunk_data = new byte[chunk_size];
+
+					fread(chunk_data, sizeof(byte), chunk_size, fd);
+					fclose(fd);
+
+					chunks_data[chunkId] = chunk_data;
+					chunks_size[chunkId] = chunk_size;
+					has_chunk = true;
+					break;
+				}
+
+				if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", chunk_file);
+
+				*langPath = '\0';
+			}
+			*langPath = '/';
+		}
+
+		// Rebuild file content with chunks + original data
+		if (has_chunk)
+		{
+			uint32_t *toc = (uint32_t *)data + 1;
+			uint32_t cur_data_pos = (11 + 2) * sizeof(uint32_t);
+			byte *old_data = new byte[toc[12]];
+			memcpy(old_data, data, toc[12] * sizeof(byte));
+			uint32_t *old_toc = (uint32_t *)old_data + 1;
+
+			for (int chunkId = 0; chunkId < 11; ++chunkId)
+			{
+				byte *chunk_data = chunks_data[chunkId];
+				long chunk_size;
+				toc[chunkId] = cur_data_pos;
+				if (chunk_data != nullptr)
+				{
+					chunk_size = chunks_size[chunkId];
+					memcpy((uint8_t *)data + toc[chunkId], chunk_data, chunks_size[chunkId]);
+					delete[] chunk_data;
+				}
+				else
+				{
+					chunk_size = old_toc[chunkId + 1] - old_toc[chunkId];
+					memcpy((uint8_t *)data + toc[chunkId], old_data + old_toc[chunkId], chunk_size);
+				}
+				cur_data_pos += chunk_size;
+			}
+
+			toc[11] = cur_data_pos;
+
+			delete[] old_data;
+		}
+	}
+
+	return ret;
 }
 
 void *ff8_battle_open_effect(const char *fileName, void *data, int dataSize, DWORD *outSize)


### PR DESCRIPTION
## Summary

Add chunk feature for battle ennemies c0mXXX.dat files

### Motivation

Allow modders to publish only a modded section of the file (for example the section 7, aka monster stats)

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
