### PR TITLE
Common: SDL Gamepad Button constants refactor

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,9 +6,6 @@
 
 - Core: [`SDL Gamepad`] refactor Gamepad Buttons to use the API enums directly
 - Core: updated `FFNx.toml`to inform that 7th Heaven/Junction VIII currently do not sync Controls Mappings. (This affects some Controllers)
-
-## Common
-
 - Renderer: fix `enable_bilinear` option for original game textures ( https://github.com/julianxhokaxhiu/FFNx/pull/914 )
 
 # 1.24.3

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,8 +4,6 @@
 
 ## Common
 
-- Core: [`SDL Gamepad`] refactor Gamepad Buttons to use the API enums directly
-- Core: updated `FFNx.toml`to inform that 7th Heaven/Junction VIII currently do not sync Controls Mappings. (This affects some Controllers)
 - Renderer: fix `enable_bilinear` option for original game textures ( https://github.com/julianxhokaxhiu/FFNx/pull/914 )
 
 # 1.24.3
@@ -14,7 +12,7 @@
 
 ## Common
 
-- Core: added SDL Gamepad API support, enhancing controller support
+- Core: Add support for SDL3 Gamepad API
 
 ## FF7
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,14 +5,11 @@
 ## Common
 
 - Renderer: fix `enable_bilinear` option for original game textures ( https://github.com/julianxhokaxhiu/FFNx/pull/914 )
+- Core: Add support for SDL3 Gamepad API (`use_sdl_gamepad`) ( https://github.com/julianxhokaxhiu/FFNx/pull/915 )
 
 # 1.24.3
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.24.2...1.24.3
-
-## Common
-
-- Core: Add support for SDL3 Gamepad API
 
 ## FF7
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@
 
 ## Common
 
+- Core: [`SDL Gamepad`] refactor Gamepad Buttons to use the API enums directly
+- Core: updated `FFNx.toml`to inform that 7th Heaven/Junction VIII currently do not sync Controls Mappings. (This affects some Controllers)
+
+## Common
+
 - Renderer: fix `enable_bilinear` option for original game textures ( https://github.com/julianxhokaxhiu/FFNx/pull/914 )
 
 # 1.24.3

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -387,7 +387,6 @@ external_movie_audio_ext = "ogg"
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # EXPERIMENTAL
 # This flag will enable SDL Gamepad API for enhanced Controller Support.
-#
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 use_sdl_gamepad = false
 

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -387,8 +387,7 @@ external_movie_audio_ext = "ogg"
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # EXPERIMENTAL
 # This flag will enable SDL Gamepad API for enhanced Controller Support.
-# for FF7 2020/2026: Face Button layout (South/East/West/North aka ABXY Layout) is corrected across 
-# all Controller types (notable for Nintendo Controllers).
+# for FF7 2020/2026: Face Button layout (South/East/West/North aka ABXY Layout) is corrected across all Controller types (notable for Nintendo Controllers).
 #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 use_sdl_gamepad = false

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -390,9 +390,6 @@ external_movie_audio_ext = "ogg"
 # for FF7 2020/2026: Face Button layout (South/East/West/North aka ABXY Layout) is corrected across 
 # all Controller types (notable for Nintendo Controllers).
 #
-# WARNING: If using 7th Heaven (as of v4.5.2.8) / Junction VIII (as of v1.4.1.8), this feature is not syncronized yet
-# as the Controls binding will be using DirectInput bindings as the basis
-#
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 use_sdl_gamepad = false
 

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -387,7 +387,7 @@ external_movie_audio_ext = "ogg"
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # EXPERIMENTAL
 # This flag will enable SDL Gamepad API for enhanced Controller Support.
-# for FF7 2020/2026: Face Button layout (South/East/West/North aka ABXY Layout) is corrected across all Controller types (notable for Nintendo Controllers).
+# for FF7 Steam/GOG/Xbox PC versions: Face Button layout (South/East/West/North aka ABXY Layout) is corrected across all Controller types (notable for Nintendo Controllers).
 #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 use_sdl_gamepad = false

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -385,9 +385,14 @@ external_movie_audio_ext = "ogg"
 
 #[SDL GAMEPAD API]
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# EXPERIMENTAL  
-# This flag will enable SDL Gamepad API for enhanced Controller Support,
-# for FF7 2020/2026: Face Button layout is corrected across all Controller types (notable for Nintendo Controllers)
+# EXPERIMENTAL
+# This flag will enable SDL Gamepad API for enhanced Controller Support.
+# for FF7 2020/2026: Face Button layout (South/East/West/North aka ABXY Layout) is corrected across 
+# all Controller types (notable for Nintendo Controllers).
+#
+# WARNING: If using 7th Heaven (as of v4.5.2.8) / Junction VIII (as of v1.4.1.8), this feature is not syncronized yet
+# as the Controls binding will be using DirectInput bindings as the basis
+#
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 use_sdl_gamepad = false
 

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -387,7 +387,6 @@ external_movie_audio_ext = "ogg"
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # EXPERIMENTAL
 # This flag will enable SDL Gamepad API for enhanced Controller Support.
-# for FF7 Steam (2026)/GOG/Xbox PC versions: Face Button layout (South/East/West/North aka ABXY Layout) is corrected across all Controller types (notable for Nintendo Controllers).
 #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 use_sdl_gamepad = false

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -387,7 +387,7 @@ external_movie_audio_ext = "ogg"
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # EXPERIMENTAL
 # This flag will enable SDL Gamepad API for enhanced Controller Support.
-# for FF7 Steam/GOG/Xbox PC versions: Face Button layout (South/East/West/North aka ABXY Layout) is corrected across all Controller types (notable for Nintendo Controllers).
+# for FF7 Steam (2026)/GOG/Xbox PC versions: Face Button layout (South/East/West/North aka ABXY Layout) is corrected across all Controller types (notable for Nintendo Controllers).
 #
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 use_sdl_gamepad = false

--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -181,7 +181,7 @@ void ff7_use_analogue_controls(float analog_threshold)
 			else if(sdlgamepad.leftStickY < -analog_threshold && !(sdlgamepad.leftStickX < -analog_threshold || sdlgamepad.leftStickX > analog_threshold))
 				inputDir = {0.0f, -1.0f, 0.0f};
 
-			if (sdlgamepad.IsPressed(GAMEPAD_BUTTON_RIGHT_THUMB)
+			if (sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_RIGHT_STICK)
 			    && std::abs(sdlgamepad.rightStickX) < right_analog_stick_deadzone
 				&& std::abs(sdlgamepad.rightStickY) < right_analog_stick_deadzone)
 			{
@@ -427,23 +427,23 @@ struct ff7_gamepad_status* ff7_update_gamepad_status()
 		{
 			ff7_externals.gamepad_status->pos_x = sdlgamepad.leftStickX;
 			ff7_externals.gamepad_status->pos_y = sdlgamepad.leftStickY;
-			ff7_externals.gamepad_status->dpad_up = (sdlgamepad.leftStickY > analog_threshold) || sdlgamepad.IsPressed(GAMEPAD_BUTTON_DPAD_UP); // UP
-			ff7_externals.gamepad_status->dpad_down = (sdlgamepad.leftStickY < -analog_threshold) || sdlgamepad.IsPressed(GAMEPAD_BUTTON_DPAD_DOWN); // DOWN
-			ff7_externals.gamepad_status->dpad_left = (sdlgamepad.leftStickX < -analog_threshold) || sdlgamepad.IsPressed(GAMEPAD_BUTTON_DPAD_LEFT); // LEFT
-			ff7_externals.gamepad_status->dpad_right = (sdlgamepad.leftStickX > analog_threshold) || sdlgamepad.IsPressed(GAMEPAD_BUTTON_DPAD_RIGHT); // RIGHT
-			ff7_externals.gamepad_status->button1 = sdlgamepad.IsPressed(GAMEPAD_BUTTON_X); // Square
-			ff7_externals.gamepad_status->button2 = sdlgamepad.IsPressed(GAMEPAD_BUTTON_A); // Cross
-			ff7_externals.gamepad_status->button3 = sdlgamepad.IsPressed(GAMEPAD_BUTTON_B); // Circle
-			ff7_externals.gamepad_status->button4 = sdlgamepad.IsPressed(GAMEPAD_BUTTON_Y); // Triangle
-			ff7_externals.gamepad_status->button5 = sdlgamepad.IsPressed(GAMEPAD_BUTTON_LEFT_SHOULDER); // L1
-			ff7_externals.gamepad_status->button6 = sdlgamepad.IsPressed(GAMEPAD_BUTTON_RIGHT_SHOULDER); // R1
+			ff7_externals.gamepad_status->dpad_up = (sdlgamepad.leftStickY > analog_threshold) || sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_DPAD_UP); // UP
+			ff7_externals.gamepad_status->dpad_down = (sdlgamepad.leftStickY < -analog_threshold) || sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_DPAD_DOWN); // DOWN
+			ff7_externals.gamepad_status->dpad_left = (sdlgamepad.leftStickX < -analog_threshold) || sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_DPAD_LEFT); // LEFT
+			ff7_externals.gamepad_status->dpad_right = (sdlgamepad.leftStickX > analog_threshold) || sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_DPAD_RIGHT); // RIGHT
+			ff7_externals.gamepad_status->button1 = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_WEST); // Square
+			ff7_externals.gamepad_status->button2 = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_SOUTH); // Cross
+			ff7_externals.gamepad_status->button3 = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_EAST); // Circle
+			ff7_externals.gamepad_status->button4 = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_NORTH); // Triangle
+			ff7_externals.gamepad_status->button5 = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_LEFT_SHOULDER); // L1
+			ff7_externals.gamepad_status->button6 = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER); // R1
 			ff7_externals.gamepad_status->button7 = sdlgamepad.leftTrigger > 0.85f; // L2
 			ff7_externals.gamepad_status->button8 = sdlgamepad.rightTrigger > 0.85f; // R2
