### PR TITLE
Common: Improve SDL Event Polling

### DIFF
--- a/src/ff7/misc.cpp
+++ b/src/ff7/misc.cpp
@@ -387,8 +387,8 @@ int ff7_get_gamepad()
 	}
 	else if (use_sdl_gamepad)
 	{
-		sdlgamepad.Refresh();
-		return TRUE;
+		if (sdlgamepad.Refresh())
+			return TRUE;
 	}
 	else if (xinput_connected)
 	{

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -343,8 +343,8 @@ int ff8_init_gamepad()
 {
 	if (use_sdl_gamepad)
 	{
-		sdlgamepad.Refresh();
-		return TRUE;
+		if (sdlgamepad.Refresh())
+			return TRUE;
 	}
 	else if (xinput_connected)
 	{

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -44,7 +44,7 @@ int SDLGamepad::GetPort() const
 }
 
 
-bool SDLGamepad::Gamepad_Init()
+bool SDLGamepad::init()
 {
     if (sdlInitialized)
         return true;
@@ -57,8 +57,6 @@ bool SDLGamepad::Gamepad_Init()
         ffnx_error("SDL gamepad: failed to initialize subsystem\n");
         return false;
     }
-
-    SDL_SetGamepadEventsEnabled(true);
 
     int GamepadMappingLoaded = SDL_AddGamepadMappingsFromFile("gamecontrollerdb.txt");
     sdlInitialized = true;
@@ -81,47 +79,91 @@ const char* SDLGamepad::GetName() const
 
 void SDLGamepad::GamepadEvents()
 {
-    SDL_PumpEvents();
-
-    SDL_Event events[8];
-    int count;
-    while ((count = SDL_PeepEvents(events, SDL_arraysize(events), SDL_GETEVENT,
-                                   SDL_EVENT_GAMEPAD_AXIS_MOTION,
-                                   SDL_EVENT_GAMEPAD_STEAM_HANDLE_UPDATED)) > 0)
+    SDL_Event event;
+    while (SDL_PollEvent(&event))
     {
-        for (int i = 0; i < count; ++i)
+        switch (event.type)
         {
-            const SDL_Event &event = events[i];
-            switch (event.type)
-            {
-                case SDL_EVENT_GAMEPAD_ADDED:
-                    if (!sdlgamepad)
+            case SDL_EVENT_GAMEPAD_AXIS_MOTION:
+                if (sdlgamepad && event.gaxis.which == sdlInstanceId)
+                {
+                    float leftDeadzone  = (float)left_analog_stick_deadzone;
+                    float rightDeadzone = (float)right_analog_stick_deadzone;
+
+                    auto normAxis = [](Sint16 v) -> float { return SDL_clamp((float)v / SDL_JOYSTICK_AXIS_MAX, -1.0f, 1.0f); };
+                    auto applyDeadzone = [](float v, float dz) -> float {
+                        if (fabsf(v) < dz) return 0.0f;
+                        float sign = (v < 0.0f) ? -1.0f : 1.0f;
+                        return ((fabsf(v) - dz) / (1.0f - dz)) * sign;
+                    };
+                    auto applyTriggerDeadzone = [](float v, float dz) -> float {
+                        if (v <= dz) return 0.0f;
+                        return (v - dz) / (1.0f - dz);
+                    };
+
+                    switch ((SDL_GamepadAxis)event.gaxis.axis)
                     {
-                        SDL_JoystickID id = event.gdevice.which;
-                        SDL_Gamepad *gp = SDL_OpenGamepad(id);
-                        if (gp)
-                        {
-                            sdlgamepad = gp;
-                            sdlInstanceId = id;
-                        }
+                        case SDL_GAMEPAD_AXIS_LEFTX:
+                            leftStickX =  applyDeadzone(normAxis(event.gaxis.value), leftDeadzone);
+                            break;
+                        case SDL_GAMEPAD_AXIS_LEFTY:
+                            leftStickY = -applyDeadzone(normAxis(event.gaxis.value), leftDeadzone);
+                            break;
+                        case SDL_GAMEPAD_AXIS_RIGHTX:
+                            rightStickX =  applyDeadzone(normAxis(event.gaxis.value), rightDeadzone);
+                            break;
+                        case SDL_GAMEPAD_AXIS_RIGHTY:
+                            rightStickY = -applyDeadzone(normAxis(event.gaxis.value), rightDeadzone);
+                            break;
+                        case SDL_GAMEPAD_AXIS_LEFT_TRIGGER:
+                            leftTrigger  = applyTriggerDeadzone(SDL_clamp((float)event.gaxis.value / SDL_JOYSTICK_AXIS_MAX, 0.0f, 1.0f), (float)left_analog_trigger_deadzone);
+                            break;
+                        case SDL_GAMEPAD_AXIS_RIGHT_TRIGGER:
+                            rightTrigger = applyTriggerDeadzone(SDL_clamp((float)event.gaxis.value / SDL_JOYSTICK_AXIS_MAX, 0.0f, 1.0f), (float)right_analog_trigger_deadzone);
+                            break;
+                        default:
+                            break;
                     }
-                    break;
+                }
+                break;
 
-                case SDL_EVENT_GAMEPAD_REMOVED:
-                    if (sdlgamepad && event.gdevice.which == sdlInstanceId)
-                        closeGamepad();
-                    break;
+            case SDL_EVENT_GAMEPAD_ADDED:
+                if (!sdlgamepad)
+                {
+                    SDL_JoystickID id = event.gdevice.which;
+                    SDL_Gamepad *gp = SDL_OpenGamepad(id);
+                    if (gp)
+                    {
+                        sdlgamepad = gp;
+                        sdlInstanceId = id;
+                    }
+                }
+                break;
 
-                default:
-                    break;
-            }
+            case SDL_EVENT_GAMEPAD_REMOVED:
+                if (sdlgamepad && event.gdevice.which == sdlInstanceId)
+                    closeGamepad();
+                break;
+
+            case SDL_EVENT_GAMEPAD_REMAPPED:
+                if (sdlgamepad && event.gdevice.which == sdlInstanceId)
+                {
+                    closeGamepad();
+                    openGamepad();
+                    if (trace_all || trace_gamepad)
+                        ffnx_trace("SDL gamepad: mapping remapped, reopened\n");
+                }
+                break;
+
+            default:
+                break;
         }
     }
 }
 
 bool SDLGamepad::openGamepad()
 {
-    if (!Gamepad_Init())
+    if (!init())
         return false;
 
     int count = 0;
@@ -149,7 +191,7 @@ bool SDLGamepad::openGamepad()
 
 bool SDLGamepad::CheckConnection()
 {
-    if (!Gamepad_Init())
+    if (!init())
         return false;
 
     GamepadEvents();
@@ -179,30 +221,7 @@ bool SDLGamepad::Refresh()
             return false;
     }
 
-    float leftDeadzone  = (float)left_analog_stick_deadzone;
-    float rightDeadzone = (float)right_analog_stick_deadzone;
-
-    auto normAxis = [](Sint16 v) -> float { return fmaxf(-1.0f, (float)v / 32767.0f); };
-    auto applyDeadzone = [](float v, float dz) -> float
-    {
-        if (fabsf(v) < dz) return 0.0f;
-        float sign = (v < 0.0f) ? -1.0f : 1.0f;
-        return ((fabsf(v) - dz) / (1.0f - dz)) * sign;
-    };
-
-    leftStickX  =  applyDeadzone(normAxis(SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_LEFTX)),  leftDeadzone);
-    leftStickY  = -applyDeadzone(normAxis(SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_LEFTY)),  leftDeadzone);
-    rightStickX =  applyDeadzone(normAxis(SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_RIGHTX)), rightDeadzone);
-    rightStickY = -applyDeadzone(normAxis(SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_RIGHTY)), rightDeadzone);
-
-    auto applyTriggerDeadzone = [](float v, float dz) -> float
-    {
-        if (v <= dz) return 0.0f;
-        return (v - dz) / (1.0f - dz);
-    };
-
-    leftTrigger  = applyTriggerDeadzone(SDL_clamp((float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_LEFT_TRIGGER)  / 32767.0f, 0.0f, 1.0f), (float)left_analog_trigger_deadzone);
-    rightTrigger = applyTriggerDeadzone(SDL_clamp((float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER) / 32767.0f, 0.0f, 1.0f), (float)right_analog_trigger_deadzone);
+    GamepadEvents();
 
     return true;
 }
