### PR TITLE
FF7: Add multibyte_font mode for non-Japanese multibyte text

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 ## FF7
 
 - Core: Add native support for japanese text rendering ( https://github.com/julianxhokaxhiu/FFNx/pull/737 + https://github.com/julianxhokaxhiu/FFNx/pull/925 + https://github.com/julianxhokaxhiu/FFNx/pull/952 + https://github.com/julianxhokaxhiu/FFNx/pull/953 + https://github.com/julianxhokaxhiu/FFNx/pull/951) 
+- Core: Add `ff7_multibyte_font` mode: multibyte text support for non-Japanese translations on the English executable ( https://github.com/julianxhokaxhiu/FFNx/pull/948 )
 
 # 1.24.3
 

--- a/docs/ff7/multibyte_font.md
+++ b/docs/ff7/multibyte_font.md
@@ -53,7 +53,7 @@ The loader reads the 6 sheets by the same names the JP edition uses:
 
 Each sheet is a 16×16 grid of glyph cells (256 cells per sheet). Author them exactly like any
 other FFNx-replaceable menu texture — external hi-res textures are supported through the normal
-texture replacement path (see [External textures](external_textures.md)).
+texture replacement path (see [External textures](../mods/external_textures.md)).
 
 ## Per-character widths: `multibyte_widths.bin`
 

--- a/docs/ff7/multibyte_font.md
+++ b/docs/ff7/multibyte_font.md
@@ -59,7 +59,10 @@ texture replacement path (see [External textures](../mods/external_textures.md))
 
 Glyph advance widths come from a table you can override **at runtime, without recompiling**:
 
-- Path: `<basedir>/multibyte_widths.bin` (next to `FFNx.toml`).
+- Path: `data/kernel/multibyte_widths.bin`, resolved through the standard layers — the
+  `override_path` layer is checked first, then the release's data path: `data/lang-en/kernel/`
+  (or the active language) on Steam/GOG/Store/2026 releases, plain `data/kernel/` on the 1998
+  release.
 - Format: raw `6 * 256` bytes — one byte per glyph, sheets in order 1..6, code order `0x00-0xFF`
   within each sheet.
 - Byte packing: `(left_padding << 5) | width`, i.e. low 5 bits = advance width in font units
@@ -73,7 +76,7 @@ If the file is missing, built-in defaults are used.
 
 Optional. Controls the vertical line advance of field dialogue for multibyte text:
 
-- Path: `<basedir>/multibyte_linestep.bin`.
+- Path: `data/kernel/multibyte_linestep.bin` (same layered resolution as the widths file).
 - Format: a 2-byte little-endian value, line step in **quarter pixels** (e.g. `128` = 32.0 px,
   `98` = 24.5 px). A 1-byte file is also accepted as whole pixels. Accepted range 80–160
   quarter-px; out-of-range values are ignored.
@@ -87,7 +90,7 @@ default; adjust live until lines neither overlap nor float apart.
 Optional, read once at startup. Marks sheet-1 cells that contain icon art (item/weapon type
 icons, button prompts) rather than letters:
 
-- Path: `<basedir>/multibyte_iconmask.bin`.
+- Path: `data/kernel/multibyte_iconmask.bin` (same layered resolution as the widths file).
 - Format: raw 256 bytes, one per `jafont_1` code. Non-zero = icon cell.
 - Effect: marked cells are always drawn pure white instead of taking the current text color,
   so colored icon art keeps its true colors. This addresses the recolor conflict with icon

--- a/docs/mods/multibyte_font.md
+++ b/docs/mods/multibyte_font.md
@@ -1,0 +1,114 @@
+# Multibyte Font Mode (FF7)
+
+`multibyte_font` lets a translation use the Japanese edition's multi-sheet font system on the
+**English/International executable**, without pulling in the Japanese-edition-only menu scaling
+and layout changes. It was built and tested against a full Arabic localization of FF7, but the
+mechanism is script-agnostic: any translation that needs more glyphs than the base 256-entry
+charset (Arabic presentation forms, Chinese, Korean, extended Cyrillic, ...) can use it.
+
+## Enabling
+
+In `FFNx.toml`:
+
+```toml
+multibyte_font = true
+```
+
+Do **not** combine it with `ff7_japanese_edition` — that flag is for the actual Japanese
+executable and additionally applies JP-only menu layout/scaling that breaks non-JP menus.
+`multibyte_font` installs only the shared pieces: the multi-sheet font loader, the per-character
+multibyte draw path, and the text-drawing hooks (field, menu, battle, battle top-bar).
+
+## How text is encoded
+
+Text bytes are interpreted like the Japanese edition interprets them:
+
+- A plain byte `0x00-0xFF` draws the glyph at that index of font sheet 1 (`jafont_1`).
+- Escape byte `0xFA`, `0xFB`, `0xFC`, `0xFD` or `0xFE` switches the NEXT byte to font sheet
+  2, 3, 4, 5 or 6 respectively. Two-byte sequence per extended glyph, e.g. `FA 12` = glyph
+  `0x12` of `jafont_2`.
+
+That gives up to 6 × 256 glyph cells. Your text-encoding pipeline decides which characters live
+at which codes — FFNx does not impose any particular character set. Practical caveats:
+
+- Control codes of the game's text format (`0xE0`+ range in kernel/field text: names, colors,
+  new-line, new-page, variables...) keep their engine meaning. Don't place glyphs on bytes your
+  target text sections use as control codes.
+- `0xDE` in battle window D is redirected to a heart icon by the Japanese text support
+  (a vanilla JP quirk). Treat `0xDE` as reserved if your translation may run with JP text
+  features enabled.
+- Bytes drawn through the multibyte path are recolored via the palette/color data. Mods that
+  repaint icon cells expecting NOT to be recolored (button prompts, item icons) can conflict
+  with glyphs you place in those cells; prefer free cells.
+
+## Font textures
+
+The loader reads the 6 sheets by the same names the JP edition uses:
+
+```
+<direct/mod path>/menu/jafont_1.tim (or .tex, and hi-res .dds/.png overrides work as usual)
+...
+<direct/mod path>/menu/jafont_6.tim
+```
+
+Each sheet is a 16×16 grid of glyph cells (256 cells per sheet). Author them exactly like any
+other FFNx-replaceable menu texture — external hi-res textures are supported through the normal
+texture replacement path (see [External textures](external_textures.md)).
+
+## Per-character widths: `multibyte_widths.bin`
+
+Glyph advance widths come from a table you can override **at runtime, without recompiling**:
+
+- Path: `<basedir>/multibyte_widths.bin` (next to `FFNx.toml`).
+- Format: raw `6 * 256` bytes — one byte per glyph, sheets in order 1..6, code order `0x00-0xFF`
+  within each sheet.
+- Byte packing: `(left_padding << 5) | width`, i.e. low 5 bits = advance width in font units
+  (0-31), high 3 bits = left padding. Same packing as member 3 of `window.bin`.
+- Hot-reload: FFNx re-reads the file whenever its modification time changes (checked at most
+  once per second). You can tune spacing live while the game runs.
+
+If the file is missing, built-in defaults are used.
+
+## Field line step: `multibyte_linestep.bin`
+
+Optional. Controls the vertical line advance of field dialogue for multibyte text:
+
+- Path: `<basedir>/multibyte_linestep.bin`.
+- Format: a 2-byte little-endian value, line step in **quarter pixels** (e.g. `128` = 32.0 px,
+  `98` = 24.5 px). A 1-byte file is also accepted as whole pixels. Accepted range 80–160
+  quarter-px; out-of-range values are ignored.
+- Hot-reloaded the same way as the widths file.
+
+Taller scripts (e.g. Arabic with diacritics) typically need a larger step than the Latin
+default; adjust live until lines neither overlap nor float apart.
+
+## Icon cells: `multibyte_iconmask.bin`
+
+Optional, read once at startup. Marks sheet-1 cells that contain icon art (item/weapon type
+icons, button prompts) rather than letters:
+
+- Path: `<basedir>/multibyte_iconmask.bin`.
+- Format: raw 256 bytes, one per `jafont_1` code. Non-zero = icon cell.
+- Effect: marked cells are always drawn pure white instead of taking the current text color,
+  so colored icon art keeps its true colors. This addresses the recolor conflict with icon
+  mods noted above.
+
+## What multibyte_font does NOT do
+
+- **Name-entry screen**: the 3-mode (hiragana/katakana/eisuu) name-entry screen stays gated
+  behind `ff7_japanese_edition`. A translation whose alphabet doesn't fit the stock name screen
+  needs its own solution (the Arabic project keeps default names / renames via save editing).
+- **Window auto-resize**: the JP-edition window auto-resize hook is not installed. Field files
+  are expected to ship with correctly sized windows for the translated text (retranslation
+  pipelines normally rebuild field files anyway).
+- **Text conversion**: FFNx only draws bytes. Reshaping/bidi (Arabic), charmap design, and
+  re-encoding game files remain the translation pipeline's job.
+
+## Quick checklist for a new translation
+
+1. Design your charmap: assign characters to sheet/code slots, avoiding engine control codes
+   (and `0xDE`, see above).
+2. Paint `jafont_1..6` textures (16×16 grid per sheet).
+3. Re-encode game text (kernel, field, battle, world, exe strings) to your charmap.
+4. Generate `multibyte_widths.bin` from your glyph metrics.
+5. Set `multibyte_font = true` and iterate on widths/linestep live in-game.

--- a/docs/mods/multibyte_font.md
+++ b/docs/mods/multibyte_font.md
@@ -1,6 +1,6 @@
 # Multibyte Font Mode (FF7)
 
-`multibyte_font` lets a translation use the Japanese edition's multi-sheet font system on the
+`ff7_multibyte_font` lets a translation use the Japanese edition's multi-sheet font system on the
 **English/International executable**, without pulling in the Japanese-edition-only menu scaling
 and layout changes. It was built and tested against a full Arabic localization of FF7, but the
 mechanism is script-agnostic: any translation that needs more glyphs than the base 256-entry
@@ -11,12 +11,12 @@ charset (Arabic presentation forms, Chinese, Korean, extended Cyrillic, ...) can
 In `FFNx.toml`:
 
 ```toml
-multibyte_font = true
+ff7_multibyte_font = true
 ```
 
 Do **not** combine it with `ff7_japanese_edition` — that flag is for the actual Japanese
 executable and additionally applies JP-only menu layout/scaling that breaks non-JP menus.
-`multibyte_font` installs only the shared pieces: the multi-sheet font loader, the per-character
+`ff7_multibyte_font` installs only the shared pieces: the multi-sheet font loader, the per-character
 multibyte draw path, and the text-drawing hooks (field, menu, battle, battle top-bar).
 
 ## How text is encoded
@@ -93,7 +93,7 @@ icons, button prompts) rather than letters:
   so colored icon art keeps its true colors. This addresses the recolor conflict with icon
   mods noted above.
 