-			ff7_externals.gamepad_status->button9 = sdlgamepad.IsPressed(GAMEPAD_BUTTON_BACK); // SELECT
-			ff7_externals.gamepad_status->button10 = sdlgamepad.IsPressed(GAMEPAD_BUTTON_START); // START
-			ff7_externals.gamepad_status->button11 = sdlgamepad.IsPressed(GAMEPAD_BUTTON_LEFT_THUMB); // L3
-			ff7_externals.gamepad_status->button12 = sdlgamepad.IsPressed(GAMEPAD_BUTTON_RIGHT_THUMB); // R3
-			ff7_externals.gamepad_status->button13 = sdlgamepad.IsPressed(GAMEPAD_BUTTON_GUIDE); // PS Button
+			ff7_externals.gamepad_status->button9 = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_BACK); // SELECT
+			ff7_externals.gamepad_status->button10 = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_START); // START
+			ff7_externals.gamepad_status->button11 = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_LEFT_STICK); // L3
+			ff7_externals.gamepad_status->button12 = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_RIGHT_STICK); // R3
+			ff7_externals.gamepad_status->button13 = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_GUIDE); // PS Button
 
 			// Update the player intent based on the analogue movement
 			if (enable_auto_run)

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -409,23 +409,23 @@ LPDIJOYSTATE2 ff8_update_gamepad_status()
 		if (!sdlgamepad.Refresh() || !gamehacks.canInputBeProcessed())
 			return ff8_externals.dinput_gamepad_state;
 