@@ -217,14 +236,10 @@ bool SDLGamepad::HasRumble() const
 
 bool SDLGamepad::Vibrate(WORD wLeftMotorSpeed, WORD wRightMotorSpeed)
 {
-    if (!Gamepad_Init())
-        return false;
-
     if (!sdlgamepad && !openGamepad())
         return false;
 
-    Uint32 duration = (wLeftMotorSpeed > 0 || wRightMotorSpeed > 0) ? SDL_HAPTIC_INFINITY : 0;
-    if (!SDL_RumbleGamepad(sdlgamepad, wLeftMotorSpeed, wRightMotorSpeed, duration))
+    if (!SDL_RumbleGamepad(sdlgamepad, wLeftMotorSpeed, wRightMotorSpeed, SDL_HAPTIC_INFINITY))
         return false;
 
     return true;

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -77,6 +77,21 @@ const char* SDLGamepad::GetName() const
     return name ? name : "";
 }
 
+static float applyDeadzone(float value, float deadzone)
+{
+    float norm = fmaxf(-1.0f, value / SDL_JOYSTICK_AXIS_MAX);
+    if (fabsf(norm) < deadzone) return 0.0f;
+    float sign = (norm < 0.0f) ? -1.0f : 1.0f;
+    return ((fabsf(norm) - deadzone) / (1.0f - deadzone)) * sign;
+}
+
+static float applyTriggerDeadzone(float value, float deadzone)
+{
+    float raw = SDL_clamp(value / SDL_JOYSTICK_AXIS_MAX, 0.0f, 1.0f);
+    if (raw <= deadzone) return 0.0f;
+    return (raw - deadzone) / (1.0f - deadzone);
+}
+
 void SDLGamepad::GamepadEvents()
 {
     SDL_Event event;
@@ -93,41 +108,23 @@ void SDLGamepad::GamepadEvents()
                     switch ((SDL_GamepadAxis)event.gaxis.axis)
                     {
                         case SDL_GAMEPAD_AXIS_LEFTX:
+                            leftStickX = applyDeadzone((float)event.gaxis.value, leftDz);
+                            break;
                         case SDL_GAMEPAD_AXIS_LEFTY:
-                        {
-                            float normLX = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_LEFTX) / SDL_JOYSTICK_AXIS_MAX);
-                            float normLY = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_LEFTY) / SDL_JOYSTICK_AXIS_MAX);
-                            leftStickX = (fabsf(normLX) < leftDz ? 0.0f : (fabsf(normLX) - leftDz) * (normLX / fabsf(normLX)));
-                            leftStickY = (fabsf(normLY) < leftDz ? 0.0f : (fabsf(normLY) - leftDz) * (normLY / fabsf(normLY)));
-                            if (leftDz > 0.0f) { leftStickX *= 1.0f / (1.0f - leftDz); leftStickY *= 1.0f / (1.0f - leftDz); }
-                            leftStickY = -leftStickY;
+                            leftStickY = -applyDeadzone((float)event.gaxis.value, leftDz);
                             break;