-## What multibyte_font does NOT do
+## What ff7_multibyte_font does NOT do
 
 - **Name-entry screen**: the 3-mode (hiragana/katakana/eisuu) name-entry screen stays gated
   behind `ff7_japanese_edition`. A translation whose alphabet doesn't fit the stock name screen
@@ -111,4 +111,4 @@ icons, button prompts) rather than letters:
 2. Paint `jafont_1..6` textures (16×16 grid per sheet).
 3. Re-encode game text (kernel, field, battle, world, exe strings) to your charmap.
 4. Generate `multibyte_widths.bin` from your glyph metrics.
-5. Set `multibyte_font = true` and iterate on widths/linestep live in-game.
+5. Set `ff7_multibyte_font = true` and iterate on widths/linestep live in-game.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -24,3 +24,4 @@ Welcome to the FFNx documentation!
 - [Video Encoding Guide](mods/video_encoding_guide.md)
 - [External textures](mods/external_textures.md)
 - [Preparing Textures for NTSC-J Mode](mods/preparing_textures_for_ntscj_mode.md)
+- [Multibyte Font Mode (FF7)](mods/multibyte_font.md)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -11,6 +11,8 @@ Welcome to the FFNx documentation!
 
 ## FF7
 
+- [Multibyte Font Mode](ff7/multibyte_font.md)
+
 ## FF8
 
  - [FF8 Specific documentation](ff8/readme.md)
@@ -24,4 +26,3 @@ Welcome to the FFNx documentation!
 - [Video Encoding Guide](mods/video_encoding_guide.md)
 - [External textures](mods/external_textures.md)
 - [Preparing Textures for NTSC-J Mode](mods/preparing_textures_for_ntscj_mode.md)
-- [Multibyte Font Mode (FF7)](mods/multibyte_font.md)

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -297,7 +297,7 @@ void read_cfg()
 	ff7_fps_limiter = config["ff7_fps_limiter"].value_or(FPS_LIMITER_DEFAULT);
 	ff7_footsteps = config["ff7_footsteps"].value_or(false);
 	ff7_field_center = config["ff7_field_center"].value_or(true);
-	multibyte_font = config["multibyte_font"].value_or(false);
+	ff7_multibyte_font = config["ff7_multibyte_font"].value_or(false);
 	use_sdl_gamepad = config["use_sdl_gamepad"].value_or(false);
 	ff7_japanese_text = config["ff7_japanese_text"].value_or(false);
 	ff7_japanese_edition = config["ff7_japanese_edition"].value_or(false);

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -297,6 +297,7 @@ void read_cfg()
 	ff7_fps_limiter = config["ff7_fps_limiter"].value_or(FPS_LIMITER_DEFAULT);
 	ff7_footsteps = config["ff7_footsteps"].value_or(false);
 	ff7_field_center = config["ff7_field_center"].value_or(true);
+	multibyte_font = config["multibyte_font"].value_or(false);
 	use_sdl_gamepad = config["use_sdl_gamepad"].value_or(false);
 	ff7_japanese_text = config["ff7_japanese_text"].value_or(false);
 	ff7_japanese_edition = config["ff7_japanese_edition"].value_or(false);

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -145,7 +145,7 @@ uint32_t ff7_japanese_edition = false;
 // multibyte font mode: enable the extra-font escape codes (FA-FE -> jafont_2..6) WITHOUT the
 // JP-only menu scaling/name-screen, so English-exe translations (e.g. Arabic) get the extra
 // glyph space while keeping native EN menu layout.