-		if ((sdlgamepad.leftStickY > 0.5f) || sdlgamepad.IsPressed(GAMEPAD_BUTTON_DPAD_UP))
+		if ((sdlgamepad.leftStickY > 0.5f) || sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_DPAD_UP))
 		{
 			ff8_externals.dinput_gamepad_state->lY = 0xFFFFFFFFFFFFFFFF;
 			ff8_externals.dinput_gamepad_state->rgdwPOV[0] = 0;
 		}
-		else if ((sdlgamepad.leftStickY < -0.5f) || sdlgamepad.IsPressed(GAMEPAD_BUTTON_DPAD_DOWN))
+		else if ((sdlgamepad.leftStickY < -0.5f) || sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_DPAD_DOWN))
 		{
 			ff8_externals.dinput_gamepad_state->lY = -0xFFFFFFFFFFFFFFFF;
 			ff8_externals.dinput_gamepad_state->rgdwPOV[0] = 18000;
 		}
 
-		if ((sdlgamepad.leftStickX < -0.5f) || sdlgamepad.IsPressed(GAMEPAD_BUTTON_DPAD_LEFT))
+		if ((sdlgamepad.leftStickX < -0.5f) || sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_DPAD_LEFT))
 		{
 			ff8_externals.dinput_gamepad_state->lX = 0xFFFFFFFFFFFFFFFF;
 			ff8_externals.dinput_gamepad_state->rgdwPOV[0] = 27000;
 		}