-                        }
                         case SDL_GAMEPAD_AXIS_RIGHTX:
+                            rightStickX = applyDeadzone((float)event.gaxis.value, rightDz);
+                            break;
                         case SDL_GAMEPAD_AXIS_RIGHTY:
-                        {
-                            float normRX = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_RIGHTX) / SDL_JOYSTICK_AXIS_MAX);
-                            float normRY = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_RIGHTY) / SDL_JOYSTICK_AXIS_MAX);
-                            rightStickX = (fabsf(normRX) < rightDz ? 0.0f : (fabsf(normRX) - rightDz) * (normRX / fabsf(normRX)));
-                            rightStickY = (fabsf(normRY) < rightDz ? 0.0f : (fabsf(normRY) - rightDz) * (normRY / fabsf(normRY)));
-                            if (rightDz > 0.0f) { rightStickX *= 1.0f / (1.0f - rightDz); rightStickY *= 1.0f / (1.0f - rightDz); }
-                            rightStickY = -rightStickY;
+                            rightStickY = -applyDeadzone((float)event.gaxis.value, rightDz);
                             break;
-                        }
                         case SDL_GAMEPAD_AXIS_LEFT_TRIGGER:
-                        {
-                            float raw = SDL_clamp((float)event.gaxis.value / SDL_JOYSTICK_AXIS_MAX, 0.0f, 1.0f);
-                            float dz  = (float)left_analog_trigger_deadzone;
-                            leftTrigger = (raw <= dz) ? 0.0f : (raw - dz) / (1.0f - dz);
+                            leftTrigger = applyTriggerDeadzone((float)event.gaxis.value, (float)left_analog_trigger_deadzone);
                             break;
-                        }
                         case SDL_GAMEPAD_AXIS_RIGHT_TRIGGER:
