### PR TITLE
FF8: clear texture packer on module loading

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@
 ## FF8
 
 - Core: Fix random crash when battles start ( https://github.com/julianxhokaxhiu/FFNx/pull/912 )
+- External textures: Clear identified textures properly between game modes ( https://github.com/julianxhokaxhiu/FFNx/pull/913 )
 
 # 1.24.1
 

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1217,6 +1217,7 @@ struct ff8_externals
 	uint32_t pubintro_enter_main;
 	uint32_t pubintro_exit;
 	uint32_t pubintro_main_loop;
+	uint32_t credits_enter;
 	uint32_t credits_main_loop;
 	uint32_t go_to_main_menu_main_loop;
 	uint32_t main_menu_enter;

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -900,6 +900,14 @@ Tim ff8_wm_set_texture_name_from_section_position(uint8_t section_number, uint32
 	return tim;
 }
 
+void ff8_wm_set_section_positions()
+{
+	// This is when the worldmap loads: Clear all textures in the VRAM
+	texturePacker.clearTextures();
+
+	((void(*)())ff8_externals.worldmap_wmset_set_pointers_sub_542DA0)();
+}
+
 void ff8_wm_section_17_upload(uint8_t *tim_file_data, int16_t x, int16_t y)
 {
 	if (trace_all || trace_vram) ffnx_trace("%s: pos=(%d, %d)\n", __func__, x, y);
@@ -1210,6 +1218,9 @@ void ff8_wm_texl_palette_upload_vram(int16_t *pos_and_size, uint8_t *texture_buf
 void ff8_field_mim_palette_upload_vram(int16_t *pos_and_size, uint8_t *texture_buffer)
 {
 	if (trace_all || trace_vram) ffnx_trace("%s\n", __func__);
+
+	// This is the first upload when a field map loads: Clear all textures in the VRAM
+	texturePacker.clearTextures();
 
 	field_effect_texture_infos = TexturePacker::TextureInfos();
 
@@ -1851,6 +1862,7 @@ void vram_init()
 	replace_call(ff8_externals.sub_5391B0 + 0x1CC, ff8_upload_vram_triple_triad_2_palette);
 	replace_call(ff8_externals.sub_5391B0 + 0x1E1, ff8_upload_vram_triple_triad_2_data);
 	// worldmap
+	replace_call(ff8_externals.worldmap_sub_53F310_call_24D, ff8_wm_set_section_positions); // Replaced to clear the textures on module loading
 	replace_call(ff8_externals.sub_554940_call_130, ff8_wm_section_17_upload); // Waves
 	replace_call(ff8_externals.worldmap_sub_53F310_call_2A9, ff8_wm_section_38_prepare_texture_for_upload);
 	replace_call(ff8_externals.worldmap_sub_53F310_call_30D, ff8_upload_vram_wm_section_38_palette);
@@ -1939,6 +1951,7 @@ void vram_init()
 
 	// Fix missing textures in battle module by clearing custom textures
 	replace_call(ff8_externals.battle_enter + 0x35, engine_set_init_time);
+	replace_call(ff8_externals.credits_enter + 0x12, engine_set_init_time);
 	// Clear texture_packer on every module exits
 	replace_call(ff8_externals.psxvram_texture_pages_free + 0x5A, clean_psxvram_pages);
 	// Free pc_name in tex_header

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -78,6 +78,7 @@ void ff8_find_externals()
 
 	ff8_externals.pubintro_exit = get_absolute_value(ff8_externals.main_entry, 0x176);
 	ff8_externals.pubintro_main_loop = get_absolute_value(ff8_externals.main_entry, 0x180);
+	ff8_externals.credits_enter = get_absolute_value(ff8_externals.pubintro_main_loop, 0x5D);
 	ff8_externals.credits_main_loop = get_absolute_value(ff8_externals.pubintro_main_loop, 0x6D);
 	ff8_externals.go_to_main_menu_main_loop = get_absolute_value(ff8_externals.credits_main_loop, 0xE2);
 	ff8_externals.main_menu_enter = get_absolute_value(ff8_externals.go_to_main_menu_main_loop, 0x19);


### PR DESCRIPTION
## Summary

Clear texture packer on module loading

### Motivation

When you reset the game, sometimes FFNx try to load external textures with irrelevant names. Those are artifacts from the previous module, field for example.

To ensure this do not happen, we can clear the textures we identified when we change modules. This is already the case for battle.

Field and worldmap modules cannot be cleared like we do for battle, because we can switch to the menu and come back without reloading the textures. In this case, when we come from the menu, we don't want to clear the textures. So in field and worldmap, we must clear the textures just before the game loads the main textures.

This change could help with the remaining texture bleeding issues.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