-		else if ((sdlgamepad.leftStickX > 0.5f) || sdlgamepad.IsPressed(GAMEPAD_BUTTON_DPAD_RIGHT))
+		else if ((sdlgamepad.leftStickX > 0.5f) || sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_DPAD_RIGHT))
 		{
 			ff8_externals.dinput_gamepad_state->lX = -0xFFFFFFFFFFFFFFFF;
 			ff8_externals.dinput_gamepad_state->rgdwPOV[0] = 9000;
@@ -453,19 +453,19 @@ LPDIJOYSTATE2 ff8_update_gamepad_status()
 		ff8_externals.dinput_gamepad_state->rgdwPOV[1] = -1;
 		ff8_externals.dinput_gamepad_state->rgdwPOV[2] = -1;
 		ff8_externals.dinput_gamepad_state->rgdwPOV[3] = -1;
-		ff8_externals.dinput_gamepad_state->rgbButtons[0] = sdlgamepad.IsPressed(steam_stock_launcher ? GAMEPAD_BUTTON_A : GAMEPAD_BUTTON_X) ? 0x80 : 0; // Cross (Steam)/Square
-		ff8_externals.dinput_gamepad_state->rgbButtons[1] = sdlgamepad.IsPressed(steam_stock_launcher ? GAMEPAD_BUTTON_B : GAMEPAD_BUTTON_A) ? 0x80 : 0; // Circle (Steam)/Cross
-		ff8_externals.dinput_gamepad_state->rgbButtons[2] = sdlgamepad.IsPressed(steam_stock_launcher ? GAMEPAD_BUTTON_X : GAMEPAD_BUTTON_B) ? 0x80 : 0; // Square (Steam)/Circle
-		ff8_externals.dinput_gamepad_state->rgbButtons[3] = sdlgamepad.IsPressed(GAMEPAD_BUTTON_Y) ? 0x80 : 0; // Triangle
-		ff8_externals.dinput_gamepad_state->rgbButtons[4] = sdlgamepad.IsPressed(GAMEPAD_BUTTON_LEFT_SHOULDER) ? 0x80 : 0; // L1
-		ff8_externals.dinput_gamepad_state->rgbButtons[5] = sdlgamepad.IsPressed(GAMEPAD_BUTTON_RIGHT_SHOULDER) ? 0x80 : 0; // R1
-		ff8_externals.dinput_gamepad_state->rgbButtons[6] = (steam_stock_launcher ? sdlgamepad.IsPressed(GAMEPAD_BUTTON_BACK) : sdlgamepad.leftTrigger > 0.85f) ? 0x80 : 0; // SELECT (Steam)/L2
-		ff8_externals.dinput_gamepad_state->rgbButtons[7] = (steam_stock_launcher ? sdlgamepad.IsPressed(GAMEPAD_BUTTON_START) : sdlgamepad.rightTrigger > 0.85f) ? 0x80 : 0; // START (Steam)/R2
-		ff8_externals.dinput_gamepad_state->rgbButtons[8] = (steam_stock_launcher ? sdlgamepad.leftTrigger > 0.85f : sdlgamepad.IsPressed(GAMEPAD_BUTTON_BACK)) ? 0x80 : 0; // L2 (Steam)/SELECT
-		ff8_externals.dinput_gamepad_state->rgbButtons[9] = (steam_stock_launcher ? sdlgamepad.rightTrigger > 0.85f : sdlgamepad.IsPressed(GAMEPAD_BUTTON_START)) ? 0x80 : 0; // R2 (Steam)/START
-		ff8_externals.dinput_gamepad_state->rgbButtons[10] = sdlgamepad.IsPressed(GAMEPAD_BUTTON_LEFT_THUMB) ? 0x80 : 0; // L3
-		ff8_externals.dinput_gamepad_state->rgbButtons[11] = sdlgamepad.IsPressed(GAMEPAD_BUTTON_RIGHT_THUMB) ? 0x80 : 0; // R3
-		ff8_externals.dinput_gamepad_state->rgbButtons[12] = sdlgamepad.IsPressed(GAMEPAD_BUTTON_GUIDE) ? 0x80 : 0; // PS Button
+		ff8_externals.dinput_gamepad_state->rgbButtons[0] = sdlgamepad.IsPressed(steam_stock_launcher ? SDL_GAMEPAD_BUTTON_SOUTH : SDL_GAMEPAD_BUTTON_WEST) ? 0x80 : 0; // Cross (Steam)/Square
+		ff8_externals.dinput_gamepad_state->rgbButtons[1] = sdlgamepad.IsPressed(steam_stock_launcher ? SDL_GAMEPAD_BUTTON_EAST : SDL_GAMEPAD_BUTTON_SOUTH) ? 0x80 : 0; // Circle (Steam)/Cross
+		ff8_externals.dinput_gamepad_state->rgbButtons[2] = sdlgamepad.IsPressed(steam_stock_launcher ? SDL_GAMEPAD_BUTTON_WEST : SDL_GAMEPAD_BUTTON_EAST) ? 0x80 : 0; // Square (Steam)/Circle
+		ff8_externals.dinput_gamepad_state->rgbButtons[3] = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_NORTH) ? 0x80 : 0; // Triangle
+		ff8_externals.dinput_gamepad_state->rgbButtons[4] = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_LEFT_SHOULDER) ? 0x80 : 0; // L1
+		ff8_externals.dinput_gamepad_state->rgbButtons[5] = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER) ? 0x80 : 0; // R1
+		ff8_externals.dinput_gamepad_state->rgbButtons[6] = (steam_stock_launcher ? sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_BACK) : sdlgamepad.leftTrigger > 0.85f) ? 0x80 : 0; // SELECT (Steam)/L2
+		ff8_externals.dinput_gamepad_state->rgbButtons[7] = (steam_stock_launcher ? sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_START) : sdlgamepad.rightTrigger > 0.85f) ? 0x80 : 0; // START (Steam)/R2
+		ff8_externals.dinput_gamepad_state->rgbButtons[8] = (steam_stock_launcher ? sdlgamepad.leftTrigger > 0.85f : sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_BACK)) ? 0x80 : 0; // L2 (Steam)/SELECT
+		ff8_externals.dinput_gamepad_state->rgbButtons[9] = (steam_stock_launcher ? sdlgamepad.rightTrigger > 0.85f : sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_START)) ? 0x80 : 0; // R2 (Steam)/START
+		ff8_externals.dinput_gamepad_state->rgbButtons[10] = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_LEFT_STICK) ? 0x80 : 0; // L3
+		ff8_externals.dinput_gamepad_state->rgbButtons[11] = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_RIGHT_STICK) ? 0x80 : 0; // R3
+		ff8_externals.dinput_gamepad_state->rgbButtons[12] = sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_GUIDE) ? 0x80 : 0; // PS Button
 	}
 	else if (xinput_connected)
 	{

--- a/src/gamehacks.cpp
+++ b/src/gamehacks.cpp
@@ -214,7 +214,7 @@ void GameHacks::processGamepadInput()
 				return;
 			}
 