-                        {
-                            float raw = SDL_clamp((float)event.gaxis.value / SDL_JOYSTICK_AXIS_MAX, 0.0f, 1.0f);
-                            float dz  = (float)right_analog_trigger_deadzone;
-                            rightTrigger = (raw <= dz) ? 0.0f : (raw - dz) / (1.0f - dz);
+                            rightTrigger = applyTriggerDeadzone((float)event.gaxis.value, (float)right_analog_trigger_deadzone);
                             break;
-                        }
                         default:
                             break;
                     }

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -40,7 +40,7 @@ SDLGamepad::~SDLGamepad()
 
 int SDLGamepad::GetPort() const
 {
-    return sdlgamepad ? 1 : 0;
+    return handle ? 1 : 0;
 }
 
 
@@ -72,8 +72,8 @@ bool SDLGamepad::init()
 
 const char* SDLGamepad::GetName() const
 {
-    if (!sdlgamepad) return "";
-    const char *name = SDL_GetGamepadName(sdlgamepad);
+    if (!handle) return "";
+    const char *name = SDL_GetGamepadName(handle);
     return name ? name : "";
 }
 
@@ -85,42 +85,49 @@ void SDLGamepad::GamepadEvents()
         switch (event.type)
         {
             case SDL_EVENT_GAMEPAD_AXIS_MOTION:
-                if (sdlgamepad && event.gaxis.which == sdlInstanceId)
+                if (handle && event.gaxis.which == sdlInstanceId)
                 {
-                    float leftDeadzone  = (float)left_analog_stick_deadzone;
-                    float rightDeadzone = (float)right_analog_stick_deadzone;
-
-                    auto normAxis = [](Sint16 v) -> float { return SDL_clamp((float)v / SDL_JOYSTICK_AXIS_MAX, -1.0f, 1.0f); };
-                    auto applyDeadzone = [](float v, float dz) -> float {
-                        if (fabsf(v) < dz) return 0.0f;
-                        float sign = (v < 0.0f) ? -1.0f : 1.0f;
-                        return ((fabsf(v) - dz) / (1.0f - dz)) * sign;
-                    };
-                    auto applyTriggerDeadzone = [](float v, float dz) -> float {
-                        if (v <= dz) return 0.0f;
-                        return (v - dz) / (1.0f - dz);
-                    };
+                    float leftDz  = (float)left_analog_stick_deadzone;
+                    float rightDz = (float)right_analog_stick_deadzone;
 
                     switch ((SDL_GamepadAxis)event.gaxis.axis)
                     {
                         case SDL_GAMEPAD_AXIS_LEFTX:
-                            leftStickX =  applyDeadzone(normAxis(event.gaxis.value), leftDeadzone);
-                            break;
                         case SDL_GAMEPAD_AXIS_LEFTY:
-                            leftStickY = -applyDeadzone(normAxis(event.gaxis.value), leftDeadzone);
+                        {
+                            float normLX = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(handle, SDL_GAMEPAD_AXIS_LEFTX) / SDL_JOYSTICK_AXIS_MAX);
+                            float normLY = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(handle, SDL_GAMEPAD_AXIS_LEFTY) / SDL_JOYSTICK_AXIS_MAX);
+                            leftStickX = (fabsf(normLX) < leftDz ? 0.0f : (fabsf(normLX) - leftDz) * (normLX / fabsf(normLX)));
+                            leftStickY = (fabsf(normLY) < leftDz ? 0.0f : (fabsf(normLY) - leftDz) * (normLY / fabsf(normLY)));
+                            if (leftDz > 0.0f) { leftStickX *= 1.0f / (1.0f - leftDz); leftStickY *= 1.0f / (1.0f - leftDz); }
+                            leftStickY = -leftStickY;
                             break;
+                        }
                         case SDL_GAMEPAD_AXIS_RIGHTX:
-                            rightStickX =  applyDeadzone(normAxis(event.gaxis.value), rightDeadzone);
-                            break;
                         case SDL_GAMEPAD_AXIS_RIGHTY:
-                            rightStickY = -applyDeadzone(normAxis(event.gaxis.value), rightDeadzone);
+                        {
+                            float normRX = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(handle, SDL_GAMEPAD_AXIS_RIGHTX) / SDL_JOYSTICK_AXIS_MAX);
+                            float normRY = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(handle, SDL_GAMEPAD_AXIS_RIGHTY) / SDL_JOYSTICK_AXIS_MAX);
+                            rightStickX = (fabsf(normRX) < rightDz ? 0.0f : (fabsf(normRX) - rightDz) * (normRX / fabsf(normRX)));
+                            rightStickY = (fabsf(normRY) < rightDz ? 0.0f : (fabsf(normRY) - rightDz) * (normRY / fabsf(normRY)));
+                            if (rightDz > 0.0f) { rightStickX *= 1.0f / (1.0f - rightDz); rightStickY *= 1.0f / (1.0f - rightDz); }
+                            rightStickY = -rightStickY;
                             break;
