### PR TITLE
FF7: Fix 2026 achievement for KOTR and Bahamut Zero

### DIFF
--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -447,11 +447,11 @@ void SteamAchievementsFF7::unlockGotMateriaAchievement(byte materiaID)
 
     if (materiaID == BAHAMUT_ZERO_MATERIA_ID)
     {
-        this->steamManager->setAchievement(getAchievementIdByVersion(GET_MATERIA_KOTR, A17_KnightsOfTheRound));
+        this->steamManager->setAchievement(getAchievementIdByVersion(GET_MATERIA_BAHAMUT_ZERO, A16_BahamutZero));
     }
     else if (materiaID == KOTR_MATERIA_ID)
     {
-        this->steamManager->setAchievement(getAchievementIdByVersion(GET_MATERIA_BAHAMUT_ZERO, A16_BahamutZero));
+        this->steamManager->setAchievement(getAchievementIdByVersion(GET_MATERIA_KOTR, A17_KnightsOfTheRound));
     }
 
     if (!this->isFF72013Release) {


### PR DESCRIPTION
## Summary

Fix 2026 achievement for KOTR and Bahamut Zero

### Motivation

Yes

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