-			if (sdlgamepad.IsPressed(GAMEPAD_BUTTON_LEFT_THUMB)) // L3
+			if (sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_LEFT_STICK)) // L3
 			{
 				isGamepadShortcutMode = !isGamepadShortcutMode;
 				if(isGamepadShortcutMode) show_popup_msg(TEXTCOLOR_LIGHT_BLUE, "Waiting for shortcut input..");
@@ -226,18 +226,18 @@ void GameHacks::processGamepadInput()
 
 			// Soft reset on START+SELECT
 			if (
-				sdlgamepad.IsPressed(GAMEPAD_BUTTON_BACK) &&
-				sdlgamepad.IsPressed(GAMEPAD_BUTTON_START)
+				sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_BACK) &&
+				sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_START)
 				)
 				softReset();
 			// Increase in-game speed on R1
 			else if (
-				sdlgamepad.IsPressed(GAMEPAD_BUTTON_RIGHT_SHOULDER)
+				sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER)
 				)
 				increaseSpeedhack();
 			// Decrease in-game speed on L1
 			else if (
-				sdlgamepad.IsPressed(GAMEPAD_BUTTON_LEFT_SHOULDER)
+				sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_LEFT_SHOULDER)
 				)
 				decreaseSpeedhack();
 			// Toggle Speedhack on L2/R2