+                        }
                         case SDL_GAMEPAD_AXIS_LEFT_TRIGGER:
-                            leftTrigger  = applyTriggerDeadzone(SDL_clamp((float)event.gaxis.value / SDL_JOYSTICK_AXIS_MAX, 0.0f, 1.0f), (float)left_analog_trigger_deadzone);
+                        {
+                            float raw = SDL_clamp((float)event.gaxis.value / SDL_JOYSTICK_AXIS_MAX, 0.0f, 1.0f);
+                            float dz  = (float)left_analog_trigger_deadzone;
+                            leftTrigger = (raw <= dz) ? 0.0f : (raw - dz) / (1.0f - dz);
                             break;
+                        }
                         case SDL_GAMEPAD_AXIS_RIGHT_TRIGGER:
-                            rightTrigger = applyTriggerDeadzone(SDL_clamp((float)event.gaxis.value / SDL_JOYSTICK_AXIS_MAX, 0.0f, 1.0f), (float)right_analog_trigger_deadzone);
+                        {
+                            float raw = SDL_clamp((float)event.gaxis.value / SDL_JOYSTICK_AXIS_MAX, 0.0f, 1.0f);
+                            float dz  = (float)right_analog_trigger_deadzone;
+                            rightTrigger = (raw <= dz) ? 0.0f : (raw - dz) / (1.0f - dz);
                             break;
+                        }
                         default:
                             break;
                     }
@@ -128,31 +135,20 @@ void SDLGamepad::GamepadEvents()
                 break;
 
             case SDL_EVENT_GAMEPAD_ADDED:
-                if (!sdlgamepad)
+                if (!handle)
                 {
-                    SDL_JoystickID id = event.gdevice.which;
-                    SDL_Gamepad *gp = SDL_OpenGamepad(id);
+                    SDL_Gamepad *gp = SDL_OpenGamepad(event.gdevice.which);
                     if (gp)
                     {
-                        sdlgamepad = gp;
-                        sdlInstanceId = id;
+                        handle = gp;
+                        sdlInstanceId = event.gdevice.which;
                     }
                 }
                 break;
 
             case SDL_EVENT_GAMEPAD_REMOVED:
-                if (sdlgamepad && event.gdevice.which == sdlInstanceId)
+                if (handle && event.gdevice.which == sdlInstanceId)
                     closeGamepad();
-                break;
-
-            case SDL_EVENT_GAMEPAD_REMAPPED:
-                if (sdlgamepad && event.gdevice.which == sdlInstanceId)
-                {
-                    closeGamepad();
-                    openGamepad();
-                    if (trace_all || trace_gamepad)
-                        ffnx_trace("SDL gamepad: mapping remapped, reopened\n");
-                }
                 break;
 
             default:
@@ -161,53 +157,21 @@ void SDLGamepad::GamepadEvents()
     }
 }
 
-bool SDLGamepad::openGamepad()
-{
-    if (!init())
-        return false;
-
-    int count = 0;
-    SDL_JoystickID *ids = SDL_GetGamepads(&count);
-
-    if (!ids || count == 0)
-    {
-        SDL_free(ids);
-        return false;
-    }
-
-    for (int i = 0; i < count; ++i)
-    {
-        SDL_Gamepad *gp = SDL_OpenGamepad(ids[i]);
-        if (!gp) continue;
-
-        sdlgamepad = gp;
-        sdlInstanceId = ids[i];
-        break;
-    }
-
-    SDL_free(ids);
-    return sdlgamepad != nullptr;
-}
 
 bool SDLGamepad::CheckConnection()
 {
-    if (!init())
-        return false;
-
-    GamepadEvents();
-
-    return sdlgamepad != nullptr;
+    return Refresh();
 }
 
 void SDLGamepad::closeGamepad()
 {
-    if (sdlgamepad)
+    if (handle)
     {
-        SDL_CloseGamepad(sdlgamepad);
-        sdlgamepad = nullptr;
+        SDL_CloseGamepad(handle);
+        handle = nullptr;
     }
 
-    sdlInstanceId = -1;
+    sdlInstanceId = 0;
 
     leftStickX = leftStickY = rightStickX = rightStickY = 0.0f;
     leftTrigger = rightTrigger = 0.0f;
@@ -215,31 +179,28 @@ void SDLGamepad::closeGamepad()
 
 bool SDLGamepad::Refresh()
 {
-    if (!sdlgamepad)
-    {
-        if (!openGamepad())
-            return false;
-    }
+    if (!init())
+        return false;
 
     GamepadEvents();
 
-    return true;
+    return handle != nullptr;
 }
 
 bool SDLGamepad::HasRumble() const
 {
-    if (!sdlgamepad)
+    if (!handle)
         return false;
-    SDL_PropertiesID props = SDL_GetGamepadProperties(sdlgamepad);
+    SDL_PropertiesID props = SDL_GetGamepadProperties(handle);
     return SDL_GetBooleanProperty(props, SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN, false);
 }
 
 bool SDLGamepad::Vibrate(WORD wLeftMotorSpeed, WORD wRightMotorSpeed)
 {
-    if (!sdlgamepad && !openGamepad())
+    if (!handle)
         return false;
 
-    if (!SDL_RumbleGamepad(sdlgamepad, wLeftMotorSpeed, wRightMotorSpeed, SDL_HAPTIC_INFINITY))
+    if (!SDL_RumbleGamepad(handle, wLeftMotorSpeed, wRightMotorSpeed, SDL_HAPTIC_INFINITY))
         return false;
 
     return true;
@@ -247,8 +208,8 @@ bool SDLGamepad::Vibrate(WORD wLeftMotorSpeed, WORD wRightMotorSpeed)
 
 bool SDLGamepad::IsPressed(SDL_GamepadButton button) const
 {
-    if (!sdlgamepad) return false;
-    return SDL_GetGamepadButton(sdlgamepad, button);
+    if (!handle) return false;
+    return SDL_GetGamepadButton(handle, button);
 }
 
 bool SDLGamepad::IsIdle() const

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -40,7 +40,7 @@ SDLGamepad::~SDLGamepad()
 
 int SDLGamepad::GetPort() const
 {
-    return handle ? 1 : 0;
+    return sdlgamepad ? 1 : 0;
 }
 
 
@@ -72,8 +72,8 @@ bool SDLGamepad::init()
 
 const char* SDLGamepad::GetName() const
 {
-    if (!handle) return "";
-    const char *name = SDL_GetGamepadName(handle);
+    if (!sdlgamepad) return "";
+    const char *name = SDL_GetGamepadName(sdlgamepad);
     return name ? name : "";
 }
 
@@ -85,7 +85,7 @@ void SDLGamepad::GamepadEvents()
         switch (event.type)
         {
             case SDL_EVENT_GAMEPAD_AXIS_MOTION:
-                if (handle && event.gaxis.which == sdlInstanceId)
+                if (sdlgamepad && event.gaxis.which == sdlInstanceId)
                 {
                     float leftDz  = (float)left_analog_stick_deadzone;
                     float rightDz = (float)right_analog_stick_deadzone;
@@ -95,8 +95,8 @@ void SDLGamepad::GamepadEvents()
                         case SDL_GAMEPAD_AXIS_LEFTX:
                         case SDL_GAMEPAD_AXIS_LEFTY:
                         {
-                            float normLX = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(handle, SDL_GAMEPAD_AXIS_LEFTX) / SDL_JOYSTICK_AXIS_MAX);
-                            float normLY = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(handle, SDL_GAMEPAD_AXIS_LEFTY) / SDL_JOYSTICK_AXIS_MAX);
+                            float normLX = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_LEFTX) / SDL_JOYSTICK_AXIS_MAX);
+                            float normLY = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_LEFTY) / SDL_JOYSTICK_AXIS_MAX);
                             leftStickX = (fabsf(normLX) < leftDz ? 0.0f : (fabsf(normLX) - leftDz) * (normLX / fabsf(normLX)));
                             leftStickY = (fabsf(normLY) < leftDz ? 0.0f : (fabsf(normLY) - leftDz) * (normLY / fabsf(normLY)));
                             if (leftDz > 0.0f) { leftStickX *= 1.0f / (1.0f - leftDz); leftStickY *= 1.0f / (1.0f - leftDz); }
