### PR TITLE
[ FF7 ] Ground beneath Ifrit: color inverted - v2

### DIFF
--- a/src/externals_102_de.h
+++ b/src/externals_102_de.h
@@ -63,6 +63,7 @@ ff7_externals.matrix4x3_multiply =            0x66CC0B;
 ff7_externals.sub_6B26C0 =                    0x6B2690;
 ff7_externals.sub_6B2720 =                    0x6B26F0;
 ff7_externals.sub_673F5C =                    0x673F2C;
+ff7_externals.set_blend_mode =                0x694C50;
 ff7_externals.savemap =               (savemap *)0xF38A68;
 ff7_externals.menu_objects =          (menu_objects *)0xF39CF0;
 ff7_externals.magic_thread_start =            0x427928;

--- a/src/externals_102_fr.h
+++ b/src/externals_102_fr.h
@@ -63,6 +63,7 @@ ff7_externals.matrix4x3_multiply =            0x66CBDB;
 ff7_externals.sub_6B26C0 =                    0x6B2660;
 ff7_externals.sub_6B2720 =                    0x6B26C0;
 ff7_externals.sub_673F5C =                    0x673EFC;
+ff7_externals.set_blend_mode =                0x694C20;
 ff7_externals.savemap =               (savemap*)0xF39A78;
 ff7_externals.menu_objects =          (menu_objects*)0xF3AD00;
 ff7_externals.magic_thread_start =            0x427938;

--- a/src/externals_102_sp.h
+++ b/src/externals_102_sp.h
@@ -63,6 +63,7 @@ ff7_externals.matrix4x3_multiply =            0x66CBDB;
 ff7_externals.sub_6B26C0 =                    0x6B2660;
 ff7_externals.sub_6B2720 =                    0x6B26C0;
 ff7_externals.sub_673F5C =                    0x673EFC;
+ff7_externals.set_blend_mode =                0x694C20;
 ff7_externals.savemap =               (savemap *)0xF3A548;
 ff7_externals.menu_objects =          (menu_objects *)0xF3B7D0;
 ff7_externals.magic_thread_start =            0x427938;

--- a/src/externals_102_us.h
+++ b/src/externals_102_us.h
@@ -63,6 +63,7 @@ ff7_externals.matrix4x3_multiply =            0x66CC3B;
 ff7_externals.sub_6B26C0 =                    0x6B26C0;
 ff7_externals.sub_6B2720 =                    0x6B2720;
 ff7_externals.sub_673F5C =                    0x673F5C;
+ff7_externals.set_blend_mode =                0x694C80;
 ff7_externals.savemap =               (savemap *)0xDBFD38;
 ff7_externals.menu_objects =          (menu_objects *)0xDC0FC0;
 ff7_externals.magic_thread_start =            0x427928;

--- a/src/ff7.h
+++ b/src/ff7.h
@@ -2789,6 +2789,8 @@ struct ff7_externals
 	uint32_t sub_6B26C0;
 	uint32_t sub_6B2720;
 	uint32_t sub_673F5C;
+	uint32_t set_blend_mode;
+	uint32_t ifrit_summon_render_descriptors_8BFEE8;
 	struct savemap *savemap;
 	struct menu_objects *menu_objects;
 	uint32_t magic_thread_start;

--- a/src/ff7/blend.cpp
+++ b/src/ff7/blend.cpp
@@ -1,0 +1,100 @@
+/****************************************************************************/
+//    Copyright (C) 2026 Jakob Dowdle                                       //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+// SetBlendMode hook + Ifrit CIRCLE.RSD data patch (#654).
+//
+// The original SetBlendMode does not write the PSX blend index to
+// p_hundred->blend_mode (+0x44), which is the field common_setrenderstate
+// reads. This hook propagates the index after the original runs.
+
+#include <windows.h>
+#include <cstdint>
+#include <cstring>
+
+#include "../ff7.h"
+#include "../patch.h"
+#include "../log.h"
+#include "../common_imports.h"
+
+#include "blend.h"
+
+namespace ff7
+{
+
+typedef void (*SetBlendMode_t)(uint32_t update_flag, uint32_t blend_mode, struct p_hundred *state);
+
+static SetBlendMode_t call_original_set_blend_mode = nullptr;
+
+// SetBlendMode's prologue is PUSH EBP; MOV EBP,ESP; SUB ESP,8 — three
+// instructions totalling 6 bytes. A 5-byte trampoline would split SUB ESP,8.
+static constexpr size_t TRAMPOLINE_COPY_BYTES = 6;
+
+static SetBlendMode_t build_set_blend_mode_trampoline(uint32_t target)
+{
+    uint8_t *tramp = static_cast<uint8_t *>(
+        VirtualAlloc(nullptr, 16, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE));
+    if (!tramp)
+        return nullptr;
+
+    std::memcpy(tramp, reinterpret_cast<void *>(target), TRAMPOLINE_COPY_BYTES);
+
+    tramp[TRAMPOLINE_COPY_BYTES] = 0xE9;
+    int32_t rel = static_cast<int32_t>(
+        (target + TRAMPOLINE_COPY_BYTES) -
+        (reinterpret_cast<uint32_t>(tramp) + TRAMPOLINE_COPY_BYTES + 5));
+    std::memcpy(tramp + TRAMPOLINE_COPY_BYTES + 1, &rel, 4);
+
+    return reinterpret_cast<SetBlendMode_t>(tramp);
+}
+
+static void ff7_set_blend_mode(uint32_t update_flag, uint32_t blend_mode, struct p_hundred *state)
+{
+    call_original_set_blend_mode(update_flag, blend_mode, state);
+
+    // Mode 6 means "restore saved mode" — the original re-applies
+    // state->blend_mode, so the field already holds the correct index.
+    if (blend_mode == 6)
+        return;
+
+    if (state != nullptr)
+        state->blend_mode = blend_mode;
+}
+
+// Ifrit summon's descriptor table holds CIRCLE.RSD (the ground hole) at
+// offset 0 with blend mode 1 (additive). The PSX renders it with mode 2
+// (subtractive). 0xb1 -> 0xb2 flips the mode while preserving flag bits.
+static constexpr uint8_t IFRIT_CIRCLE_FLAGS_SUB = 0xb2;
+
+void blend_hook_init()
+{
+    if (!ff7_externals.set_blend_mode)
+    {
+        ffnx_warning("blend_hook_init: set_blend_mode address not set for this version, skipping\n");
+        return;
+    }
+
+    call_original_set_blend_mode = build_set_blend_mode_trampoline(ff7_externals.set_blend_mode);
+    if (!call_original_set_blend_mode)
+    {
+        ffnx_error("blend_hook_init: VirtualAlloc failed, cannot build SetBlendMode trampoline\n");
+        return;
+    }
+
+    replace_function(ff7_externals.set_blend_mode, ff7_set_blend_mode);
+
+    patch_code_byte(ff7_externals.ifrit_summon_render_descriptors_8BFEE8, IFRIT_CIRCLE_FLAGS_SUB);
+}
+
+} // namespace ff7