@@ -248,17 +248,17 @@ void GameHacks::processGamepadInput()
 				toggleSpeedhack();
 			// Toggle battle mode on Circle
 			else if (
-				sdlgamepad.IsPressed(GAMEPAD_BUTTON_B)
+				sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_EAST)
 				)
 				toggleBattleMode();
 			// Toggle auto attack mode on Triangle
 			else if (
-				sdlgamepad.IsPressed(GAMEPAD_BUTTON_Y)
+				sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_NORTH)
 				)
 				toggleAutoAttackMode();
 			// Skip Movies on Square
 			else if (
-				sdlgamepad.IsPressed(GAMEPAD_BUTTON_X)
+				sdlgamepad.IsPressed(SDL_GAMEPAD_BUTTON_WEST)
 				)
 				skipMovies();
 		}

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -60,7 +60,7 @@ bool SDLGamepad::Gamepad_Init()
 
     SDL_SetGamepadEventsEnabled(true);
 
-    GamepadMappingLoaded = SDL_AddGamepadMappingsFromFile("gamecontrollerdb.txt");
+    int GamepadMappingLoaded = SDL_AddGamepadMappingsFromFile("gamecontrollerdb.txt");
     sdlInitialized = true;
 
     if (trace_all || trace_gamepad)
@@ -77,11 +77,6 @@ const char* SDLGamepad::GetName() const
     if (!sdlgamepad) return "";
     const char *name = SDL_GetGamepadName(sdlgamepad);
     return name ? name : "";
-}
-
-int SDLGamepad::GetLoadedMappingCount() const
-{
-    return GamepadMappingLoaded;
 }
 
 void SDLGamepad::GamepadEvents()
@@ -172,18 +167,12 @@ void SDLGamepad::closeGamepad()
 
     sdlInstanceId = -1;
 
-    ZeroMemory(&state, sizeof(state));
     leftStickX = leftStickY = rightStickX = rightStickY = 0.0f;
     leftTrigger = rightTrigger = 0.0f;
 }
 
 bool SDLGamepad::Refresh()
 {
-    if (!Gamepad_Init())
-        return false;
-
-    GamepadEvents();
-
     if (!sdlgamepad)
     {
         if (!openGamepad())
@@ -215,29 +204,6 @@ bool SDLGamepad::Refresh()
     leftTrigger  = applyTriggerDeadzone(SDL_clamp((float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_LEFT_TRIGGER)  / 32767.0f, 0.0f, 1.0f), (float)left_analog_trigger_deadzone);
     rightTrigger = applyTriggerDeadzone(SDL_clamp((float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER) / 32767.0f, 0.0f, 1.0f), (float)right_analog_trigger_deadzone);
 
-    static const WORD buttonMasks[] = {
-        GAMEPAD_BUTTON_DPAD_UP, GAMEPAD_BUTTON_DPAD_DOWN, GAMEPAD_BUTTON_DPAD_LEFT,  GAMEPAD_BUTTON_DPAD_RIGHT,
-        GAMEPAD_BUTTON_START,   GAMEPAD_BUTTON_BACK,      GAMEPAD_BUTTON_LEFT_THUMB, GAMEPAD_BUTTON_RIGHT_THUMB,
-        GAMEPAD_BUTTON_LEFT_SHOULDER, GAMEPAD_BUTTON_RIGHT_SHOULDER,
-        GAMEPAD_BUTTON_A, GAMEPAD_BUTTON_B, GAMEPAD_BUTTON_X, GAMEPAD_BUTTON_Y
-    };
-    static const SDL_GamepadButton sdlButtons[] = {
-        SDL_GAMEPAD_BUTTON_DPAD_UP,    SDL_GAMEPAD_BUTTON_DPAD_DOWN,  SDL_GAMEPAD_BUTTON_DPAD_LEFT,  SDL_GAMEPAD_BUTTON_DPAD_RIGHT,
-        SDL_GAMEPAD_BUTTON_START,      SDL_GAMEPAD_BUTTON_BACK,       SDL_GAMEPAD_BUTTON_LEFT_STICK, SDL_GAMEPAD_BUTTON_RIGHT_STICK,
-        SDL_GAMEPAD_BUTTON_LEFT_SHOULDER, SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER,
-        SDL_GAMEPAD_BUTTON_SOUTH, SDL_GAMEPAD_BUTTON_EAST, SDL_GAMEPAD_BUTTON_WEST, SDL_GAMEPAD_BUTTON_NORTH
-    };
-    WORD buttons = 0;
-    for (int i = 0; i < (int)(sizeof(buttonMasks) / sizeof(buttonMasks[0])); i++)
-    {
-        if (SDL_GetGamepadButton(sdlgamepad, sdlButtons[i]))
-            buttons |= buttonMasks[i];
-    }
-    if (SDL_GetGamepadButton(sdlgamepad, SDL_GAMEPAD_BUTTON_GUIDE))
-        buttons |= GAMEPAD_BUTTON_GUIDE;
-
-    state.Gamepad.wButtons = buttons;
-
     return true;
 }
 
@@ -264,28 +230,29 @@ bool SDLGamepad::Vibrate(WORD wLeftMotorSpeed, WORD wRightMotorSpeed)
     return true;
 }
 