@@ -106,8 +106,8 @@ void SDLGamepad::GamepadEvents()
                         case SDL_GAMEPAD_AXIS_RIGHTX:
                         case SDL_GAMEPAD_AXIS_RIGHTY:
                         {
-                            float normRX = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(handle, SDL_GAMEPAD_AXIS_RIGHTX) / SDL_JOYSTICK_AXIS_MAX);
-                            float normRY = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(handle, SDL_GAMEPAD_AXIS_RIGHTY) / SDL_JOYSTICK_AXIS_MAX);
+                            float normRX = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_RIGHTX) / SDL_JOYSTICK_AXIS_MAX);
+                            float normRY = fmaxf(-1.0f, (float)SDL_GetGamepadAxis(sdlgamepad, SDL_GAMEPAD_AXIS_RIGHTY) / SDL_JOYSTICK_AXIS_MAX);
                             rightStickX = (fabsf(normRX) < rightDz ? 0.0f : (fabsf(normRX) - rightDz) * (normRX / fabsf(normRX)));
                             rightStickY = (fabsf(normRY) < rightDz ? 0.0f : (fabsf(normRY) - rightDz) * (normRY / fabsf(normRY)));
                             if (rightDz > 0.0f) { rightStickX *= 1.0f / (1.0f - rightDz); rightStickY *= 1.0f / (1.0f - rightDz); }
@@ -135,19 +135,19 @@ void SDLGamepad::GamepadEvents()
                 break;
 
             case SDL_EVENT_GAMEPAD_ADDED:
-                if (!handle)
+                if (!sdlgamepad)
                 {
                     SDL_Gamepad *gp = SDL_OpenGamepad(event.gdevice.which);
                     if (gp)
                     {
-                        handle = gp;
+                        sdlgamepad = gp;
                         sdlInstanceId = event.gdevice.which;
                     }
                 }
                 break;
 
             case SDL_EVENT_GAMEPAD_REMOVED:
