### PR TITLE
Common: Fix bilinear filtering

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.24.3...master
 
+## Common
+
+- Renderer: fix `enable_bilinear` option for original game textures ( https://github.com/julianxhokaxhiu/FFNx/pull/914 )
+
 # 1.24.3
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.24.2...1.24.3

--- a/src/ff8/uv_patch.cpp
+++ b/src/ff8/uv_patch.cpp
@@ -138,11 +138,24 @@ int pubintro_psxvram_buffer_init_sub_45B310()
 
 	// Divide by 255 instead of 256, and don't alter values of psx_floats1[0] and psx_floats1[255]
 	for (int i = 0; i < 256; ++i) {
-		ff8_externals.psx_floats1[i] = float(double(i) / 255.0);
+		ff8_externals.psx_floats1[i] = float(double(i) / (enable_bilinear ? 256.0 : 255.0));
 	}
 
 	for (int i = 0; i < 512; ++i) {
-		psx_floats512[i] = float(double(i) / 511.0);
+		psx_floats512[i] = float(double(i) / (enable_bilinear ? 512.0 : 511.0));
+	}
+
+	if (enable_bilinear)
+	{
+		ff8_externals.psx_floats1[0] = ff8_externals.psx_floats1[1];
+		ff8_externals.psx_floats1[255] = ff8_externals.psx_floats1[254];
+
+		psx_floats512[0] = psx_floats512[3];
+		psx_floats512[1] = psx_floats512[3];
+		psx_floats512[2] = psx_floats512[3];
+		psx_floats512[509] = psx_floats512[508];
+		psx_floats512[510] = psx_floats512[508];
+		psx_floats512[511] = psx_floats512[508];
 	}
 
 	return ret;

--- a/src/gl/special_case.cpp
+++ b/src/gl/special_case.cpp
@@ -41,28 +41,28 @@ uint32_t gl_special_case(uint32_t primitivetype, uint32_t vertextype, struct nve
 	uint32_t mode = getmode_cached()->driver_mode;
 	VOBJ(texture_set, texture_set, current_state.texture_set);
 	uint32_t defer = false, force_defer = false;
+	bool isExternalTexture = current_state.texture_set && VREF(texture_set, ogl.external);
 
-	// modpath textures rendered in 3D should always be filtered
-	if(vertextype != TLVERTEX && current_state.texture_set && VREF(texture_set, ogl.external)) current_state.texture_filter = true;
-
-	// modpath textures in menu should always be filtered
-	if((mode == MODE_MENU || mode == MODE_MAIN_MENU) && current_state.texture_set && VREF(texture_set, ogl.external)) current_state.texture_filter = true;
+	// Force disabling filter for ff7 minigames internal textures
+	if(!ff8 && (mode == MODE_SUBMARINE || mode == MODE_COASTER) && !isExternalTexture) current_state.texture_filter = false;
 
 	// some modpath textures have filtering forced on
-	if(current_state.texture_set && VREF(texture_set, ogl.gl_set->force_filter) && VREF(texture_set, ogl.external)) current_state.texture_filter = true;
-
-	// Texture filtering mostly does not work well in FF8
-	if(ff8) current_state.texture_filter = enable_bilinear && vertextype != TLVERTEX && current_state.texture_set;
-	else if (enable_bilinear && (vertextype != TLVERTEX || mode == MODE_MENU || mode == MODE_MAIN_MENU || (current_state.texture_set && VREF(texture_set, ogl.gl_set->force_filter)))) current_state.texture_filter = true;
+	if(current_state.texture_set && VREF(texture_set, ogl.gl_set->force_filter) && isExternalTexture) current_state.texture_filter = true;
 
 	// some modpath textures have z-sort forced on
-	if(current_state.texture_set && VREF(texture_set, ogl.gl_set->force_zsort) && VREF(texture_set, ogl.external)) defer = true;
+	if(current_state.texture_set && VREF(texture_set, ogl.gl_set->force_zsort) && isExternalTexture) defer = true;
 
 	// z-sort by default in menu, unnecessary sorting will be avoided by defer logic
 	if(mode == MODE_MENU || mode == MODE_MAIN_MENU) defer = true;
 
 	if(!ff8)
 	{
+		// modpath textures rendered in 3D should always be filtered
+		if(vertextype != TLVERTEX && isExternalTexture) current_state.texture_filter = true;
+
+		// modpath textures in menu should always be filtered
+		if((mode == MODE_MENU || mode == MODE_MAIN_MENU) && isExternalTexture) current_state.texture_filter = true;
+
 		if(SAFE_GFXOBJ_CHECK(graphics_object, ff7_externals.menu_objects->buster_tex))
 		{
 			// stretch main menu to fullscreen if it is a modpath texture
@@ -135,6 +135,11 @@ uint32_t gl_special_case(uint32_t primitivetype, uint32_t vertextype, struct nve
 	}
 
 	if((defer || force_defer) && !ff8) return gl_defer_sorted_draw(primitivetype, vertextype, vertices, vertexcount, indices, count, clip, mipmap, force_defer);
+
+	// If we use internal texture and the game asks for filtering, we only enabled it if enable_bilinear is set
+	if (!isExternalTexture && current_state.texture_filter && !enable_bilinear) {
+		current_state.texture_filter = false;
+	}
 
 	return false;
 }

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -721,7 +721,7 @@ void Renderer::bindTextures()
 
                             if (internalState.bIsMovie) flags |= BGFX_SAMPLER_U_CLAMP | BGFX_SAMPLER_V_CLAMP | BGFX_SAMPLER_W_CLAMP;
 
-                            if (!internalState.bDoTextureFiltering || !internalState.bIsExternalTexture) flags |= BGFX_SAMPLER_MIN_POINT | BGFX_SAMPLER_MAG_POINT | BGFX_SAMPLER_MIP_POINT;
+                            if (!internalState.bDoTextureFiltering) flags |= BGFX_SAMPLER_MIN_POINT | BGFX_SAMPLER_MAG_POINT | BGFX_SAMPLER_MIP_POINT;
                         }
                         break;
                     case RendererTextureSlot::TEX_S:


### PR DESCRIPTION
## Summary

`enable_bilinear` enables linear filtering when the game asks to for internal textures

### Motivation

Official Steam versions of ff7 and ff8 have a linear filtering option

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [X] I did test my code on FF8