-uint32_t multibyte_font = false;
+uint32_t ff7_multibyte_font = false;
 
 // window dimensions requested by the game, normally 640x480
 uint32_t game_width;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -142,6 +142,11 @@ uint32_t ff7_2026_rerelease = false;
 // global FF7 flag, check if is japanese edition ( detected as US )
 uint32_t ff7_japanese_edition = false;
 
+// multibyte font mode: enable the extra-font escape codes (FA-FE -> jafont_2..6) WITHOUT the
+// JP-only menu scaling/name-screen, so English-exe translations (e.g. Arabic) get the extra
+// glyph space while keeping native EN menu layout.
+uint32_t multibyte_font = false;
+
 // window dimensions requested by the game, normally 640x480
 uint32_t game_width;
 uint32_t game_height;

--- a/src/ff7/japanese_text.cpp
+++ b/src/ff7/japanese_text.cpp
@@ -18,8 +18,11 @@
 #include "../patch.h"
 #include <string.h>
 
+static void multibyte_load_widths();
+
 void engine_load_menu_graphics_objects_6C1468_jp(int a1)
 {
+  multibyte_load_widths();
   unsigned int v1; // eax
   unsigned int v2; // eax
   unsigned int v3; // ecx
@@ -422,6 +425,75 @@ int charWidthData[6][256] =
     }
 };
 