--- a/src/ff7/blend.h
+++ b/src/ff7/blend.h
@@ -1,0 +1,21 @@
+/****************************************************************************/
+//    Copyright (C) 2026 Jakob Dowdle                                       //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#pragma once
+
+namespace ff7
+{
+    void blend_hook_init();
+}

--- a/src/ff7_data.h
+++ b/src/ff7_data.h
@@ -991,6 +991,8 @@ inline void ff7_find_externals(struct ff7_game_obj* game_object)
 	uint32_t run_ifrit_main_loop_593A95 = get_absolute_value(run_ifrit_sub_5928FE, 0x9D);
 	ff7_externals.run_ifrit_movement_596702 = get_absolute_value(run_ifrit_main_loop_593A95, 0x15B);
 	ff7_externals.run_ifrit_camera_592A36 = get_absolute_value(run_ifrit_camera_handler_5929F6, 0x5);
+	uint32_t ifrit_summon_loader_592720 = get_relative_call(run_ifrit_main_5927C1, 0x122);
+	ff7_externals.ifrit_summon_render_descriptors_8BFEE8 = get_absolute_value(ifrit_summon_loader_592720, 0x2C);
 	uint32_t run_summon_ramuh_main_596FF1 = get_relative_call(ff7_externals.run_summon_animations_5C0E4B, 0x311);
 	uint32_t run_summon_ramuh_sub_59706F = get_relative_call(run_summon_ramuh_main_596FF1, 0x70);
 	uint32_t run_summon_ramuh_sub_5971C6 = get_relative_call(run_summon_ramuh_sub_59706F, 0x13C);

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -26,6 +26,7 @@
 #include "patch.h"
 #include "ff7/defs.h"
 #include "ff7_data.h"
+#include "ff7/blend.h"
 #include "ff7/widescreen.h"
 #include "ff7/time.h"
 #include "ff7/battle/defs.h"
@@ -100,6 +101,9 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	memset_code((uint32_t)ff7_externals.sub_6B27A9 + 25, 0x90, 6);
 	replace_function(ff7_externals.sub_6B26C0, draw_single_triangle);
 	replace_function(ff7_externals.sub_6B2720, sub_6B2720);
+
+	// Blend mode fix (#654)
+	ff7::blend_hook_init();
 
 	// replace framebuffer access routine with our own version
 	replace_function(ff7_externals.sub_673F5C, sub_673F5C);


### PR DESCRIPTION
## Summary

Fixes Ifrit summon ground hole rendering with two changes: a SetBlendMode trampoline hook so per-state blend modes actually reach the renderer, and a one-byte patch on the Ifrit summon's CIRCLE.RSD (the ground hole model) descriptor that flips it from additive to subtractive blending.

### Motivation

The PC port lost the original PSX subtractive blending on Ifrit's ground hole, so it shows up as white instead of black. This fixes issue #654 and brings the effect closer to the original PSX look.

### More Info

The descriptor for CIRCLE.RSD  in Ifrit's table hard-codes blend mode 1 (additive); PSX used mode 2 (subtractive). Two changes:

Data patch at 0x008bfee8 (0xb1 -> 0xb2), preserving flag bits. The address is referenced only by the Ifrit summon loader, so the change shouldn't bleed into other effects. Resolved dynamically through the run_ifrit_main call chain. Supports US/DE/FR/SP.
SetBlendMode trampoline hook that writes the PSX index into p_hundred -> blend_mode (+0x44) after the original runs. The original sets D3D factors but never this field (which is what common_setrenderstate reads) so the descriptor flip wouldn't reach BLEND_SUB without it.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