-                if (handle && event.gdevice.which == sdlInstanceId)
+                if (sdlgamepad && event.gdevice.which == sdlInstanceId)
                     closeGamepad();
                 break;
 
@@ -165,10 +165,10 @@ bool SDLGamepad::CheckConnection()
 
 void SDLGamepad::closeGamepad()
 {
-    if (handle)
+    if (sdlgamepad)
     {
-        SDL_CloseGamepad(handle);
-        handle = nullptr;
+        SDL_CloseGamepad(sdlgamepad);
+        sdlgamepad = nullptr;
     }
 
     sdlInstanceId = 0;
@@ -184,23 +184,23 @@ bool SDLGamepad::Refresh()
 
     GamepadEvents();
 
-    return handle != nullptr;
+    return sdlgamepad != nullptr;
 }
 
 bool SDLGamepad::HasRumble() const
 {
-    if (!handle)
+    if (!sdlgamepad)
         return false;
-    SDL_PropertiesID props = SDL_GetGamepadProperties(handle);
+    SDL_PropertiesID props = SDL_GetGamepadProperties(sdlgamepad);
     return SDL_GetBooleanProperty(props, SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN, false);
 }
 
 bool SDLGamepad::Vibrate(WORD wLeftMotorSpeed, WORD wRightMotorSpeed)
 {
-    if (!handle)
+    if (!sdlgamepad)
         return false;
 
-    if (!SDL_RumbleGamepad(handle, wLeftMotorSpeed, wRightMotorSpeed, SDL_HAPTIC_INFINITY))
+    if (!SDL_RumbleGamepad(sdlgamepad, wLeftMotorSpeed, wRightMotorSpeed, SDL_HAPTIC_INFINITY))
         return false;
 
     return true;
@@ -208,8 +208,8 @@ bool SDLGamepad::Vibrate(WORD wLeftMotorSpeed, WORD wRightMotorSpeed)
 
 bool SDLGamepad::IsPressed(SDL_GamepadButton button) const
 {
-    if (!handle) return false;
-    return SDL_GetGamepadButton(handle, button);
+    if (!sdlgamepad) return false;
+    return SDL_GetGamepadButton(sdlgamepad, button);
 }
 
 bool SDLGamepad::IsIdle() const

--- a/src/sdl_gamepad.h
+++ b/src/sdl_gamepad.h
@@ -34,12 +34,12 @@ private:
     SDL_JoystickID sdlInstanceId = -1;
     bool sdlInitialized = false;
 
+    bool init();
     void GamepadEvents();
     bool openGamepad();
     void closeGamepad();
 
 public:
-    bool Gamepad_Init();
     ~SDLGamepad();
 
     float leftStickX = 0.0f;

--- a/src/sdl_gamepad.h
+++ b/src/sdl_gamepad.h
@@ -30,13 +30,12 @@
 class SDLGamepad
 {
 private:
-    SDL_Gamepad *sdlgamepad = nullptr;
-    SDL_JoystickID sdlInstanceId = -1;
+    SDL_Gamepad *handle = nullptr;
+    SDL_JoystickID sdlInstanceId = 0;
     bool sdlInitialized = false;
 
     bool init();
     void GamepadEvents();
-    bool openGamepad();
     void closeGamepad();
 
 public:

--- a/src/sdl_gamepad.h
+++ b/src/sdl_gamepad.h
@@ -30,7 +30,7 @@
 class SDLGamepad
 {
 private:
-    SDL_Gamepad *handle = nullptr;
+    SDL_Gamepad *sdlgamepad = nullptr;
     SDL_JoystickID sdlInstanceId = 0;
     bool sdlInitialized = false;
 


### PR DESCRIPTION
## Summary

This PR is yet another quality-of-life improvement, this time focusing on event management, event polling and backporting Deadzone Math from XInput path over to SDL Gamepad. Unless there's remaining bugs, left this might be my last contribution after this.

### Motivation

After reviewing SDL Gamepad tutorials for a bit: I decided to make adjustments to rely more on SDL Events, while the Poll Event has been changed up to mirror example codes and observe how sourceport/mod projects does it,.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file 
- [x] I did test my code on FF7
- [x] I did test my code on FF8
