### PR TITLE
FF8: Disable bilinear filtering in worldmap for external textures

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,10 @@
 
 - Core: Add native support for japanese text rendering ( https://github.com/julianxhokaxhiu/FFNx/pull/737 + https://github.com/julianxhokaxhiu/FFNx/pull/925 + https://github.com/julianxhokaxhiu/FFNx/pull/952 + https://github.com/julianxhokaxhiu/FFNx/pull/953 + https://github.com/julianxhokaxhiu/FFNx/pull/951) 
 
+## FF8
+
+- External textures: Disable texture filtering in worldmap when filtering is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/954 )
+
 # 1.24.3
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.24.2...1.24.3

--- a/src/gl/special_case.cpp
+++ b/src/gl/special_case.cpp
@@ -46,6 +46,9 @@ uint32_t gl_special_case(uint32_t primitivetype, uint32_t vertextype, struct nve
 	// Force disabling filter for ff7 minigames internal textures
 	if(!ff8 && (mode == MODE_SUBMARINE || mode == MODE_COASTER) && !isExternalTexture) current_state.texture_filter = false;
 
+	// Force disabling filter for ff8 worldmap
+	if(ff8 && mode == MODE_WORLDMAP && (isExternalTexture || ff8_worldmap_internal_highres_textures)) current_state.texture_filter = false;
+
 	// some modpath textures have filtering forced on
 	if(current_state.texture_set && VREF(texture_set, ogl.gl_set->force_filter) && isExternalTexture) current_state.texture_filter = true;
 


### PR DESCRIPTION
## Summary

Disable bilinear filtering in worldmap for external textures and ff8_worldmap_internal_highres_textures flag

### Motivation

Fixes #942

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