-bool SDLGamepad::IsPressed(WORD button) const
+bool SDLGamepad::IsPressed(SDL_GamepadButton button) const
 {
-    return (state.Gamepad.wButtons & button) != 0;
+    if (!sdlgamepad) return false;
+    return SDL_GetGamepadButton(sdlgamepad, button);
 }
 
 bool SDLGamepad::IsIdle() const
 {
-    return !(leftStickY > 0.5f  || IsPressed(GAMEPAD_BUTTON_DPAD_UP))    &&
-           !(leftStickY < -0.5f || IsPressed(GAMEPAD_BUTTON_DPAD_DOWN))  &&
-           !(leftStickX < -0.5f || IsPressed(GAMEPAD_BUTTON_DPAD_LEFT))  &&
-           !(leftStickX > 0.5f  || IsPressed(GAMEPAD_BUTTON_DPAD_RIGHT)) &&
-           !IsPressed(GAMEPAD_BUTTON_X)              &&
-           !IsPressed(GAMEPAD_BUTTON_A)              &&
-           !IsPressed(GAMEPAD_BUTTON_B)              &&
-           !IsPressed(GAMEPAD_BUTTON_Y)              &&
-           !IsPressed(GAMEPAD_BUTTON_LEFT_SHOULDER)  &&
-           !IsPressed(GAMEPAD_BUTTON_RIGHT_SHOULDER) &&
-           !(leftTrigger  > 0.85f)                  &&
-           !(rightTrigger > 0.85f)                  &&
-           !IsPressed(GAMEPAD_BUTTON_BACK)           &&
-           !IsPressed(GAMEPAD_BUTTON_START)          &&
-           !IsPressed(GAMEPAD_BUTTON_LEFT_THUMB)     &&
-           !IsPressed(GAMEPAD_BUTTON_RIGHT_THUMB)    &&
-           !IsPressed(GAMEPAD_BUTTON_GUIDE);
+    return !(leftStickY > 0.5f  || IsPressed(SDL_GAMEPAD_BUTTON_DPAD_UP))    &&
+           !(leftStickY < -0.5f || IsPressed(SDL_GAMEPAD_BUTTON_DPAD_DOWN))  &&
+           !(leftStickX < -0.5f || IsPressed(SDL_GAMEPAD_BUTTON_DPAD_LEFT))  &&
+           !(leftStickX > 0.5f  || IsPressed(SDL_GAMEPAD_BUTTON_DPAD_RIGHT)) &&
+           !IsPressed(SDL_GAMEPAD_BUTTON_WEST)              &&
+           !IsPressed(SDL_GAMEPAD_BUTTON_SOUTH)             &&
+           !IsPressed(SDL_GAMEPAD_BUTTON_EAST)              &&
+           !IsPressed(SDL_GAMEPAD_BUTTON_NORTH)             &&
+           !IsPressed(SDL_GAMEPAD_BUTTON_LEFT_SHOULDER)     &&
+           !IsPressed(SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER)    &&
+           !(leftTrigger  > 0.85f)                         &&
+           !(rightTrigger > 0.85f)                         &&
+           !IsPressed(SDL_GAMEPAD_BUTTON_BACK)              &&
+           !IsPressed(SDL_GAMEPAD_BUTTON_START)             &&
+           !IsPressed(SDL_GAMEPAD_BUTTON_LEFT_STICK)        &&
+           !IsPressed(SDL_GAMEPAD_BUTTON_RIGHT_STICK)       &&
+           !IsPressed(SDL_GAMEPAD_BUTTON_GUIDE);
 }