+// multibyte (EN) advance: table value IS the advance in screen units (max 31 covers wide Arabic);
+// JP keeps the original half-width semantics (32px texel cells -> 16 units).
+static inline float z_half_width(int w) { return ff7_japanese_edition ? std::ceil(0.5f * (float)w) : (float)w; }
+
+// multibyte_font: override the hardcoded width table from <basedir>/multibyte_widths.bin
+// (6*256 bytes, one per font sheet/code, same (pad<<5|width) packing as window.bin member 3),
+// so translations can tune advances without recompiling FFNx.
+static byte multibyte_icon_mask[256] = {0};
+static int multibyte_field_linestep_q = 128;   // field line advance in QUARTER px (128 = 32.0), live-tunable
+
+static void multibyte_load_widths()
+{
+  // Hot-reload: re-read the widths file whenever its mtime changes (checked at most 1x/sec),
+  // so letter advances can be tuned live while the game runs (width_gui.py writes the file).
+  static bool tried = false;
+  static long long last_mtime = -1;
+  static DWORD last_check = 0;
+  if (!multibyte_font) return;
+  DWORD now = GetTickCount();
+  if (tried && (now - last_check) < 1000) return;
+  last_check = now;
+  char path[BASEDIR_LENGTH + 32];
+  // line step re-read every 1s tick — must NOT sit behind the widths mtime gate,
+  // or moving only the spacing slider never reaches it
+  _snprintf(path, sizeof(path), "%s/multibyte_linestep.bin", basedir);
+  FILE *lf = fopen(path, "rb");
+  if (lf)
+  {
+    unsigned char lb[2]; size_t ln = fread(lb, 1, 2, lf);
+    int q = (ln == 2) ? (lb[0] | (lb[1] << 8)) : (ln == 1 ? lb[0] * 4 : 0);  // 1-byte legacy = whole px
+    if (q >= 80 && q <= 160 && q != multibyte_field_linestep_q)
+    {
+      multibyte_field_linestep_q = q;
+      ffnx_info("multibyte_font: field line step = %d.%02d px\n", q / 4, (q % 4) * 25);
+    }
+    fclose(lf);
+  }
+  _snprintf(path, sizeof(path), "%s/multibyte_widths.bin", basedir);
+  struct _stat64 st;
+  bool first = !tried;
+  if (_stat64(path, &st) == 0)
+  {
+    if (tried && (long long)st.st_mtime == last_mtime) return;
+    last_mtime = (long long)st.st_mtime;
+  }
+  tried = true;
+  FILE *f = fopen(path, "rb");
+  if (!f) { if (first) ffnx_info("multibyte_font: no %s, using built-in widths\n", path); return; }
+  unsigned char buf[6 * 256];
+  if (fread(buf, 1, sizeof(buf), f) == sizeof(buf))
+  {
+    for (int i = 0; i < 6; i++)
+      for (int j = 0; j < 256; j++)
+        charWidthData[i][j] = buf[i * 256 + j];
+    ffnx_info("multibyte_font: widths %s\n", first ? "loaded" : "RELOADED (live)");
+  }
+  else ffnx_error("multibyte_font: %s wrong size (need 1536 bytes)\n", path);
+  fclose(f);
+  if (!first) return;
+  _snprintf(path, sizeof(path), "%s/multibyte_iconmask.bin", basedir);
+  f = fopen(path, "rb");
+  if (f)
+  {
+    if (fread(multibyte_icon_mask, 1, 256, f) == 256)
+      ffnx_info("multibyte_font: icon mask loaded\n");
+    fclose(f);
+  }
+}
+
 bgra_byte get_character_color(int n_shapes)
 {
   bgra_byte color = { 255, 255, 255, 255 };
@@ -464,7 +536,9 @@ __int16 field_submit_draw_text_640x480_6E706D_jp(
         byte *buffer_text,
         float z_value)
 {
-  float scaleFactor = 1.25f;  // adjust size of text. 1.25 seesm correct.
+  multibyte_load_widths();   // hot-reload here too: dialogs must respond to live width tuning
+  int _lsq_acc = 0;   // quarter-px remainder for fractional line stepping
+  float scaleFactor = ff7_japanese_edition ? 1.25f : 1.0f;  // JP upscales 1.25x; multibyte (EN) draws native 1.0x
   int special_character_do_draw; // eax
   graphics_vertex *window_vertices; // eax
   int character_do_draw; // eax
@@ -510,9 +584,17 @@ __int16 field_submit_draw_text_640x480_6E706D_jp(
     if ( *buffer_text == 231 )
     {
       character_x = (*ff7_externals.field_current_window_pos_x_DC3CB4) + 20; // need to indent this far for pointers to point properly
-      character_y += 32;
+      _lsq_acc += multibyte_field_linestep_q;
+      character_y += _lsq_acc / 4; _lsq_acc %= 4;
       ++buffer_text;
-      ++ff7_externals.field_text_line_row_DC3CB8;
+      // Window field +0x16 (field_text_line_row) must count newlines, same as the vanilla JP path.
+      // The old code incremented the pointer itself instead of the value it points to, so this
+      // field never advanced past 0 for multibyte text. The engine only sends its "window closed"
+      // signal once this row count and the character count below both reach their expected
+      // values, so leaving this at 0 stalls the field script after any multi-line message.
+      ++(*ff7_externals.field_text_line_row_DC3CB8);
+      // Character count must include newlines, not just drawn glyphs, matching vanilla behavior.
+      // Both fixes on these two lines are required together; either alone still stalls the window.
       ++(*ff7_externals.field_text_box_curr_n_characters_DC3CB0);
     }
     else
@@ -644,22 +726,29 @@ LABEL_39:
             {
               character_n_shapes = (*ff7_externals.word_91F028); // read external to select chacter color normally.
             }
+            if (!ff7_japanese_edition && multibyte_icon_mask[*buffer_text])
+              character_n_shapes = 8; // icon cells: force pure white so icon art keeps true colors so icon art keeps true colors
             current_character = *buffer_text;
             character = current_character;
             //if ( *buffer_text == 0xD2 || *buffer_text == 0xD3 )
               //character = current_character - 78;
             offset_u_in_byte = 32 * (character % 16);
             graphics_object_v_in_byte += 32 * (character / 16); // calculate character position in sheet so we render the rigth character
-            /*if ( character_x
-               - (*ff7_externals.field_current_window_pos_x_DC3CB4)
-               + 2
-               * ((*(byte *)((*ff7_externals.g_text_spacing_DB958C) + text_offset_spacing + *buffer_text) & 0x1F)
-                + ((int)*(unsigned __int8 *)((*ff7_externals.g_text_spacing_DB958C) + text_offset_spacing + *buffer_text) >> 5)) > text_box_right_position )
+            // SOFT-WRAP (Arabic long-line wrap). Not the soft-lock cause (verified: scene still locks
+            // with this disabled). Kept for Arabic line wrapping. zaphod77 PR#925 leaves it off (JP text
+            // pre-wrapped in flevel); Arabic needs it since RTL lines can exceed the window width.
             {
-              character_x = (*ff7_externals.field_current_window_pos_x_DC3CB4) + 16;
-              character_y += 32;
-              ++ff7_externals.field_text_line_row_DC3CB8;
-            }*/
+              int character_advance = (*ff7_externals.dword_DC3CD4)
+                ? 30
+                : leftPadding + (int)std::ceil(z_half_width(charWidth) * scaleFactor);
+              if ( character_x - (*ff7_externals.field_current_window_pos_x_DC3CB4) + character_advance > text_box_right_position )
+              {
+                character_x = (*ff7_externals.field_current_window_pos_x_DC3CB4) + 20;
+                _lsq_acc += multibyte_field_linestep_q;
+                character_y += _lsq_acc / 4; _lsq_acc %= 4;
+                ++(*ff7_externals.field_text_line_row_DC3CB8);   // deref: soft-wrap advances the real row (see newline block).
+              }
+            }
             if ( !(*ff7_externals.dword_DC3CD4) ) // if not going to next window
               character_x += leftPadding; // apply padding 
                            //* ((int)*(unsigned __int8 *)((*ff7_externals.g_text_spacing_DB958C) + text_offset_spacing + current_character) >> 5);*/
@@ -736,7 +825,7 @@ LABEL_39:
             if ( (*ff7_externals.dword_DC3CD4) )  // if goign to next window
               character_x += 30; // extra padding
             else
-              character_x += std::ceil(0.5f * charWidth*scaleFactor); // scaled up to match scaling we did above
+              character_x += std::ceil(z_half_width(charWidth)*scaleFactor); // scaled up to match scaling we did above
             --(*ff7_externals.field_remaining_character_length_DC3CCC);
             ++buffer_text;
             ++(*ff7_externals.field_text_box_curr_n_characters_DC3CB0);
@@ -1019,6 +1108,8 @@ void field_draw_text_boxes_and_text_graphics_object_6ECA68_jp()
 
 int common_submit_draw_char_from_buffer_6F564E_jp(int x, int vertex_y, int n_shapes, unsigned __int16 letter, float z_value)
 {
+  multibyte_load_widths();   // 1s-gated hot-reload for live width tuning
+
   // FIXME: this function can draw characters with different scaling, dependent on what sorta text is being printed.
   // But it needs to know what the source of hte text that was put into the buffer was to work this out, and that info is NOT passed as a parameter
   // will need to hook the function that loads texts to the buffer and set a global based on where in memory the original text is.
@@ -1265,7 +1356,7 @@ int common_submit_draw_char_from_buffer_6F564E_jp(int x, int vertex_y, int n_sha
       return vertex_x + std::ceil(0.5f * charWidth) * 1.6666666;//(__int64)((double)(*(byte *)(*ff7_externals.g_text_spacing_DB958C + offset_text_spacing + letter) & 0x1F) * 1.6666666)
            //+ vertex_x;
     else*/
-    return vertex_x + std::ceil(0.5f * charWidth * scaleFactor);// 2 * (*(byte *)(*ff7_externals.g_text_spacing_DB958C + offset_text_spacing + letter) & 0x1F);
+    return vertex_x + std::ceil(z_half_width(charWidth) * scaleFactor);// 2 * (*(byte *)(*ff7_externals.g_text_spacing_DB958C + offset_text_spacing + letter) & 0x1F);
   }
 }
 
@@ -1633,7 +1724,7 @@ void draw_text_top_display_6D1CC0_jp(int a1, __int16 menu_box_idx, char a3, unsi
           text_sub_41963C = (attack_name_fixed_buffer *)((char *)text_sub_41963C + 1);
           charWidth = charWidthData[1][*(byte*)(text_sub_41963C)] & 0x1F;
           leftPadding = charWidthData[1][*(byte*)(text_sub_41963C)] >> 5;
-          v106 += leftPadding + std::ceil(0.5f * charWidth);
+          v106 += leftPadding + std::ceil(z_half_width(charWidth));
           isKanjiDetected = true;
           //v106 += 2 * (*(byte *)(*ff7_externals.g_text_spacing_DB958C + text_sub_41963C->name[0] + 231) & 0x1F)
           //      + 2 * ((int)*(unsigned __int8 *)(*ff7_externals.g_text_spacing_DB958C + text_sub_41963C->name[0] + 231) >> 5);
@@ -1643,7 +1734,7 @@ void draw_text_top_display_6D1CC0_jp(int a1, __int16 menu_box_idx, char a3, unsi
           text_sub_41963C = (attack_name_fixed_buffer *)((char *)text_sub_41963C + 1);
           charWidth = charWidthData[2][*(byte*)(text_sub_41963C)] & 0x1F;
           leftPadding = charWidthData[2][*(byte*)(text_sub_41963C)] >> 5;
-          v106 += leftPadding + std::ceil(0.5f * charWidth);
+          v106 += leftPadding + std::ceil(z_half_width(charWidth));
           isKanjiDetected = true;
           //v106 += 2 * (*(byte *)(*ff7_externals.g_text_spacing_DB958C + text_sub_41963C->name[0] + 441) & 0x1F)
           //      + 2 * ((int)*(unsigned __int8 *)(*ff7_externals.g_text_spacing_DB958C + text_sub_41963C->name[0] + 441) >> 5);
@@ -1653,7 +1744,7 @@ void draw_text_top_display_6D1CC0_jp(int a1, __int16 menu_box_idx, char a3, unsi
           text_sub_41963C = (attack_name_fixed_buffer *)((char *)text_sub_41963C + 1);
           charWidth = charWidthData[3][*(byte*)(text_sub_41963C)] & 0x1F;
           leftPadding = charWidthData[3][*(byte*)(text_sub_41963C)] >> 5;
-          v106 += leftPadding + std::ceil(0.5f * charWidth);
+          v106 += leftPadding + std::ceil(z_half_width(charWidth));
           isKanjiDetected = true;
           //v106 += 2 * (*(byte *)(*ff7_externals.g_text_spacing_DB958C + text_sub_41963C->name[0] + 672) & 0x1F)
           //      + 2 * ((int)*(unsigned __int8 *)(*ff7_externals.g_text_spacing_DB958C + text_sub_41963C->name[0] + 672) >> 5);
@@ -1663,7 +1754,7 @@ void draw_text_top_display_6D1CC0_jp(int a1, __int16 menu_box_idx, char a3, unsi
           text_sub_41963C = (attack_name_fixed_buffer *)((char *)text_sub_41963C + 1);
           charWidth = charWidthData[4][*(byte*)(text_sub_41963C)] & 0x1F;
           leftPadding = charWidthData[4][*(byte*)(text_sub_41963C)] >> 5;
-          v106 += leftPadding + std::ceil(0.5f * charWidth);
+          v106 += leftPadding + std::ceil(z_half_width(charWidth));
           isKanjiDetected = true;
           //v106 += 2 * (*(byte *)(*ff7_externals.g_text_spacing_DB958C + text_sub_41963C->name[0] + 672) & 0x1F)
           //      + 2 * ((int)*(unsigned __int8 *)(*ff7_externals.g_text_spacing_DB958C + text_sub_41963C->name[0] + 672) >> 5);
@@ -1673,7 +1764,7 @@ void draw_text_top_display_6D1CC0_jp(int a1, __int16 menu_box_idx, char a3, unsi
           text_sub_41963C = (attack_name_fixed_buffer *)((char *)text_sub_41963C + 1);
           charWidth = charWidthData[5][*(byte*)(text_sub_41963C)] & 0x1F;
           leftPadding = charWidthData[5][*(byte*)(text_sub_41963C)] >> 5;
-          v106 += leftPadding + std::ceil(0.5f * charWidth);
+          v106 += leftPadding + std::ceil(z_half_width(charWidth));
           isKanjiDetected = true;
           //v106 += 2 * (*(byte *)(*ff7_externals.g_text_spacing_DB958C + text_sub_41963C->name[0] + 672) & 0x1F)
           //      + 2 * ((int)*(unsigned __int8 *)(*ff7_externals.g_text_spacing_DB958C + text_sub_41963C->name[0] + 672) >> 5);
@@ -1688,7 +1779,7 @@ void draw_text_top_display_6D1CC0_jp(int a1, __int16 menu_box_idx, char a3, unsi
           {
             charWidth = charWidthData[0][*(byte*)(text_sub_41963C)] & 0x1F;
             leftPadding = charWidthData[0][*(byte*)(text_sub_41963C)] >> 5;
-            v106 += leftPadding + std::ceil(0.5f * charWidth);
+            v106 += leftPadding + std::ceil(z_half_width(charWidth));
           }
           isKanjiDetected = false;
           //v106 += 2 * (*(byte *)(*ff7_externals.g_text_spacing_DB958C + text_sub_41963C->name[0]) & 0x1F)
@@ -1851,7 +1942,7 @@ LABEL_49:
             a2->field_7C = 14;
           }
           v135 = (attack_name_fixed_buffer *)((char *)v135 + 1);
-          v107 = v96 + v108+ std::ceil(0.5f * charWidth*scaleFactor); // character width+padding+previous centering offset.
+          v107 = v96 + v108+ std::ceil(z_half_width(charWidth)*scaleFactor); // character width+padding+previous centering offset.
 LABEL_31:
           ++v120;
           break;
@@ -2311,7 +2402,7 @@ void main_menu_draw_everything_maybe_6C0B91_jp()
 void auto_resize_text_box(int16_t WINDOW_ID, int16_t* pOutW, int16_t* pOutH)
 {
   // as many textboxes in flevel are set wrong, we need to resize them.
-  float scaleFactor = 1.25f; // resizer neeeds to scale too
+  float scaleFactor = ff7_japanese_edition ? 1.25f : 1.0f; // resizer needs to match the draw scale (JP 1.25 / multibyte EN 1.0)
 	int16_t W = 0;
 	int16_t H = 0;
 	int16_t maxW = 0; // used to remember the longest row so far.
@@ -2396,7 +2487,7 @@ void auto_resize_text_box(int16_t WINDOW_ID, int16_t* pOutW, int16_t* pOutH)
 
         charWidth = charWidthData[0][name_char] & 0x1F;
         leftPadding = charWidthData[0][name_char] >> 5;
-        W += leftPadding + std::ceil(0.5f * charWidth);
+        W += leftPadding + std::ceil(z_half_width(charWidth));
       }
       
       continue; // back to the start, we already added to the length
@@ -2429,7 +2520,7 @@ void auto_resize_text_box(int16_t WINDOW_ID, int16_t* pOutW, int16_t* pOutH)
 		{
       maxW = std::max(maxW, W); // update max
       W = 0;
-			H += 32;
+			H += multibyte_field_linestep_q / 4;
       continue;
 		}
 		if(character == 0xE9 || character == 0xE8) // next window
@@ -2441,7 +2532,7 @@ void auto_resize_text_box(int16_t WINDOW_ID, int16_t* pOutW, int16_t* pOutH)
       continue;
 		}
 
-		W += leftPadding + std::ceil(0.5f * charWidth); // if we get here, normal charcter, OR fixed string. add char width
+		W += leftPadding + std::ceil(z_half_width(charWidth)); // if we get here, normal charcter, OR fixed string. add char width
 	}
   float pOutWtmp = (std::max(maxW, W) + 40) * scaleFactor;  // make calculated length bigger, but not height.
   // final sanity check
@@ -2457,13 +2548,30 @@ void field_text_box_window_opening_6317A9_jp(short WINDOW_ID)
 {
   int16_t W = 0;
   int16_t H = 0;
+  // The vanilla create routine (0x631586) assigns this window's owner (CC0960[win] = the entity
+  // that opened it) before marking it active, and clears both owner and mode together on close.
+  // On the multibyte path a window can end up active with no owner assigned (0xFF) — the owner
+  // check below then never matches the current entity, the window never grows, and the field
+  // script that's waiting on it deadlocks. Restore the normal owner assignment for any window
+  // found in this orphaned state before continuing.
+  if ( ff7_externals.field_text_box_window_entity_id_CC0960[WINDOW_ID] == 0xFF )
+    ff7_externals.field_text_box_window_entity_id_CC0960[WINDOW_ID] = *ff7_externals.current_entity_id_byte_CC0964;
   int16_t originalW = ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_width;  // store original width
-  int16_t originalH = ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_height; // and height. just in case we need to set it back later. 
-  auto_resize_text_box(WINDOW_ID, &W, &H);                                                      // haven't needed to do it yet, but we might.
-  if (ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_pos_x < 0)
-    ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_pos_x = 0;                // if off the left, move it back on. :)
-  ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_width = W;
-  ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_height = H;
+  int16_t originalH = ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_height; // and height. just in case we need to set it back later.
+  // auto_resize_text_box recomputes the window's target width/height from the text every time
+  // it's called, including reading back the values it wrote the previous call — so calling it
+  // every frame makes the target keep moving and the window's grow animation never reaches it,
+  // stalling the open. Instead, compute the target once here while the window is still small,
+  // then hold width/height fixed so the animation converges normally, matching vanilla behavior.
+  // Field files already ship with correctly sized windows, so this only fixes the animation target.
+  if ( ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].current_window_width < 8 )
+  {
+    auto_resize_text_box(WINDOW_ID, &W, &H);
+    if (ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_pos_x < 0)
+      ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_pos_x = 0;              // if off the left, move it back on. :)
+    ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_width = W;
+    ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_height = H;
+  }
   if ( ff7_externals.field_text_box_window_entity_id_CC0960[WINDOW_ID] == *ff7_externals.current_entity_id_byte_CC0964 )
   {
     ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].current_window_width += ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_width
@@ -2491,7 +2599,7 @@ int sub_6F54A2_jp(byte *a1) // this function appears to affect aligning stuff to
   int v2; // [esp+Ch] [ebp-Ch]
   int v3; // [esp+10h] [ebp-8h]
   int v4; // [esp+14h] [ebp-4h]
-  float scaleFactor = 1.25f; //even if text is small, treat as large for x alignment with pointers
+  float scaleFactor = ff7_japanese_edition ? 1.25f : 1.0f; //JP: treat as large for pointer alignment; multibyte EN: native 1.0
   v3 = 0;
   v2 = 0;
   bool kanjiDetected = false;
@@ -2582,7 +2690,7 @@ int sub_6F54A2_jp(byte *a1) // this function appears to affect aligning stuff to
     else
       v2 += 2 * ((int)*(unsigned __int8 *)(ff7_externals.g_text_spacing_DB958C + v4 + (unsigned __int8)*a1) >> 5)
           + 2 * (*(byte *)(ff7_externals.g_text_spacing_DB958C + v4 + (unsigned __int8)*a1) & 0x1F);*/
-    v2 += leftPadding + std::ceil(std::ceil(0.5f*charWidth)*scaleFactor); // round after EACH multiplication should align properly with pointers. hooray for inherited jank from no FP in PS1
+    v2 += leftPadding + std::ceil(std::ceil(z_half_width(charWidth))*scaleFactor); // round after EACH multiplication should align properly with pointers. hooray for inherited jank from no FP in PS1
     ++a1;
     ++v3;
   }

--- a/src/ff7/japanese_text.cpp
+++ b/src/ff7/japanese_text.cpp
@@ -16,6 +16,7 @@
 #include "../log.h"
 #include "../ff7.h"
 #include "../patch.h"
+#include "../redirect.h"
 #include <string.h>
 
 static void multibyte_load_widths();
@@ -435,6 +436,15 @@ static inline float z_half_width(int w) { return ff7_japanese_edition ? std::cei
 static byte multibyte_icon_mask[256] = {0};
 static int multibyte_field_linestep_q = 128;   // field line advance in QUARTER px (128 = 32.0), live-tunable
 
+// Resolve a multibyte tuning file through the standard layers: override_path first, then the
+// per-release data path (data/lang-*/kernel on Steam/GOG/Store/2026, data/kernel on 1998).
+static bool multibyte_resolve_path(const char *name, char *out, size_t out_size)
+{
+  char in[MAX_PATH]{ 0 };
+  _snprintf(in, sizeof(in), R"(data\kernel\%s)", name);
+  return redirect_path_with_override(in, out, out_size) != 1;
+}
+
 static void multibyte_load_widths()
 {
   // Hot-reload: re-read the widths file whenever its mtime changes (checked at most 1x/sec),
@@ -446,23 +456,20 @@ static void multibyte_load_widths()
   DWORD now = GetTickCount();
   if (tried && (now - last_check) < 1000) return;
   last_check = now;
-  char path[BASEDIR_LENGTH + 32];
+  char path[MAX_PATH]{ 0 };
   // line step re-read every 1s tick — must NOT sit behind the widths mtime gate,
   // or moving only the spacing slider never reaches it
-  _snprintf(path, sizeof(path), "%s/multibyte_linestep.bin", basedir);
+  multibyte_resolve_path("multibyte_linestep.bin", path, sizeof(path));
   FILE *lf = fopen(path, "rb");
   if (lf)
   {
     unsigned char lb[2]; size_t ln = fread(lb, 1, 2, lf);
     int q = (ln == 2) ? (lb[0] | (lb[1] << 8)) : (ln == 1 ? lb[0] * 4 : 0);  // 1-byte legacy = whole px
     if (q >= 80 && q <= 160 && q != multibyte_field_linestep_q)
-    {
       multibyte_field_linestep_q = q;
-      ffnx_info("ff7_multibyte_font: field line step = %d.%02d px\n", q / 4, (q % 4) * 25);
-    }
     fclose(lf);
   }
-  _snprintf(path, sizeof(path), "%s/multibyte_widths.bin", basedir);
+  multibyte_resolve_path("multibyte_widths.bin", path, sizeof(path));
   struct _stat64 st;
   bool first = !tried;
   if (_stat64(path, &st) == 0)
@@ -472,24 +479,22 @@ static void multibyte_load_widths()
   }
   tried = true;
   FILE *f = fopen(path, "rb");
-  if (!f) { if (first) ffnx_info("ff7_multibyte_font: no %s, using built-in widths\n", path); return; }
+  if (!f) return;
   unsigned char buf[6 * 256];
   if (fread(buf, 1, sizeof(buf), f) == sizeof(buf))
   {
     for (int i = 0; i < 6; i++)
       for (int j = 0; j < 256; j++)
         charWidthData[i][j] = buf[i * 256 + j];
-    ffnx_info("ff7_multibyte_font: widths %s\n", first ? "loaded" : "RELOADED (live)");
   }
   else ffnx_error("ff7_multibyte_font: %s wrong size (need 1536 bytes)\n", path);
   fclose(f);
   if (!first) return;
-  _snprintf(path, sizeof(path), "%s/multibyte_iconmask.bin", basedir);
+  multibyte_resolve_path("multibyte_iconmask.bin", path, sizeof(path));
   f = fopen(path, "rb");
   if (f)
   {
-    if (fread(multibyte_icon_mask, 1, 256, f) == 256)
-      ffnx_info("ff7_multibyte_font: icon mask loaded\n");
+    fread(multibyte_icon_mask, 1, 256, f);
     fclose(f);
   }
 }

--- a/src/ff7/japanese_text.cpp
+++ b/src/ff7/japanese_text.cpp
@@ -429,7 +429,7 @@ int charWidthData[6][256] =
 // JP keeps the original half-width semantics (32px texel cells -> 16 units).
 static inline float z_half_width(int w) { return ff7_japanese_edition ? std::ceil(0.5f * (float)w) : (float)w; }
 
-// multibyte_font: override the hardcoded width table from <basedir>/multibyte_widths.bin
+// ff7_multibyte_font: override the hardcoded width table from <basedir>/multibyte_widths.bin
 // (6*256 bytes, one per font sheet/code, same (pad<<5|width) packing as window.bin member 3),
 // so translations can tune advances without recompiling FFNx.
 static byte multibyte_icon_mask[256] = {0};
@@ -442,7 +442,7 @@ static void multibyte_load_widths()
   static bool tried = false;
   static long long last_mtime = -1;
   static DWORD last_check = 0;
-  if (!multibyte_font) return;
+  if (!ff7_multibyte_font) return;
   DWORD now = GetTickCount();
   if (tried && (now - last_check) < 1000) return;
   last_check = now;
@@ -458,7 +458,7 @@ static void multibyte_load_widths()
     if (q >= 80 && q <= 160 && q != multibyte_field_linestep_q)
     {
       multibyte_field_linestep_q = q;
-      ffnx_info("multibyte_font: field line step = %d.%02d px\n", q / 4, (q % 4) * 25);
+      ffnx_info("ff7_multibyte_font: field line step = %d.%02d px\n", q / 4, (q % 4) * 25);
     }
     fclose(lf);
   }
@@ -472,16 +472,16 @@ static void multibyte_load_widths()
   }
   tried = true;
   FILE *f = fopen(path, "rb");
-  if (!f) { if (first) ffnx_info("multibyte_font: no %s, using built-in widths\n", path); return; }
+  if (!f) { if (first) ffnx_info("ff7_multibyte_font: no %s, using built-in widths\n", path); return; }
   unsigned char buf[6 * 256];
   if (fread(buf, 1, sizeof(buf), f) == sizeof(buf))
   {
     for (int i = 0; i < 6; i++)
       for (int j = 0; j < 256; j++)
         charWidthData[i][j] = buf[i * 256 + j];
-    ffnx_info("multibyte_font: widths %s\n", first ? "loaded" : "RELOADED (live)");
+    ffnx_info("ff7_multibyte_font: widths %s\n", first ? "loaded" : "RELOADED (live)");
   }
-  else ffnx_error("multibyte_font: %s wrong size (need 1536 bytes)\n", path);
+  else ffnx_error("ff7_multibyte_font: %s wrong size (need 1536 bytes)\n", path);
   fclose(f);
   if (!first) return;
   _snprintf(path, sizeof(path), "%s/multibyte_iconmask.bin", basedir);
@@ -489,7 +489,7 @@ static void multibyte_load_widths()
   if (f)
   {
     if (fread(multibyte_icon_mask, 1, 256, f) == 256)
-      ffnx_info("multibyte_font: icon mask loaded\n");
+      ffnx_info("ff7_multibyte_font: icon mask loaded\n");
     fclose(f);
   }
 }

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -380,13 +380,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	// Shared multi-font glyph space (extra jafont_2..6 via FA-FE escape bytes): needed by BOTH the JP
 	// edition AND English-exe multibyte translations (e.g. Arabic). Only the font LOAD + per-char draw
 	// are shared; the remaining hooks below are JP-only layout that breaks native EN menus.
-	ffnx_info("multibyte hook install check: multibyte_font=%d ff7_japanese_edition=%d\n", multibyte_font, ff7_japanese_edition);
-	ffnx_info("mb-ext: load_menu=%X submit_char=%X sub_6F54A2=%X field_submit=%X field_boxes=%X menu_draw=%X battle_draw=%X mainmenu_draw=%X\n",
-		(uint32_t)ff7_externals.engine_load_menu_graphics_objects_6C1468, (uint32_t)ff7_externals.common_submit_draw_char_from_buffer_6F564E,
-		ff7_externals.sub_6F54A2, ff7_externals.field_submit_draw_text_640x480_6E706D,
-		(uint32_t)ff7_externals.field_draw_text_boxes_and_text_graphics_object_6ECA68, (uint32_t)ff7_externals.menu_draw_everything_6CC9D3,
-		(uint32_t)ff7_externals.battle_draw_menu_everything_6CEE84, (uint32_t)ff7_externals.main_menu_draw_everything_maybe_6C0B91);
-	if (ff7_japanese_edition || multibyte_font)
+	if (ff7_japanese_edition || ff7_multibyte_font)
 	{
 		replace_function((uint32_t)ff7_externals.engine_load_menu_graphics_objects_6C1468, engine_load_menu_graphics_objects_6C1468_jp);
 		replace_function((uint32_t)ff7_externals.common_submit_draw_char_from_buffer_6F564E, common_submit_draw_char_from_buffer_6F564E_jp);
@@ -394,15 +388,15 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		// jafont glyph FLUSH + field char submitter — without these, multibyte glyphs queue but never draw
 		replace_function(ff7_externals.field_submit_draw_text_640x480_6E706D, field_submit_draw_text_640x480_6E706D_jp);
 		replace_function((uint32_t)ff7_externals.field_draw_text_boxes_and_text_graphics_object_6ECA68, field_draw_text_boxes_and_text_graphics_object_6ECA68_jp);
-		replace_function((uint32_t)	ff7_externals.menu_draw_everything_6CC9D3, menu_draw_everything_6CC9D3_jp);
-		replace_function((uint32_t)	ff7_externals.battle_draw_menu_everything_6CEE84, battle_draw_menu_everything_6CEE84_jp);
-		replace_function((uint32_t)	ff7_externals.main_menu_draw_everything_maybe_6C0B91, main_menu_draw_everything_maybe_6C0B91_jp);
+		replace_function((uint32_t)ff7_externals.menu_draw_everything_6CC9D3, menu_draw_everything_6CC9D3_jp);
+		replace_function((uint32_t)ff7_externals.battle_draw_menu_everything_6CEE84, battle_draw_menu_everything_6CEE84_jp);
+		replace_function((uint32_t)ff7_externals.main_menu_draw_everything_maybe_6C0B91, main_menu_draw_everything_maybe_6C0B91_jp);
 		// battle top-display bar (draw_text_top_display_6D1CC0): shares the same per-char draw path as the
-		// rest of multibyte text. Without this hook, English-exe multibyte_font mode (Arabic) falls through
+		// rest of multibyte text. Without this hook, English-exe ff7_multibyte_font mode (Arabic) falls through
 		// to the vanilla single-byte draw for this specific bar -> Arabic byte codes get reinterpreted as
 		// vanilla Latin glyph indices -> garbled text (2026-07-09, reported in-battle). Moved here (out of
-		// the ff7_japanese_edition-only block below) since it's needed by BOTH JP edition and multibyte_font.
-		replace_function((uint32_t)	ff7_externals.draw_text_top_display_6D1CC0, draw_text_top_display_6D1CC0_jp);
+		// the ff7_japanese_edition-only block below) since it's needed by BOTH JP edition and ff7_multibyte_font.
+		replace_function((uint32_t)ff7_externals.draw_text_top_display_6D1CC0, draw_text_top_display_6D1CC0_jp);
 	}
 	if (ff7_japanese_edition)
 	{
@@ -419,8 +413,6 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		patch_code_byte(0x632C4E + 0x2, 0xC);
 		patch_code_byte(0x632C4E + 0x3, 0xC);
 		patch_code_byte(0x632C4E + 0x4, 0xC);
-
-		// sub_6F54A2 hook lives in the shared (ff7_japanese_edition || multibyte_font) block above.
 
 		// 3-mode (hiragana/katakana/eisuu) name-entry screen
 		name_input_jp_install();

--- a/src/ff7_opengl.cpp
+++ b/src/ff7_opengl.cpp
@@ -377,17 +377,41 @@ void ff7_init_hooks(struct game_obj *_game_object)
 	// ###########################
 	// japanese text
 	// ###########################
-	if (ff7_japanese_edition)
+	// Shared multi-font glyph space (extra jafont_2..6 via FA-FE escape bytes): needed by BOTH the JP
+	// edition AND English-exe multibyte translations (e.g. Arabic). Only the font LOAD + per-char draw
+	// are shared; the remaining hooks below are JP-only layout that breaks native EN menus.
+	ffnx_info("multibyte hook install check: multibyte_font=%d ff7_japanese_edition=%d\n", multibyte_font, ff7_japanese_edition);
+	ffnx_info("mb-ext: load_menu=%X submit_char=%X sub_6F54A2=%X field_submit=%X field_boxes=%X menu_draw=%X battle_draw=%X mainmenu_draw=%X\n",
+		(uint32_t)ff7_externals.engine_load_menu_graphics_objects_6C1468, (uint32_t)ff7_externals.common_submit_draw_char_from_buffer_6F564E,
+		ff7_externals.sub_6F54A2, ff7_externals.field_submit_draw_text_640x480_6E706D,
+		(uint32_t)ff7_externals.field_draw_text_boxes_and_text_graphics_object_6ECA68, (uint32_t)ff7_externals.menu_draw_everything_6CC9D3,
+		(uint32_t)ff7_externals.battle_draw_menu_everything_6CEE84, (uint32_t)ff7_externals.main_menu_draw_everything_maybe_6C0B91);
+	if (ff7_japanese_edition || multibyte_font)
 	{
-		replace_function(ff7_externals.field_submit_draw_text_640x480_6E706D, field_submit_draw_text_640x480_6E706D_jp);
 		replace_function((uint32_t)ff7_externals.engine_load_menu_graphics_objects_6C1468, engine_load_menu_graphics_objects_6C1468_jp);
-		replace_function((uint32_t)ff7_externals.field_draw_text_boxes_and_text_graphics_object_6ECA68, field_draw_text_boxes_and_text_graphics_object_6ECA68_jp);
 		replace_function((uint32_t)ff7_externals.common_submit_draw_char_from_buffer_6F564E, common_submit_draw_char_from_buffer_6F564E_jp);
+		replace_function(ff7_externals.sub_6F54A2, sub_6F54A2_jp);
+		// jafont glyph FLUSH + field char submitter — without these, multibyte glyphs queue but never draw
+		replace_function(ff7_externals.field_submit_draw_text_640x480_6E706D, field_submit_draw_text_640x480_6E706D_jp);
+		replace_function((uint32_t)ff7_externals.field_draw_text_boxes_and_text_graphics_object_6ECA68, field_draw_text_boxes_and_text_graphics_object_6ECA68_jp);
 		replace_function((uint32_t)	ff7_externals.menu_draw_everything_6CC9D3, menu_draw_everything_6CC9D3_jp);
 		replace_function((uint32_t)	ff7_externals.battle_draw_menu_everything_6CEE84, battle_draw_menu_everything_6CEE84_jp);
-		replace_function((uint32_t)	ff7_externals.draw_text_top_display_6D1CC0, draw_text_top_display_6D1CC0_jp);
 		replace_function((uint32_t)	ff7_externals.main_menu_draw_everything_maybe_6C0B91, main_menu_draw_everything_maybe_6C0B91_jp);
+		// battle top-display bar (draw_text_top_display_6D1CC0): shares the same per-char draw path as the
+		// rest of multibyte text. Without this hook, English-exe multibyte_font mode (Arabic) falls through
+		// to the vanilla single-byte draw for this specific bar -> Arabic byte codes get reinterpreted as
+		// vanilla Latin glyph indices -> garbled text (2026-07-09, reported in-battle). Moved here (out of
+		// the ff7_japanese_edition-only block below) since it's needed by BOTH JP edition and multibyte_font.
+		replace_function((uint32_t)	ff7_externals.draw_text_top_display_6D1CC0, draw_text_top_display_6D1CC0_jp);
+	}
+	if (ff7_japanese_edition)
+	{
 		//replace_function((uint32_t)	ff7_externals.field_text_box_window_paging_631945, field_text_box_window_paging_631945_jp);
+		// This hook is JP-edition only: its window auto-resize can feed back into itself across
+		// frames (each call recomputes the target size from values it wrote the previous frame),
+		// which can prevent multi-window field scenes from ever finishing their open animation.
+		// The English-exe multibyte path avoids this by using the vanilla opening function and
+		// relying on field files that already ship with correctly sized windows.
 		replace_function((uint32_t)	ff7_externals.field_text_box_window_opening_6317A9, field_text_box_window_opening_6317A9_jp);
 
 		patch_code_byte(0x632C4E, 0xC);
@@ -396,7 +420,7 @@ void ff7_init_hooks(struct game_obj *_game_object)
 		patch_code_byte(0x632C4E + 0x3, 0xC);
 		patch_code_byte(0x632C4E + 0x4, 0xC);
 
-		replace_function(ff7_externals.sub_6F54A2, sub_6F54A2_jp);
+		// sub_6F54A2 hook lives in the shared (ff7_japanese_edition || multibyte_font) block above.
 
 		// 3-mode (hiragana/katakana/eisuu) name-entry screen
 		name_input_jp_install();

--- a/src/globals.h
+++ b/src/globals.h
@@ -55,7 +55,7 @@ extern uint32_t steam_stock_launcher;
 extern uint32_t estore_edition;
 extern uint32_t ff7_2026_rerelease;
 extern uint32_t ff7_japanese_edition;
-extern uint32_t multibyte_font;
+extern uint32_t ff7_multibyte_font;
 extern uint32_t ff7_do_reset;
 
 #define BASEDIR_LENGTH 512

--- a/src/globals.h
+++ b/src/globals.h
@@ -55,6 +55,7 @@ extern uint32_t steam_stock_launcher;
 extern uint32_t estore_edition;
 extern uint32_t ff7_2026_rerelease;
 extern uint32_t ff7_japanese_edition;
+extern uint32_t multibyte_font;
 extern uint32_t ff7_do_reset;
 
 #define BASEDIR_LENGTH 512


### PR DESCRIPTION
Adds a `multibyte_font` config flag, separate from `ff7_japanese_edition`. It enables the extra font glyph space (jafont_2..6 via escape codes) and the multibyte width/draw system, for English-exe translations that need more glyphs than the base charset gives you — I built this against Arabic. It skips the JP-only menu scaling/layout, since that breaks native English menus.

Three engine bugs turned up while testing this — all general correctness bugs, not multibyte-specific, I just happened to hit them here:

- `field_submit_draw_text_640x480_jp` incremented a pointer instead of dereferencing it when counting newlines, so the field engine's line-row counter never moved. The window-close handshake waits on that counter, so multi-line messages could stall indefinitely.
- `field_text_box_window_opening_jp` could leave a window active with no owner assigned if it got there via the multibyte draw path — the owner check that lets a window grow then never passes, and the field script waiting on it hangs.
- Same function's auto-resize recomputed its grow target from the previous frame's output every frame. On multi-window scenes the target kept moving and the grow animation never finished.
- `draw_text_top_display_jp` (battle top message bar) was only hooked for `ff7_japanese_edition`. Multibyte text through this specific bar fell through to the vanilla single-byte draw and came out garbled. Moved it into the shared hook block.

Also added a live width-tuning system (`multibyte_widths.bin` / `multibyte_linestep.bin`, hot-reloaded off disk), so a translation project can tune per-character spacing without rebuilding FFNx.

Tested against a full Arabic localization of FF7, 713 field maps. The window-stall fix resolves what was a 100%-reproducible soft-lock. The top-display fix resolves garbled battle text. No regressions in `ff7_japanese_edition` — everything new is gated behind the flag or falls back to the existing JP path.