--- a/src/sdl_gamepad.h
+++ b/src/sdl_gamepad.h
@@ -27,41 +27,12 @@
 // Kudos to https://katyscode.wordpress.com/2013/08/30/xinput-tutorial-part-1-adding-gamepad-support-to-your-windows-game/
 // for the foundation of FFNx's original XInput implementation
 
-#define GAMEPAD_BUTTON_DPAD_UP        0x0001
-#define GAMEPAD_BUTTON_DPAD_DOWN      0x0002
-#define GAMEPAD_BUTTON_DPAD_LEFT      0x0004
-#define GAMEPAD_BUTTON_DPAD_RIGHT     0x0008
-#define GAMEPAD_BUTTON_START          0x0010
-#define GAMEPAD_BUTTON_BACK           0x0020
-#define GAMEPAD_BUTTON_LEFT_THUMB     0x0040
-#define GAMEPAD_BUTTON_RIGHT_THUMB    0x0080
-#define GAMEPAD_BUTTON_LEFT_SHOULDER  0x0100
-#define GAMEPAD_BUTTON_RIGHT_SHOULDER 0x0200
-#define GAMEPAD_BUTTON_GUIDE          0x0400
-#define GAMEPAD_BUTTON_A              0x1000
-#define GAMEPAD_BUTTON_B              0x2000
-#define GAMEPAD_BUTTON_X              0x4000
-#define GAMEPAD_BUTTON_Y              0x8000
-
-typedef struct GamepadInput
-{
-    WORD wButtons;
-} GamepadInput;
-
-typedef struct GamepadState
-{
-    GamepadInput Gamepad;
-} GamepadState;
-
 class SDLGamepad
 {
 private:
-    GamepadState state;
-
     SDL_Gamepad *sdlgamepad = nullptr;
     SDL_JoystickID sdlInstanceId = -1;
     bool sdlInitialized = false;
-    int GamepadMappingLoaded = 0;
 
     void GamepadEvents();
     bool openGamepad();
@@ -71,21 +42,20 @@ public:
     bool Gamepad_Init();
     ~SDLGamepad();
 
-    float leftStickX;
-    float leftStickY;
-    float rightStickX;
-    float rightStickY;
-    float leftTrigger;
-    float rightTrigger;
+    float leftStickX = 0.0f;
+    float leftStickY = 0.0f;
+    float rightStickX = 0.0f;
+    float rightStickY = 0.0f;
+    float leftTrigger = 0.0f;
+    float rightTrigger = 0.0f;
 
     int  GetPort() const;
     const char* GetName() const;
-    int  GetLoadedMappingCount() const;
     bool CheckConnection();
     bool HasRumble() const;
     bool Refresh();
     bool Vibrate(WORD wLeftMotorSpeed, WORD wRightMotorSpeed);
-    bool IsPressed(WORD) const;
+    bool IsPressed(SDL_GamepadButton) const;
     bool IsIdle() const;
 };
 


### PR DESCRIPTION
## Summary

To prepare for a future 7th Heaven / Junction VIII update: the SDL Gamepad Bindings went through a refactor to better mirror XInput counterpart. 

the notes portion of `FFNx.toml`'s `use_sdl_gamepad` has been updated to better reflect a known bug with 7th Heaven launcher accidentally breaking the controls layout for some controllers. 

### Motivation

As I was trying to fix a bug when using a 8BitDo Controller type...then realizing that 7th Heaven launcher still uses DirectInput setup under the hood (the paddle buttons and misc buttons works on my 8BitDo Ultimate 2 Wireless variant, they're just mapped incorrectly!). I decided to refactor the SDL Gameapd Buttons to mirror XInput's setup instead!

That should enable additional buttons down in the line, while preparing for the next 7th Heaven/Junction VIII update that adds launcher-based controls mapping support.

### ACKs

- [x] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [x] I did test my code on FF8
