### PR TITLE
FF8: Allow loading more monster files up to 199

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,7 +14,7 @@
 
 ## FF8
 
-- Core: Unlock unused battle monster models c0m144-c0m199 (EN/FR/DE/IT/SP/JP), selectable via `enemy_com_value` 160-215 in scene.out ( not yet a PR - branch `AllMonsterFilesUsable` )
+- Core: Unlock unused battle monster models c0m144-c0m199 (EN/FR/DE/IT/SP/JP), selectable via `enemy_com_value` 160-215 in scene.out
 
 # 1.24.3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,10 @@
 
 - Core: Add native support for japanese text rendering ( https://github.com/julianxhokaxhiu/FFNx/pull/737 + https://github.com/julianxhokaxhiu/FFNx/pull/925 + https://github.com/julianxhokaxhiu/FFNx/pull/952 + https://github.com/julianxhokaxhiu/FFNx/pull/953 + https://github.com/julianxhokaxhiu/FFNx/pull/951) 
 
+## FF8
+
+- Core: Unlock unused battle monster models c0m144-c0m199 (EN/FR/DE/IT/SP/JP), selectable via `enemy_com_value` 160-215 in scene.out ( not yet a PR - branch `AllMonsterFilesUsable` )
+
 # 1.24.3
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.24.2...1.24.3

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1623,6 +1623,7 @@ struct ff8_externals
 	uint32_t battle_open_file_wrapper;
 	uint32_t battle_open_file;
 	char **battle_filenames;
+	uint32_t battle_monster_dat_loader_com_id_add_site; // "add eax, 96h" (com_id + 150) inside battle_monster_dat_loader; only reachable per-version, not via a relative-call chain (see ff8_data.cpp). 0 if unmapped for the running version.
 	uint32_t battle_load_textures_sub_500900;
 	uint32_t loc_5005A0;
 	uint32_t battle_upload_texture_to_vram;

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1623,7 +1623,7 @@ struct ff8_externals
 	uint32_t battle_open_file_wrapper;
 	uint32_t battle_open_file;
 	char **battle_filenames;
-	uint32_t battle_monster_dat_loader_com_id_add_site; // "add eax, 96h" (com_id + 150) inside battle_monster_dat_loader; only reachable per-version, not via a relative-call chain (see ff8_data.cpp). 0 if unmapped for the running version.
+	uint32_t battle_monster_dat_loader_com_id_add_site; // "add eax, 96h" (com_id + 150) inside battle_monster_dat_loader, derived from battle_monster_dat_loader + 0x23A (see ff8_data.cpp).
 	uint32_t battle_load_textures_sub_500900;
 	uint32_t loc_5005A0;
 	uint32_t battle_upload_texture_to_vram;
@@ -1670,6 +1670,9 @@ struct ff8_externals
 	DWORD* battle_current_actor_talking;
 	uint32_t sub_502380;
 	uint32_t sub_50A790;
+	uint32_t sub_50B830; // embedded pointer read out of sub_50A790 ("mov eax, offset ...")
+	uint32_t battle_task_dispatch_com_entity_load; // resolved via a call inside sub_50B830
+	uint32_t battle_monster_dat_loader; // embedded pointer read out of battle_task_dispatch_com_entity_load
 	uint32_t sub_50A9A0;
 	uint32_t battle_read_effect_sub_50AF20;
 	DWORD* func_off_battle_effects_C81774;

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1623,7 +1623,7 @@ struct ff8_externals
 	uint32_t battle_open_file_wrapper;
 	uint32_t battle_open_file;
 	char **battle_filenames;
-	uint32_t battle_monster_dat_loader_com_id_add_site; // "add eax, 96h" (com_id + 150) inside battle_monster_dat_loader, derived from battle_monster_dat_loader + 0x23A (see ff8_data.cpp).
+	uint32_t battle_monster_file_load_call_site; // BattleFile_CharacterLoad call inside battle_monster_dat_loader (+0x240), hooked to unlock c0m144-199 (see ff8_data.cpp / ff8/battle/monsters.cpp).
 	uint32_t battle_load_textures_sub_500900;
 	uint32_t loc_5005A0;
 	uint32_t battle_upload_texture_to_vram;
@@ -1673,6 +1673,7 @@ struct ff8_externals
 	uint32_t sub_50B830; // embedded pointer read out of sub_50A790 ("mov eax, offset ...")
 	uint32_t battle_task_dispatch_com_entity_load; // resolved via a call inside sub_50B830
 	uint32_t battle_monster_dat_loader; // embedded pointer read out of battle_task_dispatch_com_entity_load
+	uint32_t battle_file_character_load; // BattleFile_CharacterLoad, the monster loader's file-load call target (see monsters.cpp)
 	uint32_t sub_50A9A0;
 	uint32_t battle_read_effect_sub_50AF20;
 	DWORD* func_off_battle_effects_C81774;

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1670,10 +1670,12 @@ struct ff8_externals
 	DWORD* battle_current_actor_talking;
 	uint32_t sub_502380;
 	uint32_t sub_50A790;
-	uint32_t sub_50B830; // embedded pointer read out of sub_50A790 ("mov eax, offset ...")
-	uint32_t battle_task_dispatch_com_entity_load; // resolved via a call inside sub_50B830
-	uint32_t battle_monster_dat_loader; // embedded pointer read out of battle_task_dispatch_com_entity_load
-	uint32_t battle_file_character_load; // BattleFile_CharacterLoad, the monster loader's file-load call target (see monsters.cpp)
+	uint32_t sub_502670; // embedded pointer read out of sub_502380 ("push offset ...")
+	uint32_t battle_entity_task_dispatch_sub_507080; // maps a battle entity id to its task function; called from sub_502670
+	uint32_t battle_monster_dat_loader; // sub_507120, the entity task for monsters; embedded pointer read out of the dispatcher
+	uint32_t battle_load_file_sub_508480; // generic "load battle file by index" wrapper, the monster loader's file-load call target (see monsters.cpp)
+	uint32_t battle_enemy_scanned_read_operand;  // disp32 of the ATTACK_TYPE_SCAN "already scanned?" test (see monsters.cpp)
+	uint32_t battle_enemy_scanned_write_operand; // disp32 of the "mark this com_id scanned" or (see monsters.cpp)
 	uint32_t sub_50A9A0;
 	uint32_t battle_read_effect_sub_50AF20;
 	DWORD* func_off_battle_effects_C81774;

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -19,6 +19,7 @@
 #include "../../ff8.h"
 #include "../../patch.h"
 #include "../../globals.h"
+#include "../../cfg.h"
 #include "../../log.h"
 
 #include <stdint.h>
@@ -62,6 +63,22 @@
 // (c0m000..c0m143 at indices 166..309, D0C000.DAT immediately at 310, 1117
 // entries total) is confirmed identical across all seven builds, so
 // FF8_BATTLE_FILES_ARRAY_LEN below is not version-dependent.
+//
+// KNOWN LIMITATION (not fixed by this patch - savemap corruption, not a
+// crash): the Scan/Libra "already scanned" bitfield SG_ENEMY_SCANNED_ONCE
+// (savemap global @ 0x1cfe964, IDA-verified) is only 5 DWORDs (20 bytes),
+// immediately followed in the packed savemap struct by SG_RENZOKUKEN_AUTO /
+// SG_RENZOKUKEN_INDICATOR / SG_ODIN_ANGEL_GILGA_FLAG / SG_TUTORIAL_INFO.
+// Both readers/writers of it - Damage_DispatchByAttackType's ATTACK_TYPE_SCAN
+// case (@0x4925a6) and hasEnemyAlreadyScanned (@0x493810) - index it as
+// SG_ENEMY_SCANNED_ONCE[(unsigned __int8)com_file_id / 32] with NO bounds
+// check, so it's only safe for com_file_id (com_id) 0..159. Every com_id this
+// patch adds (160..215, i.e. c0m144..c0m199) is already past that: Scanning
+// any of the new monsters (Scan spell / Libra / Enc-None chance-scan) writes
+// out of bounds into the Renzokuken/tutorial-flag savemap fields above,
+// silently corrupting them. Not addressed here; would need its own hook on
+// the Scan check/write (same shape as the BattleFile_CharacterLoad hook
+// below) to remap or bound com_id before it reaches SG_ENEMY_SCANNED_ONCE.
 // -------------------------------------------------------------------------
 
 // Length of the original BattleFilesArray (US 1.2), indices 0..1116.
@@ -79,6 +96,9 @@
 #define FF8_FIRST_NEW_FILE_INDEX (FF8_FIRST_NEW_COM_ID + 150) // 310
 #define FF8_LAST_NEW_FILE_INDEX  (FF8_LAST_NEW_COM_ID + 150)  // 365
 
+// Must stay static, not stack-local: ff8_battle_monsters_init() hands the exe
+// (via patch_code_dword) and ff8_externals.battle_filenames a raw pointer into
+// these arrays that's expected to remain valid for the rest of the process.
 static char *ff8_extended_battle_filenames[FF8_BATTLE_FILES_ARRAY_LEN + FF8_NEW_C0M_COUNT];
 static char ff8_extended_c0m_names[FF8_NEW_C0M_COUNT][12]; // "C0M199.DAT" + NUL = 11
 
@@ -103,13 +123,13 @@ void ff8_battle_monsters_init()
 {
 	if (!ff8_externals.battle_monster_file_load_call_site || !ff8_externals.battle_file_character_load)
 	{
-		ffnx_trace("Extra battle monsters (c0m144-c0m199): unsupported game version, skipping.\n");
+		if (trace_all) ffnx_trace("Extra battle monsters (c0m144-c0m199): unsupported game version, skipping.\n");
 		return;
 	}
 
 	if (ff8_externals.battle_filenames == nullptr)
 	{
-		ffnx_trace("Extra battle monsters: battle_filenames not resolved, skipping.\n");
+		if (trace_all) ffnx_trace("Extra battle monsters: battle_filenames not resolved, skipping.\n");
 		return;
 	}
 

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -156,19 +156,20 @@ static_assert(FF8_SCANNED_ONCE_RELOCATE_SIZE >= 32, "must cover the full 0..255 
 #define FF8_SCENE_OUT_ENEMY_COM_VALUE_OFFSET 56
 #define FF8_SCENE_OUT_ENEMY_SLOTS            8
 
-// Both of these are handed to the exe (via patch_code_dword) and to
-// ff8_externals.battle_filenames as raw pointers, so they must stay valid for
-// the rest of the process: heap-allocated once, never freed, and static.
-static char **ff8_extended_battle_filenames = nullptr;
+// Backing storage for the new entries appended to battle_filenames; the table
+// keeps raw pointers into it for the rest of the process, so it must stay
+// static.
 static char ff8_extended_c0m_names[FF8_NEW_C0M_COUNT][12]; // "C0M199.DAT" + NUL = 11
 // Length of the original BattleFilesArray, counted at init (see below).
 static uint32_t ff8_battle_files_count = 0;
 
-// Counts the original BattleFilesArray instead of hardcoding its length. Every
-// entry is a pointer to a filename string inside the loaded module image, and
-// the dword immediately after the last entry is not (it is 0x101 on US 1.2),
-// so the run of in-image pointers ends exactly at the end of the array. Bounds
-// come from the module's own PE header, so this needs no per-version literal.
+// Counts the original BattleFilesArray. The exe never stores this table's
+// length anywhere - LoadBattleFile indexes it blindly - so there is no value
+// in memory to read back; it has to be measured. Every entry is a pointer to
+// a filename literal inside the exe's own image (bounds read from our own PE
+// header, the same way getProcessEntryPoint in utils.cpp does), and the dword
+// immediately after the last entry is not one (it is 0x101 on US 1.2), so the
+// run of in-image pointers ends exactly at the end of the array.
 static uint32_t ff8_count_battle_filenames(const char *const *filenames)
 {
 	HMODULE module = GetModuleHandleA(nullptr);
@@ -218,17 +219,25 @@ static int ff8_battle_monster_load_file(int fileIndex, void *dst)
 static bool ff8_get_battle_file_size_on_disk(const char *relative_path, uint32_t *size_out)
 {
 	char full_path[MAX_PATH];
-	WIN32_FILE_ATTRIBUTE_DATA attr;
 
 	snprintf(full_path, sizeof(full_path), "%s\\direct\\%s", ff8_externals.app_path, relative_path);
-	if (!GetFileAttributesExA(full_path, GetFileExInfoStandard, &attr))
+	FILE *file = fopen(full_path, "rb");
+	if (file == nullptr)
 	{
 		snprintf(full_path, sizeof(full_path), "%s\\%s", ff8_externals.app_path, relative_path);
-		if (!GetFileAttributesExA(full_path, GetFileExInfoStandard, &attr))
+		file = fopen(full_path, "rb");
+		if (file == nullptr)
 			return false;
 	}
 
-	*size_out = attr.nFileSizeLow;
+	fseek(file, 0, SEEK_END);
+	long file_size = ftell(file);
+	fclose(file);
+
+	if (file_size <= 0)
+		return false;
+
+	*size_out = (uint32_t)file_size;
 	return true;
 }
 
@@ -300,7 +309,7 @@ static void ff8_relocate_enemy_scanned_once()
 
 	if (from != *(uint32_t *)ff8_externals.battle_enemy_scanned_write_operand || from != expected)
 	{
-		ffnx_warning("Extra battle monsters: Scan scanned-once operands do not agree with the savemap layout (read 0x%08X, expected 0x%08X), skipping relocation - scanning c0m144-c0m199 may corrupt the savemap!\n", from, expected);
+		if (trace_all) ffnx_warning("Extra battle monsters: Scan scanned-once operands do not agree with the savemap layout (read 0x%08X, expected 0x%08X), skipping relocation - scanning c0m144-c0m199 may corrupt the savemap!\n", from, expected);
 		return;
 	}
 
@@ -327,30 +336,31 @@ void ff8_battle_monsters_init()
 	ff8_battle_files_count = ff8_count_battle_filenames(ff8_externals.battle_filenames);
 	if (ff8_battle_files_count == 0 || ff8_battle_files_count >= FF8_BATTLE_FILES_ARRAY_MAX)
 	{
-		ffnx_warning("Extra battle monsters: unexpected battle file table length (%u), skipping.\n", ff8_battle_files_count);
+		if (trace_all) ffnx_warning("Extra battle monsters: unexpected battle file table length (%u), skipping.\n", ff8_battle_files_count);
 		return;
 	}
 
 	// 1) Copy the original table verbatim, then append the new c0m entries.
-	ff8_extended_battle_filenames = (char **)driver_malloc((ff8_battle_files_count + FF8_NEW_C0M_COUNT) * sizeof(char *));
-	if (ff8_extended_battle_filenames == nullptr)
+	//    The game's own table is a static exe array, never freed; its extended
+	//    replacement is likewise allocated once for the whole process and owned
+	//    by ff8_externals.battle_filenames from here on.
+	char **extended_filenames = (char **)driver_malloc((ff8_battle_files_count + FF8_NEW_C0M_COUNT) * sizeof(char *));
+	if (extended_filenames == nullptr)
 		return;
 
-	memcpy(ff8_extended_battle_filenames, ff8_externals.battle_filenames, ff8_battle_files_count * sizeof(char *));
+	memcpy(extended_filenames, ff8_externals.battle_filenames, ff8_battle_files_count * sizeof(char *));
 	for (uint32_t i = 0; i < FF8_NEW_C0M_COUNT; ++i)
 	{
 		snprintf(ff8_extended_c0m_names[i], sizeof(ff8_extended_c0m_names[i]), "C0M%03d.DAT", FF8_FIRST_NEW_C0M + i);
-		ff8_extended_battle_filenames[ff8_battle_files_count + i] = ff8_extended_c0m_names[i];
+		extended_filenames[ff8_battle_files_count + i] = ff8_extended_c0m_names[i];
 	}
+	ff8_externals.battle_filenames = extended_filenames;
 
-	//    Repoint LoadBattleFile's array base: mov ebx, BattleFilesArray[eax*4].
+	//    Repoint LoadBattleFile's array base to it: mov ebx, BattleFilesArray[eax*4].
 	//    battle_open_file + 0x11 is the absolute displacement of that instruction.
-	patch_code_dword(ff8_externals.battle_open_file + 0x11, (DWORD)(uintptr_t)ff8_extended_battle_filenames);
-
-	//    Also repoint FFNx's own cached base pointer so the hooks that index it
-	//    (ff8_battle_open_and_read_file in vram.cpp) resolve the appended
-	//    c0m144-199 indices instead of reading past the original array.
-	ff8_externals.battle_filenames = ff8_extended_battle_filenames;
+	//    FFNx's own hooks (ff8_battle_open_and_read_file in vram.cpp) read
+	//    ff8_externals.battle_filenames and pick the extended table up directly.
+	patch_code_dword(ff8_externals.battle_open_file + 0x11, (DWORD)(uintptr_t)ff8_externals.battle_filenames);
 
 	// 2) Redirect the monster loader's battle-file load call to the C hook,
 	//    keeping the original target to forward to.

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -95,10 +95,22 @@
 // field_vars_stack_1CFE9B8 - 0x54, a fixed C-struct field offset within the
 // same packed savemap globals, so it needs no per-version address table
 // either; field_vars_stack_1CFE9B8 already resolves per version elsewhere in
-// ff8_data.cpp. The relocation target uses savemap free-region bytes 785..816
-// (var 753..784 is already claimed by AddMoreMagic's drawn-once relocation -
-// see that fork's kernel_magic.cpp - so this deliberately starts right after
-// it to avoid a collision if both forks ever land upstream together).
+// ff8_data.cpp.
+//
+// The relocation target is field-script variables 785..816, inside the free
+// block that runs from var 753 to var 1023 (271 bytes). That block is unused
+// on three independent axes: no field script touches it (all 882 *.jsm
+// scanned), no exe code references it (embedded-address scan), and it is zero
+// in 28 real save files. Var 752 is the last script-used one. The block also
+// sits inside the save's CRC span (image bytes 4561..4831), so anything
+// written there survives a normal save, and unlike the temporary variables at
+// 1024+ it is never cleared on field entry - both of which the scanned-once
+// bitfield needs, since it is meant to persist. Runtime address is simply
+// field_vars_stack_1CFE9B8 + var.
+//
+// Vars 753..784 are already claimed by AddMoreMagic's drawn-once relocation
+// (a sibling FFNx fork, see its kernel_magic.cpp), so this deliberately
+// starts right after them to avoid a collision if both ever land upstream.
 //
 // Note the third .text reference to this field, in an unreferenced code gap
 // near Battle_RollCardCommand, is deliberately left alone: it is dead code on
@@ -117,7 +129,7 @@
 // com_id = c0m# + 16, so the added monsters use com_id 160..215.
 #define FF8_FIRST_NEW_COM_ID (FF8_FIRST_NEW_C0M + 16) // 160
 #define FF8_LAST_NEW_COM_ID  (FF8_LAST_NEW_C0M + 16)  // 215
-// The loader passes BattleFile_CharacterLoad a file index of (com_id + 150), so
+// The loader passes the battle-file loader an index of (com_id + 150), so
 // the new com_id 160..215 arrive as indices 310..365 (which retail resolves to
 // D0C character files); the hook remaps those onto the appended table entries.
 #define FF8_FIRST_NEW_FILE_INDEX (FF8_FIRST_NEW_COM_ID + 150) // 310
@@ -127,9 +139,10 @@
 // field-script variable block base, "VARMAP_START") in the same packed
 // savemap globals - a fixed C-struct field offset, IDA-verified on US 1.2.
 #define FF8_SG_ENEMY_SCANNED_ONCE_OFFSET (-0x54)
-// Relocation target: savemap free-region bytes 785..816 (32 bytes / 8 DWORDs,
-// safe for the full 0..255 com_id byte range). Bytes 753..784 of this same
-// free region are already claimed by AddMoreMagic's drawn-once relocation.
+// Relocation target: field-script variables 785..816 (32 bytes / 8 DWORDs,
+// safe for the full 0..255 com_id byte range), inside the verified-free
+// 753..1023 block described in the file comment above. Vars 753..784 are
+// already claimed by AddMoreMagic's drawn-once relocation.
 #define FF8_SCANNED_ONCE_RELOCATE_VAR  785
 #define FF8_SCANNED_ONCE_RELOCATE_SIZE 32
 static_assert(FF8_SCANNED_ONCE_RELOCATE_SIZE >= 32, "must cover the full 0..255 com_id byte range (8 DWORDs)");

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -53,13 +53,8 @@
 // to a bigger block in free, persisted savemap space (field vars 785..816) by
 // repointing the two instructions that use it - and only when scene.out
 // actually references a new monster, so vanilla saves stay untouched.
-//
-// Addresses are resolved relatively in ff8_data.cpp. The one fixed number here
-// is FF8_BATTLE_FILES_ARRAY_LEN, 1117 on every retail 1.2 build.
 // -------------------------------------------------------------------------
 
-// Original BattleFilesArray length. The exe never stores it, but it's 1117 on
-// every retail 1.2 build.
 #define FF8_BATTLE_FILES_ARRAY_LEN 1117
 // c0m file range to add.
 #define FF8_FIRST_NEW_C0M 144

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -29,190 +29,81 @@
 // -------------------------------------------------------------------------
 // Unlock the unused battle monster models c0m144..c0m199.
 //
-// Retail FF8 can only load c0m000..c0m143 (144 of the 200 c0m*.dat that ship
-// in battle.fs). The chain, verified in FF8_EN.exe (US 1.2):
-//   - Encounter def: FF8SceneOut.enemy_com_value[8] (1 byte/slot) = com_id.
-//   - sub_507080 dispatches com_id >= 16 (a monster) to battle_monster_dat_loader.
-//   - That loader computes the battle-file index as (com_id + 150) and calls
-//     LoadBattleFile, which reads BattleFilesArray[index] for the filename.
-//   - c0m000 is BattleFilesArray[166] (com_id 16), c0m143 is [309] (com_id 159).
-//     Index 310 is immediately D0C000.DAT (character files), so the c0m block
-//     cannot grow in place, and com_id 160..215 currently resolve to D0C/garbage.
+// Retail only loads c0m000..c0m143. An encounter picks a monster by com_id
+// (one byte per slot in FF8SceneOut.enemy_com_value); the loader adds 150 to
+// get a battle-file index and reads BattleFilesArray[index] for the filename.
+// c0m000..c0m143 live at indices 166..309, but index 310 is already
+// D0C000.DAT, so the c0m block can't grow in place - com_id 160..215 would
+// land on the character files.
 //
-// Fix (two memory patches):
-//   1) Build an enlarged copy of BattleFilesArray = the original entries
-//      verbatim + 56 appended pointers to new "C0M144.DAT".."C0M199.DAT",
-//      and repoint LoadBattleFile's array base to it. Every existing index
-//      resolves identically (the prefix is copied verbatim); nothing shifts.
-//   2) Redirect the single battle-file load call inside
-//      battle_monster_dat_loader (the monster load path) to a C hook that
-//      remaps the com_id 160..215 file indices into the appended range
-//      instead of letting them collide with D0C.
+// Two patches fix it:
+//   1) Swap BattleFilesArray for a copy with 56 extra entries appended
+//      ("C0M144.DAT".."C0M199.DAT") and repoint the loader at it. The original
+//      entries keep their indices, so nothing else moves.
+//   2) Hook the loader's file-load call and remap com_id 160..215 onto the
+//      appended entries instead of D0C.
 //
-// Encounters need no exe change: enemy_com_value is already a byte, so setting
-// it to (c0m# + 16) selects any monster up to c0m199.
+// No encounter format change is needed: enemy_com_value is already a byte, so
+// a mod just sets it to c0m# + 16 to use any monster up to c0m199.
 //
-// ff8_externals.battle_open_file / battle_filenames already resolve
-// dynamically per version via the existing get_relative_call chain in
-// ff8_data.cpp (sub_47CCB0 -> ... -> battle_open_file), so this file uses
-// them as-is with no version branching of its own. The hooked call site
-// (battle_monster_dat_loader + 0x240) and its target
-// (battle_load_file_sub_508480) are likewise resolved relatively in
-// ff8_data.cpp; the +0x240 offset is confirmed identical across all seven
-// retail 1.2 exe files (EN/FR/DE/IT/SP/JP/JP_NV). The BattleFilesArray table
-// (c0m000..c0m143 at indices 166..309, D0C000.DAT immediately at 310) is
-// confirmed identical across all seven builds. Its length is not hardcoded
-// either: it is counted at init by walking the table while its entries still
-// look like pointers into the module image (see ff8_count_battle_filenames).
+// Scan needs a fix too. Its "already scanned" bitfield SG_ENEMY_SCANNED_ONCE
+// is only 5 DWORDs and gets indexed by com_id/32 with no bounds check, so it
+// is only safe up to com_id 159. Scanning a new monster would overflow it into
+// the neighbouring Renzokuken/tutorial savemap fields. We relocate the field
+// to a bigger block in free, persisted savemap space (field vars 785..816) by
+// repointing the two instructions that use it - and only when scene.out
+// actually references a new monster, so vanilla saves stay untouched.
 //
-// Scan savemap overflow fix: the "already scanned" bitfield
-// SG_ENEMY_SCANNED_ONCE (savemap global @ 0x1cfe964, IDA-verified, modelled
-// as savemap_ff8_battle::ennemy_scanned_once in ff8/save_data.h) is only 5
-// DWORDs (20 bytes), immediately followed in the packed savemap struct by
-// SG_RENZOKUKEN_AUTO/SG_RENZOKUKEN_INDICATOR/SG_ODIN_ANGEL_GILGA_FLAG/
-// SG_TUTORIAL_INFO. It has exactly one reader and one writer:
-//   - reader @0x4925a6, in Damage_DispatchByAttackType's ATTACK_TYPE_SCAN
-//     case: tests the bit for the target's com_id (read out of the battle
-//     entity array, battle_entities_1D27BCB) and, when set, flags the enemy's
-//     info as already known.
-//   - writer @0x493810, which is a pure setter - "mark this com_id scanned",
-//     `field[id / 32] |= 1 << (id % 32)` and nothing else.
-// Both index it as SG_ENEMY_SCANNED_ONCE[(unsigned __int8)com_file_id / 32]
-// with NO bounds check, so it's only safe for com_file_id (com_id) 0..159.
-// Every com_id this patch adds (160..215, i.e. c0m144..c0m199) is already
-// past that: casting Scan on any of the new monsters would write out of
-// bounds into the Renzokuken/tutorial-flag savemap fields above, silently
-// corrupting them.
-//
-// Fixed by repointing both instructions at a bigger (32-byte / 8-DWORD, safe
-// for the full 0..255 com_id byte range) block in free savemap space, keeping
-// the existing com_id/32 index math unchanged. The two disp32 operands are
-// resolved relatively in ff8_data.cpp off battle_sub_48FE20 (see there), and
-// re-checked below before anything is written, so a build whose layout does
-// not match is left untouched rather than corrupted.
-//
-// SG_ENEMY_SCANNED_ONCE's own address is derived as
-// field_vars_stack_1CFE9B8 - 0x54, a fixed C-struct field offset within the
-// same packed savemap globals, so it needs no per-version address table
-// either; field_vars_stack_1CFE9B8 already resolves per version elsewhere in
-// ff8_data.cpp.
-//
-// The relocation target is field-script variables 785..816, inside the free
-// block that runs from var 753 to var 1023 (271 bytes). That block is unused
-// on three independent axes: no field script touches it (all 882 *.jsm
-// scanned), no exe code references it (embedded-address scan), and it is zero
-// in 28 real save files. Var 752 is the last script-used one. The block also
-// sits inside the save's CRC span (image bytes 4561..4831), so anything
-// written there survives a normal save, and unlike the temporary variables at
-// 1024+ it is never cleared on field entry - both of which the scanned-once
-// bitfield needs, since it is meant to persist. Runtime address is simply
-// field_vars_stack_1CFE9B8 + var.
-//
-// Vars 753..784 are already claimed by AddMoreMagic's drawn-once relocation
-// (a sibling FFNx fork, see its kernel_magic.cpp), so this deliberately
-// starts right after them to avoid a collision if both ever land upstream.
-//
-// Note the third .text reference to this field, in an unreferenced code gap
-// near Battle_RollCardCommand, is deliberately left alone: it is dead code on
-// every retail 1.2 build (EN, ES, FR, IT, DE, JP), so relocating it would
-// serve no purpose.
+// Addresses are resolved relatively in ff8_data.cpp. The one fixed number here
+// is FF8_BATTLE_FILES_ARRAY_LEN, 1117 on every retail 1.2 build.
 // -------------------------------------------------------------------------
 
-// Sanity bound while counting the original BattleFilesArray; it holds 1117
-// entries on every retail 1.2 build, so this only exists to stop a runaway
-// walk if the table ever looks unfamiliar.
-#define FF8_BATTLE_FILES_ARRAY_MAX 4096
+// Original BattleFilesArray length. The exe never stores it, but it's 1117 on
+// every retail 1.2 build.
+#define FF8_BATTLE_FILES_ARRAY_LEN 1117
 // c0m file range to add.
 #define FF8_FIRST_NEW_C0M 144
 #define FF8_LAST_NEW_C0M  199
 #define FF8_NEW_C0M_COUNT (FF8_LAST_NEW_C0M - FF8_FIRST_NEW_C0M + 1) // 56
-// com_id = c0m# + 16, so the added monsters use com_id 160..215.
+// com_id = c0m# + 16, so the new monsters use com_id 160..215.
 #define FF8_FIRST_NEW_COM_ID (FF8_FIRST_NEW_C0M + 16) // 160
 #define FF8_LAST_NEW_COM_ID  (FF8_LAST_NEW_C0M + 16)  // 215
-// The loader passes the battle-file loader an index of (com_id + 150), so
-// the new com_id 160..215 arrive as indices 310..365 (which retail resolves to
-// D0C character files); the hook remaps those onto the appended table entries.
+// The loader adds 150 to com_id, so com_id 160..215 arrive as file indices
+// 310..365 (D0C on retail); the hook remaps those onto the appended entries.
 #define FF8_FIRST_NEW_FILE_INDEX (FF8_FIRST_NEW_COM_ID + 150) // 310
 #define FF8_LAST_NEW_FILE_INDEX  (FF8_LAST_NEW_COM_ID + 150)  // 365
 
-// Where SG_ENEMY_SCANNED_ONCE sits relative to field_vars_stack_1CFE9B8 (the
-// field-script variable block base, "VARMAP_START"): 0x54 bytes before it, in
-// the same packed savemap globals. This is only used to sanity-check the
-// address read out of the instructions that index the field - it is not how
-// the address is obtained.
+// SG_ENEMY_SCANNED_ONCE sits 0x54 bytes before field_vars_stack_1CFE9B8 in the
+// savemap globals. Only used to sanity-check the address we read from the code.
 #define FF8_SG_ENEMY_SCANNED_ONCE_OFFSET (-0x54)
-// Relocation target: field-script variables 785..816 (32 bytes / 8 DWORDs,
-// safe for the full 0..255 com_id byte range), inside the verified-free
-// 753..1023 block described in the file comment above. Vars 753..784 are
-// already claimed by AddMoreMagic's drawn-once relocation.
+// Where we move the field: field vars 785..816 (8 DWORDs, enough for all 256
+// com_ids), in free savemap space. 753..784 are taken by AddMoreMagic.
 #define FF8_SCANNED_ONCE_RELOCATE_VAR  785
 #define FF8_SCANNED_ONCE_RELOCATE_SIZE 32
 static_assert(FF8_SCANNED_ONCE_RELOCATE_SIZE >= 32, "must cover the full 0..255 com_id byte range (8 DWORDs)");
 
-// scene.out per-record layout (128 bytes/record, enemy_com_value[8] at
-// offset 56 - the data format, not the file's total size, which is read
-// dynamically below so a modded/enlarged scene.out is handled correctly).
+// scene.out record layout: 128 bytes each, enemy_com_value[8] at offset 56.
 #define FF8_SCENE_OUT_RECORD_SIZE            128
 #define FF8_SCENE_OUT_ENEMY_COM_VALUE_OFFSET 56
 #define FF8_SCENE_OUT_ENEMY_SLOTS            8
 
-// Backing storage for the new entries appended to battle_filenames; the table
-// keeps raw pointers into it for the rest of the process, so it must stay
-// static.
-static char ff8_extended_c0m_names[FF8_NEW_C0M_COUNT][12]; // "C0M199.DAT" + NUL = 11
-// Length of the original BattleFilesArray, counted at init (see below).
-static uint32_t ff8_battle_files_count = 0;
+// Backing store for the appended filenames; the table holds pointers into it
+// for the whole session, so it stays static.
+static char ff8_extended_c0m_names[FF8_NEW_C0M_COUNT][12]; // "C0M199.DAT" + NUL
 
-// Counts the original BattleFilesArray. The exe never stores this table's
-// length anywhere - LoadBattleFile indexes it blindly - so there is no value
-// in memory to read back; it has to be measured. Every entry is a pointer to
-// a filename literal inside the exe's own image (bounds read from our own PE
-// header, the same way getProcessEntryPoint in utils.cpp does), and the dword
-// immediately after the last entry is not one (it is 0x101 on US 1.2), so the
-// run of in-image pointers ends exactly at the end of the array.
-static uint32_t ff8_count_battle_filenames(const char *const *filenames)
-{
-	HMODULE module = GetModuleHandleA(nullptr);
-	PIMAGE_DOS_HEADER dos = (PIMAGE_DOS_HEADER)module;
-	PIMAGE_NT_HEADERS nt = (PIMAGE_NT_HEADERS)((BYTE *)module + dos->e_lfanew);
-
-	uintptr_t image_start = (uintptr_t)module;
-	uintptr_t image_end = image_start + nt->OptionalHeader.SizeOfImage;
-
-	uint32_t count = 0;
-	while (count < FF8_BATTLE_FILES_ARRAY_MAX)
-	{
-		uintptr_t entry = (uintptr_t)filenames[count];
-
-		if (entry < image_start || entry >= image_end)
-			break;
-
-		++count;
-	}
-
-	return count;
-}
-
-// C replacement for the loader's "index = com_id + 150" remap. Hooked onto the
-// single battle-file load call inside battle_monster_dat_loader, which is only
-// ever reached for monsters, so a file index in 310..365 unambiguously means
-// one of the newly unlocked c0m144..c0m199; those get remapped onto the
-// appended table entries and everything else is forwarded to the original
-// battle_load_file_sub_508480 untouched.
+// Our replacement for the loader's com_id+150 file lookup. This call is only
+// reached for monsters, so an index in 310..365 means one of the new
+// c0m144..c0m199 - remap it onto the appended entries and forward the rest.
 static int ff8_battle_monster_load_file(int fileIndex, void *dst)
 {
 	if (fileIndex >= FF8_FIRST_NEW_FILE_INDEX && fileIndex <= FF8_LAST_NEW_FILE_INDEX)
-		fileIndex = ff8_battle_files_count + (fileIndex - FF8_FIRST_NEW_FILE_INDEX);
+		fileIndex = FF8_BATTLE_FILES_ARRAY_LEN + (fileIndex - FF8_FIRST_NEW_FILE_INDEX);
 
 	return ((int (*)(int, void *))ff8_externals.battle_load_file_sub_508480)(fileIndex, dst);
 }
 
-// Looks up a battle-relative file's real size on disk without reading it,
-// checking the same two places FFNx actually stores loose files: the
-// "direct" override folder first, then the plain extracted layout. Doesn't
-// need to know anything about the packed-archive format (fl/fs/fi tables) -
-// modern FFNx installs serve battle files as loose files in one of these two
-// places, not from the original PSX archives.
+// File size on disk, from the two places FFNx serves loose battle files: the
+// "direct" override folder first, then the plain extracted layout.
 static bool ff8_get_battle_file_size_on_disk(const char *relative_path, uint32_t *size_out)
 {
 	char full_path[MAX_PATH];
@@ -238,18 +129,10 @@ static bool ff8_get_battle_file_size_on_disk(const char *relative_path, uint32_t
 	return true;
 }
 
-// Reads scene.out (through FFNx's own sm_pc_read, so file overrides are
-// respected the same way the game itself would load it) and checks every
-// encounter's enemy_com_value[8] bytes for one referencing a newly unlocked
-// monster (com_id >= FF8_FIRST_NEW_COM_ID). Only encounter data determines
-// whether the relocation below is ever needed - the exe/kernel side has no
-// equivalent "count" to gate on the way AddMoreMagic gates on kernel magic
-// count. The read buffer is sized from the file's real size on disk (see
-// ff8_get_battle_file_size_on_disk above), not an assumed vanilla constant,
-// so a modded/enlarged scene.out is scanned correctly. If the size can't be
-// determined at all (e.g. a packed-archive-only install with no loose
-// scene.out anywhere), be conservative and report "needed" rather than
-// silently skip a real fix.
+// True if any encounter in scene.out uses a new monster (com_id >= 160) - the
+// Scan relocation below is only needed then. Read through sm_pc_read so file
+// overrides count, and sized from the real file so a modded scene.out works. If
+// the size can't be found, assume it's needed rather than skip a real fix.
 static bool ff8_scene_out_uses_new_monsters()
 {
 	uint32_t file_size;
@@ -281,12 +164,9 @@ static bool ff8_scene_out_uses_new_monsters()
 	return uses_new_monsters;
 }
 
-// Relocates SG_ENEMY_SCANNED_ONCE (see the file-level comment above) from its
-// native 5-DWORD savemap field to an 8-DWORD block in free savemap space, so
-// the existing com_id/32 index math stays in bounds for the full 0..255
-// com_id range instead of only 0..159. Only called when scene.out actually
-// references a new monster (see ff8_scene_out_uses_new_monsters above), so a
-// vanilla or not-yet-updated scene.out leaves this bitfield untouched.
+// Moves SG_ENEMY_SCANNED_ONCE to a bigger block so com_id/32 stays in bounds
+// for the whole 0..255 range (see file comment). Only called when scene.out
+// uses a new monster.
 static void ff8_relocate_enemy_scanned_once()
 {
 	if (!ff8_externals.field_vars_stack_1CFE9B8
@@ -294,12 +174,9 @@ static void ff8_relocate_enemy_scanned_once()
 		|| !ff8_externals.battle_enemy_scanned_write_operand)
 		return;
 
-	// Take the field's address from the instruction that indexes it rather than
-	// computing it: whatever the reader dereferences is the field, by
-	// definition. Two independent checks then guard against a mis-resolved
-	// operand, since writing to one would corrupt unrelated code: the writer
-	// must reference the same address, and it must sit where the savemap
-	// layout says it does.
+	// Read the field's address straight out of the instruction that indexes it.
+	// Then guard against a bad resolve before patching: the writer must use the
+	// same address, and it must match the savemap layout.
 	uint32_t from = *(uint32_t *)ff8_externals.battle_enemy_scanned_read_operand;
 	uint32_t expected = ff8_externals.field_vars_stack_1CFE9B8 + FF8_SG_ENEMY_SCANNED_ONCE_OFFSET;
 	uint32_t to = ff8_externals.field_vars_stack_1CFE9B8 + FF8_SCANNED_ONCE_RELOCATE_VAR;
@@ -330,54 +207,38 @@ void ff8_battle_monsters_init()
 		return;
 	}
 
-	ff8_battle_files_count = ff8_count_battle_filenames(ff8_externals.battle_filenames);
-	if (ff8_battle_files_count == 0 || ff8_battle_files_count >= FF8_BATTLE_FILES_ARRAY_MAX)
-	{
-		if (trace_all) ffnx_warning("Extra battle monsters: unexpected battle file table length (%u), skipping.\n", ff8_battle_files_count);
-		return;
-	}
-
-	// 1) Copy the original table verbatim, then append the new c0m entries.
-	//    The game's own table is a static exe array, never freed; its extended
-	//    replacement is likewise allocated once for the whole process and owned
-	//    by ff8_externals.battle_filenames from here on.
-	char **extended_filenames = (char **)driver_malloc((ff8_battle_files_count + FF8_NEW_C0M_COUNT) * sizeof(char *));
+	// 1) Build the extended table (original entries + 56 new ones) and give it
+	//    to battle_filenames. One-time allocation, never freed, like the exe's
+	//    own static table.
+	char **extended_filenames = (char **)driver_malloc((FF8_BATTLE_FILES_ARRAY_LEN + FF8_NEW_C0M_COUNT) * sizeof(char *));
 	if (extended_filenames == nullptr)
 		return;
 
-	memcpy(extended_filenames, ff8_externals.battle_filenames, ff8_battle_files_count * sizeof(char *));
+	memcpy(extended_filenames, ff8_externals.battle_filenames, FF8_BATTLE_FILES_ARRAY_LEN * sizeof(char *));
 	for (uint32_t i = 0; i < FF8_NEW_C0M_COUNT; ++i)
 	{
 		snprintf(ff8_extended_c0m_names[i], sizeof(ff8_extended_c0m_names[i]), "C0M%03d.DAT", FF8_FIRST_NEW_C0M + i);
-		extended_filenames[ff8_battle_files_count + i] = ff8_extended_c0m_names[i];
+		extended_filenames[FF8_BATTLE_FILES_ARRAY_LEN + i] = ff8_extended_c0m_names[i];
 	}
 	ff8_externals.battle_filenames = extended_filenames;
 
-	//    Repoint LoadBattleFile's array base to it: mov ebx, BattleFilesArray[eax*4].
-	//    battle_open_file + 0x11 is the absolute displacement of that instruction.
-	//    FFNx's own hooks (ff8_battle_open_and_read_file in vram.cpp) read
-	//    ff8_externals.battle_filenames and pick the extended table up directly.
+	//    Repoint the loader's array base at it (the disp32 of
+	//    mov ebx, BattleFilesArray[eax*4], at battle_open_file + 0x11). FFNx's
+	//    vram.cpp hooks read battle_filenames, so they pick it up too.
 	patch_code_dword(ff8_externals.battle_open_file + 0x11, (DWORD)(uintptr_t)ff8_externals.battle_filenames);
 
-	// 2) Redirect the monster loader's battle-file load call to the C hook; it
-	//    forwards to the original battle_load_file_sub_508480 for everything but
-	//    the remapped range.
+	// 2) Redirect the loader's file-load call to our hook.
 	replace_call(ff8_externals.battle_monster_file_load_call_site, (void *)&ff8_battle_monster_load_file);
 
-	// 3) Relocate the Scan scanned-once bitfield so it stays in bounds
-	//    for the new monsters' com_id range too (see file-level comment), but
-	//    only when scene.out actually references one - a vanilla or
-	//    not-yet-updated scene.out never reaches a com_id past 159, so the
-	//    native field is already safe and there's nothing to relocate.
+	// 3) Fix the Scan overflow, but only if scene.out actually uses a new
+	//    monster - vanilla never reaches com_id 160, so its field is already safe.
 	bool uses_new_monsters = ff8_scene_out_uses_new_monsters();
 
 	if (uses_new_monsters)
 		ff8_relocate_enemy_scanned_once();
 
-	// Only worth reporting when a mod actually references one of the new
-	// monsters: the table is extended on every supported build, but on a
-	// vanilla install nothing ever indexes into the appended range, so staying
-	// quiet there keeps this out of everyone else's log.
+	// Only log when a mod actually uses the new monsters; the table is extended
+	// everywhere, so staying quiet on vanilla keeps this out of everyone's log.
 	if (uses_new_monsters && trace_all)
-		ffnx_trace("Extra battle monsters enabled: c0m%03d-c0m%03d usable via enemy_com_value %d-%d (%u original battle files).\n", FF8_FIRST_NEW_C0M, FF8_LAST_NEW_C0M, FF8_FIRST_NEW_COM_ID, FF8_LAST_NEW_COM_ID, ff8_battle_files_count);
+		ffnx_trace("Extra battle monsters enabled: c0m%03d-c0m%03d usable via enemy_com_value %d-%d.\n", FF8_FIRST_NEW_C0M, FF8_LAST_NEW_C0M, FF8_FIRST_NEW_COM_ID, FF8_LAST_NEW_COM_ID);
 }

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -193,21 +193,18 @@ static uint32_t ff8_count_battle_filenames(const char *const *filenames)
 	return count;
 }
 
-// Original battle_load_file_sub_508480(fileIndex, dst), saved so the hook below
-// can forward to it after remapping.
-static int (*ff8_battle_load_file)(int fileIndex, void *dst) = nullptr;
-
 // C replacement for the loader's "index = com_id + 150" remap. Hooked onto the
 // single battle-file load call inside battle_monster_dat_loader, which is only
 // ever reached for monsters, so a file index in 310..365 unambiguously means
 // one of the newly unlocked c0m144..c0m199; those get remapped onto the
-// appended table entries and everything else is forwarded untouched.
+// appended table entries and everything else is forwarded to the original
+// battle_load_file_sub_508480 untouched.
 static int ff8_battle_monster_load_file(int fileIndex, void *dst)
 {
 	if (fileIndex >= FF8_FIRST_NEW_FILE_INDEX && fileIndex <= FF8_LAST_NEW_FILE_INDEX)
 		fileIndex = ff8_battle_files_count + (fileIndex - FF8_FIRST_NEW_FILE_INDEX);
 
-	return ff8_battle_load_file(fileIndex, dst);
+	return ((int (*)(int, void *))ff8_externals.battle_load_file_sub_508480)(fileIndex, dst);
 }
 
 // Looks up a battle-relative file's real size on disk without reading it,
@@ -362,9 +359,9 @@ void ff8_battle_monsters_init()
 	//    ff8_externals.battle_filenames and pick the extended table up directly.
 	patch_code_dword(ff8_externals.battle_open_file + 0x11, (DWORD)(uintptr_t)ff8_externals.battle_filenames);
 
-	// 2) Redirect the monster loader's battle-file load call to the C hook,
-	//    keeping the original target to forward to.
-	ff8_battle_load_file = (int (*)(int, void *))ff8_externals.battle_load_file_sub_508480;
+	// 2) Redirect the monster loader's battle-file load call to the C hook; it
+	//    forwards to the original battle_load_file_sub_508480 for everything but
+	//    the remapped range.
 	replace_call(ff8_externals.battle_monster_file_load_call_site, (void *)&ff8_battle_monster_load_file);
 
 	// 3) Relocate the Scan scanned-once bitfield so it stays in bounds

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -103,11 +103,11 @@ static bool ff8_get_battle_file_size_on_disk(const char *relative_path, uint32_t
 {
 	char full_path[MAX_PATH];
 
-	snprintf(full_path, sizeof(full_path), "%s\\direct\\%s", ff8_externals.app_path, relative_path);
+	snprintf(full_path, sizeof(full_path), "%s/direct/%s", ff8_externals.app_path, relative_path);
 	FILE *file = fopen(full_path, "rb");
 	if (file == nullptr)
 	{
-		snprintf(full_path, sizeof(full_path), "%s\\%s", ff8_externals.app_path, relative_path);
+		snprintf(full_path, sizeof(full_path), "%s/%s", ff8_externals.app_path, relative_path);
 		file = fopen(full_path, "rb");
 		if (file == nullptr)
 			return false;
@@ -131,7 +131,7 @@ static bool ff8_get_battle_file_size_on_disk(const char *relative_path, uint32_t
 static bool ff8_scene_out_uses_new_monsters()
 {
 	uint32_t file_size;
-	if (!ff8_get_battle_file_size_on_disk("battle\\scene.out", &file_size))
+	if (!ff8_get_battle_file_size_on_disk("battle/scene.out", &file_size))
 		return true;
 
 	uint8_t *scene_out = new uint8_t[file_size];

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -1,0 +1,127 @@
+/****************************************************************************/
+//    Copyright (C) 2026 Julian Xhokaxhiu                                    //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#include "monsters.h"
+
+#include "../../ff8.h"
+#include "../../patch.h"
+#include "../../globals.h"
+#include "../../common.h"
+#include "../../log.h"
+
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+// -------------------------------------------------------------------------
+// Unlock the unused battle monster models c0m144..c0m199.
+//
+// Retail FF8 can only load c0m000..c0m143 (144 of the 200 c0m*.dat that ship
+// in battle.fs). The chain, verified in FF8_EN.exe (US 1.2):
+//   - Encounter def: FF8SceneOut.enemy_com_value[8] (1 byte/slot) = com_id.
+//   - sub_507080 dispatches com_id >= 16 (a monster) to battle_monster_dat_loader.
+//   - That loader computes the battle-file index as (com_id + 150) and calls
+//     LoadBattleFile, which reads BattleFilesArray[index] for the filename.
+//   - c0m000 is BattleFilesArray[166] (com_id 16), c0m143 is [309] (com_id 159).
+//     Index 310 is immediately D0C000.DAT (character files), so the c0m block
+//     cannot grow in place, and com_id 160..215 currently resolve to D0C/garbage.
+//
+// Fix (three memory patches, US 1.2 only for now):
+//   1) Build an enlarged copy of BattleFilesArray = the original entries
+//      verbatim + 56 appended pointers to new "C0M144.DAT".."C0M199.DAT".
+//   2) Repoint LoadBattleFile's array base to the enlarged copy. Every existing
+//      index resolves identically (the prefix is copied verbatim); nothing shifts.
+//   3) Hook the loader's "index = com_id + 150" so com_id 160..215 map to the
+//      appended range instead of colliding with D0C.
+//
+// Encounters need no exe change: enemy_com_value is already a byte, so setting
+// it to (c0m# + 16) selects any monster up to c0m199.
+// -------------------------------------------------------------------------
+
+// Length of the original BattleFilesArray (US 1.2), indices 0..1116.
+#define FF8_BATTLE_FILES_ARRAY_LEN 1117
+// c0m file range to add.
+#define FF8_FIRST_NEW_C0M 144
+#define FF8_LAST_NEW_C0M  199
+#define FF8_NEW_C0M_COUNT (FF8_LAST_NEW_C0M - FF8_FIRST_NEW_C0M + 1) // 56
+// com_id = c0m# + 16, so the added monsters use com_id 160..215.
+#define FF8_FIRST_NEW_COM_ID (FF8_FIRST_NEW_C0M + 16) // 160
+#define FF8_LAST_NEW_COM_ID  (FF8_LAST_NEW_C0M + 16)  // 215
+// New entries are appended at index FF8_BATTLE_FILES_ARRAY_LEN, so:
+//   index(com_id) = FF8_BATTLE_FILES_ARRAY_LEN + (com_id - FF8_FIRST_NEW_COM_ID)
+//                 = com_id + (FF8_BATTLE_FILES_ARRAY_LEN - FF8_FIRST_NEW_COM_ID)
+#define FF8_NEW_C0M_INDEX_BIAS (FF8_BATTLE_FILES_ARRAY_LEN - FF8_FIRST_NEW_COM_ID) // 957
+// Address of "add eax, 96h" (com_id + 150) inside battle_monster_dat_loader (US 1.2).
+#define FF8_MONSTER_LOADER_ADD_SITE 0x50735A
+
+static char *ff8_extended_battle_filenames[FF8_BATTLE_FILES_ARRAY_LEN + FF8_NEW_C0M_COUNT];
+static char ff8_extended_c0m_names[FF8_NEW_C0M_COUNT][12]; // "C0M199.DAT" + NUL = 11
+
+// Custom "eax in / eax out" trampoline that replaces the loader's com_id+150.
+// eax = com_id on entry, returns the BattleFilesArray index in eax. Only eax
+// and the flags are touched; the surrounding code does not rely on the flags
+// after this point (it just pushes eax and calls), so this is transparent.
+static __declspec(naked) void ff8_battle_monster_index_remap()
+{
+	__asm {
+		cmp eax, FF8_FIRST_NEW_COM_ID   // 160
+		jb  normal
+		cmp eax, FF8_LAST_NEW_COM_ID    // 215
+		ja  normal
+		add eax, FF8_NEW_C0M_INDEX_BIAS // 957 -> appended c0m144..c0m199
+		ret
+	normal:
+		add eax, 150                    // original c0m000..c0m143 (and unused >= 216)
+		ret
+	}
+}
+
+void ff8_battle_monsters_init()
+{
+	// Only the US 1.2 release is mapped for now (matches the addresses above).
+	if (!FF8_US_VERSION)
+	{
+		ffnx_info("Extra battle monsters (c0m144-c0m199): unsupported game version, skipping.\n");
+		return;
+	}
+
+	char **orig = (char **)ff8_externals.battle_filenames;
+	if (orig == nullptr)
+	{
+		ffnx_warning("Extra battle monsters: battle_filenames not resolved, skipping.\n");
+		return;
+	}
+
+	// 1) Copy the original table verbatim, then append the new c0m entries.
+	memcpy(ff8_extended_battle_filenames, orig, FF8_BATTLE_FILES_ARRAY_LEN * sizeof(char *));
+	for (int i = 0; i < FF8_NEW_C0M_COUNT; ++i)
+	{
+		snprintf(ff8_extended_c0m_names[i], sizeof(ff8_extended_c0m_names[i]), "C0M%03d.DAT", FF8_FIRST_NEW_C0M + i);
+		ff8_extended_battle_filenames[FF8_BATTLE_FILES_ARRAY_LEN + i] = ff8_extended_c0m_names[i];
+	}
+
+	// 2) Repoint LoadBattleFile's array base: mov ebx, BattleFilesArray[eax*4].
+	//    battle_open_file + 0x11 is the absolute displacement of that instruction.
+	patch_code_dword(ff8_externals.battle_open_file + 0x11, (DWORD)(uintptr_t)ff8_extended_battle_filenames);
+
+	// 3) Replace "add eax, 96h" (5 bytes) with "call ff8_battle_monster_index_remap".
+	uint8_t call_patch[5];
+	call_patch[0] = 0xE8;
+	*(uint32_t *)&call_patch[1] = (uint32_t)&ff8_battle_monster_index_remap - (FF8_MONSTER_LOADER_ADD_SITE + 5);
+	memcpy_code(FF8_MONSTER_LOADER_ADD_SITE, call_patch, sizeof(call_patch));
+
+	ffnx_info("Extra battle monsters enabled: c0m%03d-c0m%03d usable via enemy_com_value %d-%d.\n",
+		FF8_FIRST_NEW_C0M, FF8_LAST_NEW_C0M, FF8_FIRST_NEW_COM_ID, FF8_LAST_NEW_COM_ID);
+}

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -44,7 +44,7 @@
 //      verbatim + 56 appended pointers to new "C0M144.DAT".."C0M199.DAT",
 //      and repoint LoadBattleFile's array base to it. Every existing index
 //      resolves identically (the prefix is copied verbatim); nothing shifts.
-//   2) Redirect the single BattleFile_CharacterLoad call inside
+//   2) Redirect the single battle-file load call inside
 //      battle_monster_dat_loader (the monster load path) to a C hook that
 //      remaps the com_id 160..215 file indices into the appended range
 //      instead of letting them collide with D0C.
@@ -56,42 +56,53 @@
 // dynamically per version via the existing get_relative_call chain in
 // ff8_data.cpp (sub_47CCB0 -> ... -> battle_open_file), so this file uses
 // them as-is with no version branching of its own. The hooked call site
-// (battle_monster_dat_loader + 0x240) and its target (BattleFile_CharacterLoad)
-// are likewise resolved relatively in ff8_data.cpp; the +0x240 offset is
-// confirmed identical across all seven retail 1.2 exe files
-// (EN/FR/DE/IT/SP/JP/JP_NV). The BattleFilesArray table structure itself
+// (battle_monster_dat_loader + 0x240) and its target
+// (battle_load_file_sub_508480) are likewise resolved relatively in
+// ff8_data.cpp; the +0x240 offset is confirmed identical across all seven
+// retail 1.2 exe files (EN/FR/DE/IT/SP/JP/JP_NV). The BattleFilesArray table
 // (c0m000..c0m143 at indices 166..309, D0C000.DAT immediately at 310, 1117
 // entries total) is confirmed identical across all seven builds, so
 // FF8_BATTLE_FILES_ARRAY_LEN below is not version-dependent.
 //
-// Scan/Libra savemap overflow fix: the "already scanned" bitfield
-// SG_ENEMY_SCANNED_ONCE (savemap global @ 0x1cfe964, IDA-verified) is only 5
+// Scan savemap overflow fix: the "already scanned" bitfield
+// SG_ENEMY_SCANNED_ONCE (savemap global @ 0x1cfe964, IDA-verified, modelled
+// as savemap_ff8_battle::ennemy_scanned_once in ff8/save_data.h) is only 5
 // DWORDs (20 bytes), immediately followed in the packed savemap struct by
 // SG_RENZOKUKEN_AUTO/SG_RENZOKUKEN_INDICATOR/SG_ODIN_ANGEL_GILGA_FLAG/
-// SG_TUTORIAL_INFO. Both readers/writers of it - Damage_DispatchByAttackType's
-// ATTACK_TYPE_SCAN case (@0x4925a6) and hasEnemyAlreadyScanned (@0x493810) -
-// index it as SG_ENEMY_SCANNED_ONCE[(unsigned __int8)com_file_id / 32] with NO
-// bounds check, so it's only safe for com_file_id (com_id) 0..159. Every
-// com_id this patch adds (160..215, i.e. c0m144..c0m199) is already past
-// that: Scanning any of the new monsters (Scan spell / Libra / Enc-None
-// chance-scan) would write out of bounds into the Renzokuken/tutorial-flag
-// savemap fields above, silently corrupting them.
+// SG_TUTORIAL_INFO. It has exactly one reader and one writer:
+//   - reader @0x4925a6, in Damage_DispatchByAttackType's ATTACK_TYPE_SCAN
+//     case: tests the bit for the target's com_id (read out of the battle
+//     entity array, battle_entities_1D27BCB) and, when set, flags the enemy's
+//     info as already known.
+//   - writer @0x493810, which is a pure setter - "mark this com_id scanned",
+//     `field[id / 32] |= 1 << (id % 32)` and nothing else.
+// Both index it as SG_ENEMY_SCANNED_ONCE[(unsigned __int8)com_file_id / 32]
+// with NO bounds check, so it's only safe for com_file_id (com_id) 0..159.
+// Every com_id this patch adds (160..215, i.e. c0m144..c0m199) is already
+// past that: casting Scan on any of the new monsters would write out of
+// bounds into the Renzokuken/tutorial-flag savemap fields above, silently
+// corrupting them.
 //
-// Fixed the same way AddMoreMagic (a sibling FFNx fork) relocates its
-// magic "drawn once" bitfield out of a too-small native field: blind
-// value-scan every dword in .text for SG_ENEMY_SCANNED_ONCE's address and
-// repoint it at a bigger (32-byte / 8-DWORD, safe for the full 0..255
-// com_id byte range) block in verified-free savemap space, keeping the
-// existing com_id/32 index math unchanged. SG_ENEMY_SCANNED_ONCE's address
-// itself is derived relatively as field_vars_stack_1CFE9B8 - 0x54 (a fixed
-// C-struct field offset within the same packed savemap globals, not a
-// signature-scanned value, so it needs no separate per-version address
-// table); field_vars_stack_1CFE9B8 already resolves per version elsewhere
-// in ff8_data.cpp. The relocation target uses savemap free-region bytes
-// 785..816 (var 753..784 is already claimed by AddMoreMagic's drawn-once
-// relocation - see that fork's kernel_magic.cpp - so this deliberately
-// starts right after it to avoid a collision if both forks ever land
-// upstream together).
+// Fixed by repointing both instructions at a bigger (32-byte / 8-DWORD, safe
+// for the full 0..255 com_id byte range) block in free savemap space, keeping
+// the existing com_id/32 index math unchanged. The two disp32 operands are
+// resolved relatively in ff8_data.cpp off battle_sub_48FE20 (see there), and
+// re-checked below before anything is written, so a build whose layout does
+// not match is left untouched rather than corrupted.
+//
+// SG_ENEMY_SCANNED_ONCE's own address is derived as
+// field_vars_stack_1CFE9B8 - 0x54, a fixed C-struct field offset within the
+// same packed savemap globals, so it needs no per-version address table
+// either; field_vars_stack_1CFE9B8 already resolves per version elsewhere in
+// ff8_data.cpp. The relocation target uses savemap free-region bytes 785..816
+// (var 753..784 is already claimed by AddMoreMagic's drawn-once relocation -
+// see that fork's kernel_magic.cpp - so this deliberately starts right after
+// it to avoid a collision if both forks ever land upstream together).
+//
+// Note the third .text reference to this field, in an unreferenced code gap
+// near Battle_RollCardCommand, is deliberately left alone: it is dead code on
+// every retail 1.2 build (EN, ES, FR, IT, DE, JP), so relocating it would
+// serve no purpose.
 // -------------------------------------------------------------------------
 
 // Length of the original BattleFilesArray (US 1.2), indices 0..1116.
@@ -118,6 +129,7 @@
 // free region are already claimed by AddMoreMagic's drawn-once relocation.
 #define FF8_SCANNED_ONCE_RELOCATE_VAR  785
 #define FF8_SCANNED_ONCE_RELOCATE_SIZE 32
+static_assert(FF8_SCANNED_ONCE_RELOCATE_SIZE >= 32, "must cover the full 0..255 com_id byte range (8 DWORDs)");
 
 // scene.out per-record layout (128 bytes/record, enemy_com_value[8] at
 // offset 56 - the data format, not the file's total size, which is read
@@ -132,78 +144,21 @@
 static char *ff8_extended_battle_filenames[FF8_BATTLE_FILES_ARRAY_LEN + FF8_NEW_C0M_COUNT];
 static char ff8_extended_c0m_names[FF8_NEW_C0M_COUNT][12]; // "C0M199.DAT" + NUL = 11
 
-// Original BattleFile_CharacterLoad(fileIndex, dst), saved so the hook below can
-// forward to it after remapping.
-static int (*ff8_battle_file_character_load)(int fileIndex, void *dst) = nullptr;
+// Original battle_load_file_sub_508480(fileIndex, dst), saved so the hook below
+// can forward to it after remapping.
+static int (*ff8_battle_load_file)(int fileIndex, void *dst) = nullptr;
 
 // C replacement for the loader's "index = com_id + 150" remap. Hooked onto the
-// single BattleFile_CharacterLoad call inside battle_monster_dat_loader, which
-// is only ever reached for monsters, so a file index in 310..365 unambiguously
-// means one of the newly unlocked c0m144..c0m199; those get remapped onto the
+// single battle-file load call inside battle_monster_dat_loader, which is only
+// ever reached for monsters, so a file index in 310..365 unambiguously means
+// one of the newly unlocked c0m144..c0m199; those get remapped onto the
 // appended table entries and everything else is forwarded untouched.
 static int ff8_battle_monster_load_file(int fileIndex, void *dst)
 {
 	if (fileIndex >= FF8_FIRST_NEW_FILE_INDEX && fileIndex <= FF8_LAST_NEW_FILE_INDEX)
 		fileIndex = FF8_BATTLE_FILES_ARRAY_LEN + (fileIndex - FF8_FIRST_NEW_FILE_INDEX);
 
-	return ff8_battle_file_character_load(fileIndex, dst);
-}
-
-// Returns the running exe's actual .text section bounds, read from its own
-// PE header (same technique as getProcessEntryPoint() in utils.cpp) rather
-// than an assumed/hardcoded address range - adapts automatically to any
-// version/build with no per-version literal at all.
-static void ff8_get_code_section_bounds(uint32_t *start, uint32_t *end)
-{
-	HMODULE base = GetModuleHandleA(nullptr);
-	PIMAGE_DOS_HEADER dos = (PIMAGE_DOS_HEADER)base;
-	PIMAGE_NT_HEADERS nt = (PIMAGE_NT_HEADERS)((BYTE *)base + dos->e_lfanew);
-
-	*start = (uint32_t)base + nt->OptionalHeader.BaseOfCode;
-	*end = *start + nt->OptionalHeader.SizeOfCode;
-}
-
-// ---- blind value-scan relocation (same technique as AddMoreMagic's --------
-// ---- drawn-once bitfield relocation, see that fork's kernel_magic.cpp) ----
-// Scans the exe's .text section for any dword equal to `from` and repoints
-// it to `to`. One false-positive class must be excluded: a `call rel32`
-// (0xE8) or `jmp rel32` (0xE9) whose opcode + displacement bytes happen to
-// numerically equal `from` - such a match has the branch opcode as its low
-// byte AND decodes to a target inside real code, which a genuine data
-// operand never does, so those are skipped.
-static uint32_t ff8_relocate_scan(uint32_t from, uint32_t to, const char *what)
-{
-	uint32_t scan_start, scan_end;
-	ff8_get_code_section_bounds(&scan_start, &scan_end);
-
-	uint32_t rewritten = 0, skipped_branch = 0;
-
-	for (uint32_t addr = scan_start; addr < scan_end - 4; ++addr)
-	{
-		uint32_t value = *(uint32_t *)addr;
-
-		if (value == from)
-		{
-			uint8_t op = *(uint8_t *)addr;
-			if (op == 0xE8 || op == 0xE9) // call/jmp rel32?
-			{
-				uint32_t target = addr + 5 + *(int32_t *)(addr + 1);
-				if (target >= scan_start && target < scan_end)
-				{
-					++skipped_branch; // real branch instruction - never touch it
-					continue;
-				}
-			}
-
-			patch_code_dword(addr, (DWORD)to);
-			++rewritten;
-			addr += 3; // skip the rewritten dword
-		}
-	}
-
-	if (trace_all) ffnx_trace("Extra battle monsters: %s: relocated %u site(s), skipped %u branch false-positive(s).\n",
-		what, rewritten, skipped_branch);
-	return rewritten;
+	return ff8_battle_load_file(fileIndex, dst);
 }
 
 // Looks up a battle-relative file's real size on disk without reading it,
@@ -273,33 +228,40 @@ static bool ff8_scene_out_uses_new_monsters()
 }
 
 // Relocates SG_ENEMY_SCANNED_ONCE (see the file-level comment above) from its
-// native 5-DWORD savemap field to an 8-DWORD block in verified-free savemap
-// space, so the existing com_id/32 index math stays in bounds for the full
-// 0..255 com_id range instead of only 0..159. Its address is derived
-// relatively from field_vars_stack_1CFE9B8, not signature-scanned, so this
-// needs no per-version address table. Empirically 3 sites reference it in
-// US 1.2 (Damage_DispatchByAttackType's read, hasEnemyAlreadyScanned's
-// write, plus one embedded reference in an unreferenced code gap between
-// Battle_RollCardCommand and Battle_applyDamage - harmless to relocate
-// either way); the actual count is only traced, not asserted, since it may
-// differ per language build. Only called when scene.out actually references
-// a new monster (see ff8_scene_out_uses_new_monsters above), so a vanilla or
-// not-yet-updated scene.out leaves this bitfield untouched.
-static_assert(FF8_SCANNED_ONCE_RELOCATE_SIZE >= 32, "must cover the full 0..255 com_id byte range (8 DWORDs)");
-
+// native 5-DWORD savemap field to an 8-DWORD block in free savemap space, so
+// the existing com_id/32 index math stays in bounds for the full 0..255
+// com_id range instead of only 0..159. Only called when scene.out actually
+// references a new monster (see ff8_scene_out_uses_new_monsters above), so a
+// vanilla or not-yet-updated scene.out leaves this bitfield untouched.
 static void ff8_relocate_enemy_scanned_once()
 {
-	if (!ff8_externals.field_vars_stack_1CFE9B8)
+	if (!ff8_externals.field_vars_stack_1CFE9B8
+		|| !ff8_externals.battle_enemy_scanned_read_operand
+		|| !ff8_externals.battle_enemy_scanned_write_operand)
 		return;
 
-	ff8_relocate_scan(ff8_externals.field_vars_stack_1CFE9B8 + FF8_SG_ENEMY_SCANNED_ONCE_OFFSET,
-		ff8_externals.field_vars_stack_1CFE9B8 + FF8_SCANNED_ONCE_RELOCATE_VAR,
-		"Scan/Libra scanned-once bitfield");
+	uint32_t from = ff8_externals.field_vars_stack_1CFE9B8 + FF8_SG_ENEMY_SCANNED_ONCE_OFFSET;
+	uint32_t to = ff8_externals.field_vars_stack_1CFE9B8 + FF8_SCANNED_ONCE_RELOCATE_VAR;
+
+	// Both operands must currently hold the vanilla field address. If either
+	// doesn't, the resolved offsets don't fit this build and writing to them
+	// would corrupt unrelated instructions, so leave the game alone.
+	if (*(uint32_t *)ff8_externals.battle_enemy_scanned_read_operand != from
+		|| *(uint32_t *)ff8_externals.battle_enemy_scanned_write_operand != from)
+	{
+		ffnx_warning("Extra battle monsters: Scan scanned-once operands do not hold the expected address, skipping relocation - scanning c0m144-c0m199 may corrupt the savemap!\n");
+		return;
+	}
+
+	patch_code_dword(ff8_externals.battle_enemy_scanned_read_operand, to);
+	patch_code_dword(ff8_externals.battle_enemy_scanned_write_operand, to);
+
+	if (trace_all) ffnx_trace("Extra battle monsters: Scan scanned-once bitfield relocated to var %d.\n", FF8_SCANNED_ONCE_RELOCATE_VAR);
 }
 
 void ff8_battle_monsters_init()
 {
-	if (!ff8_externals.battle_monster_file_load_call_site || !ff8_externals.battle_file_character_load)
+	if (!ff8_externals.battle_monster_file_load_call_site || !ff8_externals.battle_load_file_sub_508480)
 	{
 		if (trace_all) ffnx_trace("Extra battle monsters (c0m144-c0m199): unsupported game version, skipping.\n");
 		return;
@@ -328,12 +290,12 @@ void ff8_battle_monsters_init()
 	//    c0m144-199 indices instead of reading past the original array.
 	ff8_externals.battle_filenames = ff8_extended_battle_filenames;
 
-	// 2) Redirect the monster loader's BattleFile_CharacterLoad call to the C
-	//    hook, keeping the original target to forward to.
-	ff8_battle_file_character_load = (int (*)(int, void *))ff8_externals.battle_file_character_load;
+	// 2) Redirect the monster loader's battle-file load call to the C hook,
+	//    keeping the original target to forward to.
+	ff8_battle_load_file = (int (*)(int, void *))ff8_externals.battle_load_file_sub_508480;
 	replace_call(ff8_externals.battle_monster_file_load_call_site, (void *)&ff8_battle_monster_load_file);
 
-	// 3) Relocate the Scan/Libra scanned-once bitfield so it stays in bounds
+	// 3) Relocate the Scan scanned-once bitfield so it stays in bounds
 	//    for the new monsters' com_id range too (see file-level comment), but
 	//    only when scene.out actually references one - a vanilla or
 	//    not-yet-updated scene.out never reaches a com_id past 159, so the

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    Copyright (C) 2026 Julian Xhokaxhiu                                    //
+//    Copyright (C) 2026 Julian Xhokaxhiu, HobbitDur                        //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //
@@ -56,10 +56,12 @@
 // (never a direct call/jmp instruction anywhere in the exe), so its
 // "add eax, 150" com_id remap site can't be resolved through a relative-call
 // chain either; ff8_externals.battle_monster_dat_loader_com_id_add_site is
-// resolved as a per-version absolute address in ff8_data.cpp instead (same
-// pattern as sub_54A0D0 there), verified by signature-scanning all seven
-// retail 1.2 exe files (EN/FR/DE/IT/SP/JP/JP_NV) - see ff8_data.cpp for the
-// address table. The BattleFilesArray table structure itself (c0m000..c0m143
+// derived in ff8_data.cpp from a per-version absolute address for its caller
+// BattleTask_DispatchComEntityLoad (same fallback as sub_54A0D0 there, since
+// that caller also has no static xref anywhere in the exe), plus a fixed
+// +0x23A byte offset confirmed identical across all seven retail 1.2 exe
+// files (EN/FR/DE/IT/SP/JP/JP_NV) - see ff8_data.cpp for the address table.
+// The BattleFilesArray table structure itself (c0m000..c0m143
 // at indices 166..309, D0C000.DAT immediately at 310, 1117 entries total) is
 // confirmed identical across all seven builds, so FF8_BATTLE_FILES_ARRAY_LEN
 // below is not version-dependent.
@@ -106,14 +108,14 @@ void ff8_battle_monsters_init()
 	uint32_t add_site = ff8_externals.battle_monster_dat_loader_com_id_add_site;
 	if (!add_site)
 	{
-		ffnx_info("Extra battle monsters (c0m144-c0m199): unsupported game version, skipping.\n");
+		ffnx_trace("Extra battle monsters (c0m144-c0m199): unsupported game version, skipping.\n");
 		return;
 	}
 
 	char **orig = (char **)ff8_externals.battle_filenames;
 	if (orig == nullptr)
 	{
-		ffnx_warning("Extra battle monsters: battle_filenames not resolved, skipping.\n");
+		ffnx_trace("Extra battle monsters: battle_filenames not resolved, skipping.\n");
 		return;
 	}
 
@@ -135,6 +137,5 @@ void ff8_battle_monsters_init()
 	*(uint32_t *)&call_patch[1] = (uint32_t)&ff8_battle_monster_index_remap - (add_site + 5);
 	memcpy_code(add_site, call_patch, sizeof(call_patch));
 
-	ffnx_info("Extra battle monsters enabled: c0m%03d-c0m%03d usable via enemy_com_value %d-%d.\n",
-		FF8_FIRST_NEW_C0M, FF8_LAST_NEW_C0M, FF8_FIRST_NEW_COM_ID, FF8_LAST_NEW_COM_ID);
+	ffnx_info("Extra battle monsters enabled: c0m%03d-c0m%03d usable via enemy_com_value %d-%d.\n", FF8_FIRST_NEW_C0M, FF8_LAST_NEW_C0M, FF8_FIRST_NEW_COM_ID, FF8_LAST_NEW_COM_ID);
 }

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -101,22 +101,20 @@ static int ff8_battle_monster_load_file(int fileIndex, void *dst)
 
 void ff8_battle_monsters_init()
 {
-	uint32_t call_site = ff8_externals.battle_monster_file_load_call_site;
-	if (!call_site || !ff8_externals.battle_file_character_load)
+	if (!ff8_externals.battle_monster_file_load_call_site || !ff8_externals.battle_file_character_load)
 	{
 		ffnx_trace("Extra battle monsters (c0m144-c0m199): unsupported game version, skipping.\n");
 		return;
 	}
 
-	char **orig = (char **)ff8_externals.battle_filenames;
-	if (orig == nullptr)
+	if (ff8_externals.battle_filenames == nullptr)
 	{
 		ffnx_trace("Extra battle monsters: battle_filenames not resolved, skipping.\n");
 		return;
 	}
 
 	// 1) Copy the original table verbatim, then append the new c0m entries.
-	memcpy(ff8_extended_battle_filenames, orig, FF8_BATTLE_FILES_ARRAY_LEN * sizeof(char *));
+	memcpy(ff8_extended_battle_filenames, ff8_externals.battle_filenames, FF8_BATTLE_FILES_ARRAY_LEN * sizeof(char *));
 	for (int i = 0; i < FF8_NEW_C0M_COUNT; ++i)
 	{
 		snprintf(ff8_extended_c0m_names[i], sizeof(ff8_extended_c0m_names[i]), "C0M%03d.DAT", FF8_FIRST_NEW_C0M + i);
@@ -135,7 +133,7 @@ void ff8_battle_monsters_init()
 	// 2) Redirect the monster loader's BattleFile_CharacterLoad call to the C
 	//    hook, keeping the original target to forward to.
 	ff8_battle_file_character_load = (int (*)(int, void *))ff8_externals.battle_file_character_load;
-	replace_call(call_site, (void *)&ff8_battle_monster_load_file);
+	replace_call(ff8_externals.battle_monster_file_load_call_site, (void *)&ff8_battle_monster_load_file);
 
 	ffnx_info("Extra battle monsters enabled: c0m%03d-c0m%03d usable via enemy_com_value %d-%d.\n", FF8_FIRST_NEW_C0M, FF8_LAST_NEW_C0M, FF8_FIRST_NEW_COM_ID, FF8_LAST_NEW_COM_ID);
 }

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -135,9 +135,11 @@
 #define FF8_FIRST_NEW_FILE_INDEX (FF8_FIRST_NEW_COM_ID + 150) // 310
 #define FF8_LAST_NEW_FILE_INDEX  (FF8_LAST_NEW_COM_ID + 150)  // 365
 
-// SG_ENEMY_SCANNED_ONCE sits 0x54 bytes before field_vars_stack_1CFE9B8 (the
-// field-script variable block base, "VARMAP_START") in the same packed
-// savemap globals - a fixed C-struct field offset, IDA-verified on US 1.2.
+// Where SG_ENEMY_SCANNED_ONCE sits relative to field_vars_stack_1CFE9B8 (the
+// field-script variable block base, "VARMAP_START"): 0x54 bytes before it, in
+// the same packed savemap globals. This is only used to sanity-check the
+// address read out of the instructions that index the field - it is not how
+// the address is obtained.
 #define FF8_SG_ENEMY_SCANNED_ONCE_OFFSET (-0x54)
 // Relocation target: field-script variables 785..816 (32 bytes / 8 DWORDs,
 // safe for the full 0..255 com_id byte range), inside the verified-free
@@ -286,16 +288,19 @@ static void ff8_relocate_enemy_scanned_once()
 		|| !ff8_externals.battle_enemy_scanned_write_operand)
 		return;
 
-	uint32_t from = ff8_externals.field_vars_stack_1CFE9B8 + FF8_SG_ENEMY_SCANNED_ONCE_OFFSET;
+	// Take the field's address from the instruction that indexes it rather than
+	// computing it: whatever the reader dereferences is the field, by
+	// definition. Two independent checks then guard against a mis-resolved
+	// operand, since writing to one would corrupt unrelated code: the writer
+	// must reference the same address, and it must sit where the savemap
+	// layout says it does.
+	uint32_t from = *(uint32_t *)ff8_externals.battle_enemy_scanned_read_operand;
+	uint32_t expected = ff8_externals.field_vars_stack_1CFE9B8 + FF8_SG_ENEMY_SCANNED_ONCE_OFFSET;
 	uint32_t to = ff8_externals.field_vars_stack_1CFE9B8 + FF8_SCANNED_ONCE_RELOCATE_VAR;
 
-	// Both operands must currently hold the vanilla field address. If either
-	// doesn't, the resolved offsets don't fit this build and writing to them
-	// would corrupt unrelated instructions, so leave the game alone.
-	if (*(uint32_t *)ff8_externals.battle_enemy_scanned_read_operand != from
-		|| *(uint32_t *)ff8_externals.battle_enemy_scanned_write_operand != from)
+	if (from != *(uint32_t *)ff8_externals.battle_enemy_scanned_write_operand || from != expected)
 	{
-		ffnx_warning("Extra battle monsters: Scan scanned-once operands do not hold the expected address, skipping relocation - scanning c0m144-c0m199 may corrupt the savemap!\n");
+		ffnx_warning("Extra battle monsters: Scan scanned-once operands do not agree with the savemap layout (read 0x%08X, expected 0x%08X), skipping relocation - scanning c0m144-c0m199 may corrupt the savemap!\n", from, expected);
 		return;
 	}
 

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -60,9 +60,10 @@
 // (battle_load_file_sub_508480) are likewise resolved relatively in
 // ff8_data.cpp; the +0x240 offset is confirmed identical across all seven
 // retail 1.2 exe files (EN/FR/DE/IT/SP/JP/JP_NV). The BattleFilesArray table
-// (c0m000..c0m143 at indices 166..309, D0C000.DAT immediately at 310, 1117
-// entries total) is confirmed identical across all seven builds, so
-// FF8_BATTLE_FILES_ARRAY_LEN below is not version-dependent.
+// (c0m000..c0m143 at indices 166..309, D0C000.DAT immediately at 310) is
+// confirmed identical across all seven builds. Its length is not hardcoded
+// either: it is counted at init by walking the table while its entries still
+// look like pointers into the module image (see ff8_count_battle_filenames).
 //
 // Scan savemap overflow fix: the "already scanned" bitfield
 // SG_ENEMY_SCANNED_ONCE (savemap global @ 0x1cfe964, IDA-verified, modelled
@@ -105,8 +106,10 @@
 // serve no purpose.
 // -------------------------------------------------------------------------
 
-// Length of the original BattleFilesArray (US 1.2), indices 0..1116.
-#define FF8_BATTLE_FILES_ARRAY_LEN 1117
+// Sanity bound while counting the original BattleFilesArray; it holds 1117
+// entries on every retail 1.2 build, so this only exists to stop a runaway
+// walk if the table ever looks unfamiliar.
+#define FF8_BATTLE_FILES_ARRAY_MAX 4096
 // c0m file range to add.
 #define FF8_FIRST_NEW_C0M 144
 #define FF8_LAST_NEW_C0M  199
@@ -138,11 +141,41 @@ static_assert(FF8_SCANNED_ONCE_RELOCATE_SIZE >= 32, "must cover the full 0..255 
 #define FF8_SCENE_OUT_ENEMY_COM_VALUE_OFFSET 56
 #define FF8_SCENE_OUT_ENEMY_SLOTS            8
 
-// Must stay static, not stack-local: ff8_battle_monsters_init() hands the exe
-// (via patch_code_dword) and ff8_externals.battle_filenames a raw pointer into
-// these arrays that's expected to remain valid for the rest of the process.
-static char *ff8_extended_battle_filenames[FF8_BATTLE_FILES_ARRAY_LEN + FF8_NEW_C0M_COUNT];
+// Both of these are handed to the exe (via patch_code_dword) and to
+// ff8_externals.battle_filenames as raw pointers, so they must stay valid for
+// the rest of the process: heap-allocated once, never freed, and static.
+static char **ff8_extended_battle_filenames = nullptr;
 static char ff8_extended_c0m_names[FF8_NEW_C0M_COUNT][12]; // "C0M199.DAT" + NUL = 11
+// Length of the original BattleFilesArray, counted at init (see below).
+static uint32_t ff8_battle_files_count = 0;
+
+// Counts the original BattleFilesArray instead of hardcoding its length. Every
+// entry is a pointer to a filename string inside the loaded module image, and
+// the dword immediately after the last entry is not (it is 0x101 on US 1.2),
+// so the run of in-image pointers ends exactly at the end of the array. Bounds
+// come from the module's own PE header, so this needs no per-version literal.
+static uint32_t ff8_count_battle_filenames(const char *const *filenames)
+{
+	HMODULE module = GetModuleHandleA(nullptr);
+	PIMAGE_DOS_HEADER dos = (PIMAGE_DOS_HEADER)module;
+	PIMAGE_NT_HEADERS nt = (PIMAGE_NT_HEADERS)((BYTE *)module + dos->e_lfanew);
+
+	uintptr_t image_start = (uintptr_t)module;
+	uintptr_t image_end = image_start + nt->OptionalHeader.SizeOfImage;
+
+	uint32_t count = 0;
+	while (count < FF8_BATTLE_FILES_ARRAY_MAX)
+	{
+		uintptr_t entry = (uintptr_t)filenames[count];
+
+		if (entry < image_start || entry >= image_end)
+			break;
+
+		++count;
+	}
+
+	return count;
+}
 
 // Original battle_load_file_sub_508480(fileIndex, dst), saved so the hook below
 // can forward to it after remapping.
@@ -156,7 +189,7 @@ static int (*ff8_battle_load_file)(int fileIndex, void *dst) = nullptr;
 static int ff8_battle_monster_load_file(int fileIndex, void *dst)
 {
 	if (fileIndex >= FF8_FIRST_NEW_FILE_INDEX && fileIndex <= FF8_LAST_NEW_FILE_INDEX)
-		fileIndex = FF8_BATTLE_FILES_ARRAY_LEN + (fileIndex - FF8_FIRST_NEW_FILE_INDEX);
+		fileIndex = ff8_battle_files_count + (fileIndex - FF8_FIRST_NEW_FILE_INDEX);
 
 	return ff8_battle_load_file(fileIndex, dst);
 }
@@ -273,12 +306,23 @@ void ff8_battle_monsters_init()
 		return;
 	}
 
+	ff8_battle_files_count = ff8_count_battle_filenames(ff8_externals.battle_filenames);
+	if (ff8_battle_files_count == 0 || ff8_battle_files_count >= FF8_BATTLE_FILES_ARRAY_MAX)
+	{
+		ffnx_warning("Extra battle monsters: unexpected battle file table length (%u), skipping.\n", ff8_battle_files_count);
+		return;
+	}
+
 	// 1) Copy the original table verbatim, then append the new c0m entries.
-	memcpy(ff8_extended_battle_filenames, ff8_externals.battle_filenames, FF8_BATTLE_FILES_ARRAY_LEN * sizeof(char *));
-	for (int i = 0; i < FF8_NEW_C0M_COUNT; ++i)
+	ff8_extended_battle_filenames = (char **)driver_malloc((ff8_battle_files_count + FF8_NEW_C0M_COUNT) * sizeof(char *));
+	if (ff8_extended_battle_filenames == nullptr)
+		return;
+
+	memcpy(ff8_extended_battle_filenames, ff8_externals.battle_filenames, ff8_battle_files_count * sizeof(char *));
+	for (uint32_t i = 0; i < FF8_NEW_C0M_COUNT; ++i)
 	{
 		snprintf(ff8_extended_c0m_names[i], sizeof(ff8_extended_c0m_names[i]), "C0M%03d.DAT", FF8_FIRST_NEW_C0M + i);
-		ff8_extended_battle_filenames[FF8_BATTLE_FILES_ARRAY_LEN + i] = ff8_extended_c0m_names[i];
+		ff8_extended_battle_filenames[ff8_battle_files_count + i] = ff8_extended_c0m_names[i];
 	}
 
 	//    Repoint LoadBattleFile's array base: mov ebx, BattleFilesArray[eax*4].
@@ -300,8 +344,15 @@ void ff8_battle_monsters_init()
 	//    only when scene.out actually references one - a vanilla or
 	//    not-yet-updated scene.out never reaches a com_id past 159, so the
 	//    native field is already safe and there's nothing to relocate.
-	if (ff8_scene_out_uses_new_monsters())
+	bool uses_new_monsters = ff8_scene_out_uses_new_monsters();
+
+	if (uses_new_monsters)
 		ff8_relocate_enemy_scanned_once();
 
-	ffnx_info("Extra battle monsters enabled: c0m%03d-c0m%03d usable via enemy_com_value %d-%d.\n", FF8_FIRST_NEW_C0M, FF8_LAST_NEW_C0M, FF8_FIRST_NEW_COM_ID, FF8_LAST_NEW_COM_ID);
+	// Only worth reporting when a mod actually references one of the new
+	// monsters: the table is extended on every supported build, but on a
+	// vanilla install nothing ever indexes into the appended range, so staying
+	// quiet there keeps this out of everyone else's log.
+	if (uses_new_monsters && trace_all)
+		ffnx_trace("Extra battle monsters enabled: c0m%03d-c0m%03d usable via enemy_com_value %d-%d (%u original battle files).\n", FF8_FIRST_NEW_C0M, FF8_LAST_NEW_C0M, FF8_FIRST_NEW_COM_ID, FF8_LAST_NEW_COM_ID, ff8_battle_files_count);
 }

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -64,21 +64,34 @@
 // entries total) is confirmed identical across all seven builds, so
 // FF8_BATTLE_FILES_ARRAY_LEN below is not version-dependent.
 //
-// KNOWN LIMITATION (not fixed by this patch - savemap corruption, not a
-// crash): the Scan/Libra "already scanned" bitfield SG_ENEMY_SCANNED_ONCE
-// (savemap global @ 0x1cfe964, IDA-verified) is only 5 DWORDs (20 bytes),
-// immediately followed in the packed savemap struct by SG_RENZOKUKEN_AUTO /
-// SG_RENZOKUKEN_INDICATOR / SG_ODIN_ANGEL_GILGA_FLAG / SG_TUTORIAL_INFO.
-// Both readers/writers of it - Damage_DispatchByAttackType's ATTACK_TYPE_SCAN
-// case (@0x4925a6) and hasEnemyAlreadyScanned (@0x493810) - index it as
-// SG_ENEMY_SCANNED_ONCE[(unsigned __int8)com_file_id / 32] with NO bounds
-// check, so it's only safe for com_file_id (com_id) 0..159. Every com_id this
-// patch adds (160..215, i.e. c0m144..c0m199) is already past that: Scanning
-// any of the new monsters (Scan spell / Libra / Enc-None chance-scan) writes
-// out of bounds into the Renzokuken/tutorial-flag savemap fields above,
-// silently corrupting them. Not addressed here; would need its own hook on
-// the Scan check/write (same shape as the BattleFile_CharacterLoad hook
-// below) to remap or bound com_id before it reaches SG_ENEMY_SCANNED_ONCE.
+// Scan/Libra savemap overflow fix: the "already scanned" bitfield
+// SG_ENEMY_SCANNED_ONCE (savemap global @ 0x1cfe964, IDA-verified) is only 5
+// DWORDs (20 bytes), immediately followed in the packed savemap struct by
+// SG_RENZOKUKEN_AUTO/SG_RENZOKUKEN_INDICATOR/SG_ODIN_ANGEL_GILGA_FLAG/
+// SG_TUTORIAL_INFO. Both readers/writers of it - Damage_DispatchByAttackType's
+// ATTACK_TYPE_SCAN case (@0x4925a6) and hasEnemyAlreadyScanned (@0x493810) -
+// index it as SG_ENEMY_SCANNED_ONCE[(unsigned __int8)com_file_id / 32] with NO
+// bounds check, so it's only safe for com_file_id (com_id) 0..159. Every
+// com_id this patch adds (160..215, i.e. c0m144..c0m199) is already past
+// that: Scanning any of the new monsters (Scan spell / Libra / Enc-None
+// chance-scan) would write out of bounds into the Renzokuken/tutorial-flag
+// savemap fields above, silently corrupting them.
+//
+// Fixed the same way AddMoreMagic (a sibling FFNx fork) relocates its
+// magic "drawn once" bitfield out of a too-small native field: blind
+// value-scan every dword in .text for SG_ENEMY_SCANNED_ONCE's address and
+// repoint it at a bigger (32-byte / 8-DWORD, safe for the full 0..255
+// com_id byte range) block in verified-free savemap space, keeping the
+// existing com_id/32 index math unchanged. SG_ENEMY_SCANNED_ONCE's address
+// itself is derived relatively as field_vars_stack_1CFE9B8 - 0x54 (a fixed
+// C-struct field offset within the same packed savemap globals, not a
+// signature-scanned value, so it needs no separate per-version address
+// table); field_vars_stack_1CFE9B8 already resolves per version elsewhere
+// in ff8_data.cpp. The relocation target uses savemap free-region bytes
+// 785..816 (var 753..784 is already claimed by AddMoreMagic's drawn-once
+// relocation - see that fork's kernel_magic.cpp - so this deliberately
+// starts right after it to avoid a collision if both forks ever land
+// upstream together).
 // -------------------------------------------------------------------------
 
 // Length of the original BattleFilesArray (US 1.2), indices 0..1116.
@@ -95,6 +108,23 @@
 // D0C character files); the hook remaps those onto the appended table entries.
 #define FF8_FIRST_NEW_FILE_INDEX (FF8_FIRST_NEW_COM_ID + 150) // 310
 #define FF8_LAST_NEW_FILE_INDEX  (FF8_LAST_NEW_COM_ID + 150)  // 365
+
+// SG_ENEMY_SCANNED_ONCE sits 0x54 bytes before field_vars_stack_1CFE9B8 (the
+// field-script variable block base, "VARMAP_START") in the same packed
+// savemap globals - a fixed C-struct field offset, IDA-verified on US 1.2.
+#define FF8_SG_ENEMY_SCANNED_ONCE_OFFSET (-0x54)
+// Relocation target: savemap free-region bytes 785..816 (32 bytes / 8 DWORDs,
+// safe for the full 0..255 com_id byte range). Bytes 753..784 of this same
+// free region are already claimed by AddMoreMagic's drawn-once relocation.
+#define FF8_SCANNED_ONCE_RELOCATE_VAR  785
+#define FF8_SCANNED_ONCE_RELOCATE_SIZE 32
+
+// scene.out per-record layout (128 bytes/record, enemy_com_value[8] at
+// offset 56 - the data format, not the file's total size, which is read
+// dynamically below so a modded/enlarged scene.out is handled correctly).
+#define FF8_SCENE_OUT_RECORD_SIZE            128
+#define FF8_SCENE_OUT_ENEMY_COM_VALUE_OFFSET 56
+#define FF8_SCENE_OUT_ENEMY_SLOTS            8
 
 // Must stay static, not stack-local: ff8_battle_monsters_init() hands the exe
 // (via patch_code_dword) and ff8_externals.battle_filenames a raw pointer into
@@ -117,6 +147,154 @@ static int ff8_battle_monster_load_file(int fileIndex, void *dst)
 		fileIndex = FF8_BATTLE_FILES_ARRAY_LEN + (fileIndex - FF8_FIRST_NEW_FILE_INDEX);
 
 	return ff8_battle_file_character_load(fileIndex, dst);
+}
+
+// Returns the running exe's actual .text section bounds, read from its own
+// PE header (same technique as getProcessEntryPoint() in utils.cpp) rather
+// than an assumed/hardcoded address range - adapts automatically to any
+// version/build with no per-version literal at all.
+static void ff8_get_code_section_bounds(uint32_t *start, uint32_t *end)
+{
+	HMODULE base = GetModuleHandleA(nullptr);
+	PIMAGE_DOS_HEADER dos = (PIMAGE_DOS_HEADER)base;
+	PIMAGE_NT_HEADERS nt = (PIMAGE_NT_HEADERS)((BYTE *)base + dos->e_lfanew);
+
+	*start = (uint32_t)base + nt->OptionalHeader.BaseOfCode;
+	*end = *start + nt->OptionalHeader.SizeOfCode;
+}
+
+// ---- blind value-scan relocation (same technique as AddMoreMagic's --------
+// ---- drawn-once bitfield relocation, see that fork's kernel_magic.cpp) ----
+// Scans the exe's .text section for any dword equal to `from` and repoints
+// it to `to`. One false-positive class must be excluded: a `call rel32`
+// (0xE8) or `jmp rel32` (0xE9) whose opcode + displacement bytes happen to
+// numerically equal `from` - such a match has the branch opcode as its low
+// byte AND decodes to a target inside real code, which a genuine data
+// operand never does, so those are skipped.
+static uint32_t ff8_relocate_scan(uint32_t from, uint32_t to, const char *what)
+{
+	uint32_t scan_start, scan_end;
+	ff8_get_code_section_bounds(&scan_start, &scan_end);
+
+	uint32_t rewritten = 0, skipped_branch = 0;
+
+	for (uint32_t addr = scan_start; addr < scan_end - 4; ++addr)
+	{
+		uint32_t value = *(uint32_t *)addr;
+
+		if (value == from)
+		{
+			uint8_t op = *(uint8_t *)addr;
+			if (op == 0xE8 || op == 0xE9) // call/jmp rel32?
+			{
+				uint32_t target = addr + 5 + *(int32_t *)(addr + 1);
+				if (target >= scan_start && target < scan_end)
+				{
+					++skipped_branch; // real branch instruction - never touch it
+					continue;
+				}
+			}
+
+			patch_code_dword(addr, (DWORD)to);
+			++rewritten;
+			addr += 3; // skip the rewritten dword
+		}
+	}
+
+	if (trace_all) ffnx_trace("Extra battle monsters: %s: relocated %u site(s), skipped %u branch false-positive(s).\n",
+		what, rewritten, skipped_branch);
+	return rewritten;
+}
+
+// Looks up a battle-relative file's real size on disk without reading it,
+// checking the same two places FFNx actually stores loose files: the
+// "direct" override folder first, then the plain extracted layout. Doesn't
+// need to know anything about the packed-archive format (fl/fs/fi tables) -
+// modern FFNx installs serve battle files as loose files in one of these two
+// places, not from the original PSX archives.
+static bool ff8_get_battle_file_size_on_disk(const char *relative_path, uint32_t *size_out)
+{
+	char full_path[MAX_PATH];
+	WIN32_FILE_ATTRIBUTE_DATA attr;
+
+	snprintf(full_path, sizeof(full_path), "%s\\direct\\%s", ff8_externals.app_path, relative_path);
+	if (!GetFileAttributesExA(full_path, GetFileExInfoStandard, &attr))
+	{
+		snprintf(full_path, sizeof(full_path), "%s\\%s", ff8_externals.app_path, relative_path);
+		if (!GetFileAttributesExA(full_path, GetFileExInfoStandard, &attr))
+			return false;
+	}
+
+	*size_out = attr.nFileSizeLow;
+	return true;
+}
+
+// Reads scene.out (through FFNx's own sm_pc_read, so file overrides are
+// respected the same way the game itself would load it) and checks every
+// encounter's enemy_com_value[8] bytes for one referencing a newly unlocked
+// monster (com_id >= FF8_FIRST_NEW_COM_ID). Only encounter data determines
+// whether the relocation below is ever needed - the exe/kernel side has no
+// equivalent "count" to gate on the way AddMoreMagic gates on kernel magic
+// count. The read buffer is sized from the file's real size on disk (see
+// ff8_get_battle_file_size_on_disk above), not an assumed vanilla constant,
+// so a modded/enlarged scene.out is scanned correctly. If the size can't be
+// determined at all (e.g. a packed-archive-only install with no loose
+// scene.out anywhere), be conservative and report "needed" rather than
+// silently skip a real fix.
+static bool ff8_scene_out_uses_new_monsters()
+{
+	uint32_t file_size;
+	if (!ff8_get_battle_file_size_on_disk("battle\\scene.out", &file_size))
+		return true;
+
+	uint8_t *scene_out = new uint8_t[file_size];
+	char scene_out_filename[] = "battle/scene.out";
+	uint32_t read_size = ff8_externals.sm_pc_read(scene_out_filename, scene_out);
+	if (read_size > file_size)
+		read_size = file_size;
+
+	bool uses_new_monsters = false;
+	for (uint32_t offset = FF8_SCENE_OUT_ENEMY_COM_VALUE_OFFSET;
+		!uses_new_monsters && offset + FF8_SCENE_OUT_ENEMY_SLOTS <= read_size;
+		offset += FF8_SCENE_OUT_RECORD_SIZE)
+	{
+		for (int slot = 0; slot < FF8_SCENE_OUT_ENEMY_SLOTS; ++slot)
+		{
+			if (scene_out[offset + slot] >= FF8_FIRST_NEW_COM_ID)
+			{
+				uses_new_monsters = true;
+				break;
+			}
+		}
+	}
+
+	delete[] scene_out;
+	return uses_new_monsters;
+}
+
+// Relocates SG_ENEMY_SCANNED_ONCE (see the file-level comment above) from its
+// native 5-DWORD savemap field to an 8-DWORD block in verified-free savemap
+// space, so the existing com_id/32 index math stays in bounds for the full
+// 0..255 com_id range instead of only 0..159. Its address is derived
+// relatively from field_vars_stack_1CFE9B8, not signature-scanned, so this
+// needs no per-version address table. Empirically 3 sites reference it in
+// US 1.2 (Damage_DispatchByAttackType's read, hasEnemyAlreadyScanned's
+// write, plus one embedded reference in an unreferenced code gap between
+// Battle_RollCardCommand and Battle_applyDamage - harmless to relocate
+// either way); the actual count is only traced, not asserted, since it may
+// differ per language build. Only called when scene.out actually references
+// a new monster (see ff8_scene_out_uses_new_monsters above), so a vanilla or
+// not-yet-updated scene.out leaves this bitfield untouched.
+static_assert(FF8_SCANNED_ONCE_RELOCATE_SIZE >= 32, "must cover the full 0..255 com_id byte range (8 DWORDs)");
+
+static void ff8_relocate_enemy_scanned_once()
+{
+	if (!ff8_externals.field_vars_stack_1CFE9B8)
+		return;
+
+	ff8_relocate_scan(ff8_externals.field_vars_stack_1CFE9B8 + FF8_SG_ENEMY_SCANNED_ONCE_OFFSET,
+		ff8_externals.field_vars_stack_1CFE9B8 + FF8_SCANNED_ONCE_RELOCATE_VAR,
+		"Scan/Libra scanned-once bitfield");
 }
 
 void ff8_battle_monsters_init()
@@ -154,6 +332,14 @@ void ff8_battle_monsters_init()
 	//    hook, keeping the original target to forward to.
 	ff8_battle_file_character_load = (int (*)(int, void *))ff8_externals.battle_file_character_load;
 	replace_call(ff8_externals.battle_monster_file_load_call_site, (void *)&ff8_battle_monster_load_file);
+
+	// 3) Relocate the Scan/Libra scanned-once bitfield so it stays in bounds
+	//    for the new monsters' com_id range too (see file-level comment), but
+	//    only when scene.out actually references one - a vanilla or
+	//    not-yet-updated scene.out never reaches a com_id past 159, so the
+	//    native field is already safe and there's nothing to relocate.
+	if (ff8_scene_out_uses_new_monsters())
+		ff8_relocate_enemy_scanned_once();
 
 	ffnx_info("Extra battle monsters enabled: c0m%03d-c0m%03d usable via enemy_com_value %d-%d.\n", FF8_FIRST_NEW_C0M, FF8_LAST_NEW_C0M, FF8_FIRST_NEW_COM_ID, FF8_LAST_NEW_COM_ID);
 }

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************/
-//    Copyright (C) 2026 Julian Xhokaxhiu, HobbitDur                        //
+//    Copyright (C) 2026 Julian Xhokaxhiu                                    //
+//    Copyright (C) 2026 HobbitDur                                          //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -38,13 +38,15 @@
 //     Index 310 is immediately D0C000.DAT (character files), so the c0m block
 //     cannot grow in place, and com_id 160..215 currently resolve to D0C/garbage.
 //
-// Fix (three memory patches):
+// Fix (two memory patches):
 //   1) Build an enlarged copy of BattleFilesArray = the original entries
-//      verbatim + 56 appended pointers to new "C0M144.DAT".."C0M199.DAT".
-//   2) Repoint LoadBattleFile's array base to the enlarged copy. Every existing
-//      index resolves identically (the prefix is copied verbatim); nothing shifts.
-//   3) Hook the loader's "index = com_id + 150" so com_id 160..215 map to the
-//      appended range instead of colliding with D0C.
+//      verbatim + 56 appended pointers to new "C0M144.DAT".."C0M199.DAT",
+//      and repoint LoadBattleFile's array base to it. Every existing index
+//      resolves identically (the prefix is copied verbatim); nothing shifts.
+//   2) Redirect the single BattleFile_CharacterLoad call inside
+//      battle_monster_dat_loader (the monster load path) to a C hook that
+//      remaps the com_id 160..215 file indices into the appended range
+//      instead of letting them collide with D0C.
 //
 // Encounters need no exe change: enemy_com_value is already a byte, so setting
 // it to (c0m# + 16) selects any monster up to c0m199.
@@ -52,20 +54,14 @@
 // ff8_externals.battle_open_file / battle_filenames already resolve
 // dynamically per version via the existing get_relative_call chain in
 // ff8_data.cpp (sub_47CCB0 -> ... -> battle_open_file), so this file uses
-// them as-is with no version branching of its own. battle_monster_dat_loader
-// itself is only ever reached through a function-pointer task dispatch
-// (never a direct call/jmp instruction anywhere in the exe), so its
-// "add eax, 150" com_id remap site can't be resolved through a relative-call
-// chain either; ff8_externals.battle_monster_dat_loader_com_id_add_site is
-// derived in ff8_data.cpp from a per-version absolute address for its caller
-// BattleTask_DispatchComEntityLoad (same fallback as sub_54A0D0 there, since
-// that caller also has no static xref anywhere in the exe), plus a fixed
-// +0x23A byte offset confirmed identical across all seven retail 1.2 exe
-// files (EN/FR/DE/IT/SP/JP/JP_NV) - see ff8_data.cpp for the address table.
-// The BattleFilesArray table structure itself (c0m000..c0m143
-// at indices 166..309, D0C000.DAT immediately at 310, 1117 entries total) is
-// confirmed identical across all seven builds, so FF8_BATTLE_FILES_ARRAY_LEN
-// below is not version-dependent.
+// them as-is with no version branching of its own. The hooked call site
+// (battle_monster_dat_loader + 0x240) and its target (BattleFile_CharacterLoad)
+// are likewise resolved relatively in ff8_data.cpp; the +0x240 offset is
+// confirmed identical across all seven retail 1.2 exe files
+// (EN/FR/DE/IT/SP/JP/JP_NV). The BattleFilesArray table structure itself
+// (c0m000..c0m143 at indices 166..309, D0C000.DAT immediately at 310, 1117
+// entries total) is confirmed identical across all seven builds, so
+// FF8_BATTLE_FILES_ARRAY_LEN below is not version-dependent.
 // -------------------------------------------------------------------------
 
 // Length of the original BattleFilesArray (US 1.2), indices 0..1116.
@@ -77,37 +73,36 @@
 // com_id = c0m# + 16, so the added monsters use com_id 160..215.
 #define FF8_FIRST_NEW_COM_ID (FF8_FIRST_NEW_C0M + 16) // 160
 #define FF8_LAST_NEW_COM_ID  (FF8_LAST_NEW_C0M + 16)  // 215
-// New entries are appended at index FF8_BATTLE_FILES_ARRAY_LEN, so:
-//   index(com_id) = FF8_BATTLE_FILES_ARRAY_LEN + (com_id - FF8_FIRST_NEW_COM_ID)
-//                 = com_id + (FF8_BATTLE_FILES_ARRAY_LEN - FF8_FIRST_NEW_COM_ID)
-#define FF8_NEW_C0M_INDEX_BIAS (FF8_BATTLE_FILES_ARRAY_LEN - FF8_FIRST_NEW_COM_ID) // 957
+// The loader passes BattleFile_CharacterLoad a file index of (com_id + 150), so
+// the new com_id 160..215 arrive as indices 310..365 (which retail resolves to
+// D0C character files); the hook remaps those onto the appended table entries.
+#define FF8_FIRST_NEW_FILE_INDEX (FF8_FIRST_NEW_COM_ID + 150) // 310
+#define FF8_LAST_NEW_FILE_INDEX  (FF8_LAST_NEW_COM_ID + 150)  // 365
 
 static char *ff8_extended_battle_filenames[FF8_BATTLE_FILES_ARRAY_LEN + FF8_NEW_C0M_COUNT];
 static char ff8_extended_c0m_names[FF8_NEW_C0M_COUNT][12]; // "C0M199.DAT" + NUL = 11
 
-// Custom "eax in / eax out" trampoline that replaces the loader's com_id+150.
-// eax = com_id on entry, returns the BattleFilesArray index in eax. Only eax
-// and the flags are touched; the surrounding code does not rely on the flags
-// after this point (it just pushes eax and calls), so this is transparent.
-static __declspec(naked) void ff8_battle_monster_index_remap()
+// Original BattleFile_CharacterLoad(fileIndex, dst), saved so the hook below can
+// forward to it after remapping.
+static int (*ff8_battle_file_character_load)(int fileIndex, void *dst) = nullptr;
+
+// C replacement for the loader's "index = com_id + 150" remap. Hooked onto the
+// single BattleFile_CharacterLoad call inside battle_monster_dat_loader, which
+// is only ever reached for monsters, so a file index in 310..365 unambiguously
+// means one of the newly unlocked c0m144..c0m199; those get remapped onto the
+// appended table entries and everything else is forwarded untouched.
+static int ff8_battle_monster_load_file(int fileIndex, void *dst)
 {
-	__asm {
-		cmp eax, FF8_FIRST_NEW_COM_ID   // 160
-		jb  normal
-		cmp eax, FF8_LAST_NEW_COM_ID    // 215
-		ja  normal
-		add eax, FF8_NEW_C0M_INDEX_BIAS // 957 -> appended c0m144..c0m199
-		ret
-	normal:
-		add eax, 150                    // original c0m000..c0m143 (and unused >= 216)
-		ret
-	}
+	if (fileIndex >= FF8_FIRST_NEW_FILE_INDEX && fileIndex <= FF8_LAST_NEW_FILE_INDEX)
+		fileIndex = FF8_BATTLE_FILES_ARRAY_LEN + (fileIndex - FF8_FIRST_NEW_FILE_INDEX);
+
+	return ff8_battle_file_character_load(fileIndex, dst);
 }
 
 void ff8_battle_monsters_init()
 {
-	uint32_t add_site = ff8_externals.battle_monster_dat_loader_com_id_add_site;
-	if (!add_site)
+	uint32_t call_site = ff8_externals.battle_monster_file_load_call_site;
+	if (!call_site || !ff8_externals.battle_file_character_load)
 	{
 		ffnx_trace("Extra battle monsters (c0m144-c0m199): unsupported game version, skipping.\n");
 		return;
@@ -128,7 +123,7 @@ void ff8_battle_monsters_init()
 		ff8_extended_battle_filenames[FF8_BATTLE_FILES_ARRAY_LEN + i] = ff8_extended_c0m_names[i];
 	}
 
-	// 2) Repoint LoadBattleFile's array base: mov ebx, BattleFilesArray[eax*4].
+	//    Repoint LoadBattleFile's array base: mov ebx, BattleFilesArray[eax*4].
 	//    battle_open_file + 0x11 is the absolute displacement of that instruction.
 	patch_code_dword(ff8_externals.battle_open_file + 0x11, (DWORD)(uintptr_t)ff8_extended_battle_filenames);
 
@@ -137,11 +132,10 @@ void ff8_battle_monsters_init()
 	//    c0m144-199 indices instead of reading past the original array.
 	ff8_externals.battle_filenames = ff8_extended_battle_filenames;
 
-	// 3) Replace "add eax, 96h" (5 bytes) with "call ff8_battle_monster_index_remap".
-	uint8_t call_patch[5];
-	call_patch[0] = 0xE8;
-	*(uint32_t *)&call_patch[1] = (uint32_t)&ff8_battle_monster_index_remap - (add_site + 5);
-	memcpy_code(add_site, call_patch, sizeof(call_patch));
+	// 2) Redirect the monster loader's BattleFile_CharacterLoad call to the C
+	//    hook, keeping the original target to forward to.
+	ff8_battle_file_character_load = (int (*)(int, void *))ff8_externals.battle_file_character_load;
+	replace_call(call_site, (void *)&ff8_battle_monster_load_file);
 
 	ffnx_info("Extra battle monsters enabled: c0m%03d-c0m%03d usable via enemy_com_value %d-%d.\n", FF8_FIRST_NEW_C0M, FF8_LAST_NEW_C0M, FF8_FIRST_NEW_COM_ID, FF8_LAST_NEW_COM_ID);
 }

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -18,7 +18,6 @@
 #include "../../ff8.h"
 #include "../../patch.h"
 #include "../../globals.h"
-#include "../../common.h"
 #include "../../log.h"
 
 #include <stdint.h>
@@ -38,7 +37,7 @@
 //     Index 310 is immediately D0C000.DAT (character files), so the c0m block
 //     cannot grow in place, and com_id 160..215 currently resolve to D0C/garbage.
 //
-// Fix (three memory patches, US 1.2 only for now):
+// Fix (three memory patches):
 //   1) Build an enlarged copy of BattleFilesArray = the original entries
 //      verbatim + 56 appended pointers to new "C0M144.DAT".."C0M199.DAT".
 //   2) Repoint LoadBattleFile's array base to the enlarged copy. Every existing
@@ -48,6 +47,22 @@
 //
 // Encounters need no exe change: enemy_com_value is already a byte, so setting
 // it to (c0m# + 16) selects any monster up to c0m199.
+//
+// ff8_externals.battle_open_file / battle_filenames already resolve
+// dynamically per version via the existing get_relative_call chain in
+// ff8_data.cpp (sub_47CCB0 -> ... -> battle_open_file), so this file uses
+// them as-is with no version branching of its own. battle_monster_dat_loader
+// itself is only ever reached through a function-pointer task dispatch
+// (never a direct call/jmp instruction anywhere in the exe), so its
+// "add eax, 150" com_id remap site can't be resolved through a relative-call
+// chain either; ff8_externals.battle_monster_dat_loader_com_id_add_site is
+// resolved as a per-version absolute address in ff8_data.cpp instead (same
+// pattern as sub_54A0D0 there), verified by signature-scanning all seven
+// retail 1.2 exe files (EN/FR/DE/IT/SP/JP/JP_NV) - see ff8_data.cpp for the
+// address table. The BattleFilesArray table structure itself (c0m000..c0m143
+// at indices 166..309, D0C000.DAT immediately at 310, 1117 entries total) is
+// confirmed identical across all seven builds, so FF8_BATTLE_FILES_ARRAY_LEN
+// below is not version-dependent.
 // -------------------------------------------------------------------------
 
 // Length of the original BattleFilesArray (US 1.2), indices 0..1116.
@@ -63,8 +78,6 @@
 //   index(com_id) = FF8_BATTLE_FILES_ARRAY_LEN + (com_id - FF8_FIRST_NEW_COM_ID)
 //                 = com_id + (FF8_BATTLE_FILES_ARRAY_LEN - FF8_FIRST_NEW_COM_ID)
 #define FF8_NEW_C0M_INDEX_BIAS (FF8_BATTLE_FILES_ARRAY_LEN - FF8_FIRST_NEW_COM_ID) // 957
-// Address of "add eax, 96h" (com_id + 150) inside battle_monster_dat_loader (US 1.2).
-#define FF8_MONSTER_LOADER_ADD_SITE 0x50735A
 
 static char *ff8_extended_battle_filenames[FF8_BATTLE_FILES_ARRAY_LEN + FF8_NEW_C0M_COUNT];
 static char ff8_extended_c0m_names[FF8_NEW_C0M_COUNT][12]; // "C0M199.DAT" + NUL = 11
@@ -90,8 +103,8 @@ static __declspec(naked) void ff8_battle_monster_index_remap()
 
 void ff8_battle_monsters_init()
 {
-	// Only the US 1.2 release is mapped for now (matches the addresses above).
-	if (!FF8_US_VERSION)
+	uint32_t add_site = ff8_externals.battle_monster_dat_loader_com_id_add_site;
+	if (!add_site)
 	{
 		ffnx_info("Extra battle monsters (c0m144-c0m199): unsupported game version, skipping.\n");
 		return;
@@ -119,8 +132,8 @@ void ff8_battle_monsters_init()
 	// 3) Replace "add eax, 96h" (5 bytes) with "call ff8_battle_monster_index_remap".
 	uint8_t call_patch[5];
 	call_patch[0] = 0xE8;
-	*(uint32_t *)&call_patch[1] = (uint32_t)&ff8_battle_monster_index_remap - (FF8_MONSTER_LOADER_ADD_SITE + 5);
-	memcpy_code(FF8_MONSTER_LOADER_ADD_SITE, call_patch, sizeof(call_patch));
+	*(uint32_t *)&call_patch[1] = (uint32_t)&ff8_battle_monster_index_remap - (add_site + 5);
+	memcpy_code(add_site, call_patch, sizeof(call_patch));
 
 	ffnx_info("Extra battle monsters enabled: c0m%03d-c0m%03d usable via enemy_com_value %d-%d.\n",
 		FF8_FIRST_NEW_C0M, FF8_LAST_NEW_C0M, FF8_FIRST_NEW_COM_ID, FF8_LAST_NEW_COM_ID);

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -130,12 +130,12 @@ static bool ff8_get_battle_file_size_on_disk(const char *relative_path, uint32_t
 // the size can't be found, assume it's needed rather than skip a real fix.
 static bool ff8_scene_out_uses_new_monsters()
 {
+	char scene_out_filename[] = "battle/scene.out";
 	uint32_t file_size;
-	if (!ff8_get_battle_file_size_on_disk("battle/scene.out", &file_size))
+	if (!ff8_get_battle_file_size_on_disk(scene_out_filename, &file_size))
 		return true;
 
 	uint8_t *scene_out = new uint8_t[file_size];
-	char scene_out_filename[] = "battle/scene.out";
 	uint32_t read_size = ff8_externals.sm_pc_read(scene_out_filename, scene_out);
 	if (read_size > file_size)
 		read_size = file_size;

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -132,6 +132,11 @@ void ff8_battle_monsters_init()
 	//    battle_open_file + 0x11 is the absolute displacement of that instruction.
 	patch_code_dword(ff8_externals.battle_open_file + 0x11, (DWORD)(uintptr_t)ff8_extended_battle_filenames);
 
+	//    Also repoint FFNx's own cached base pointer so the hooks that index it
+	//    (ff8_battle_open_and_read_file in vram.cpp) resolve the appended
+	//    c0m144-199 indices instead of reading past the original array.
+	ff8_externals.battle_filenames = ff8_extended_battle_filenames;
+
 	// 3) Replace "add eax, 96h" (5 bytes) with "call ff8_battle_monster_index_remap".
 	uint8_t call_patch[5];
 	call_patch[0] = 0xE8;

--- a/src/ff8/battle/monsters.cpp
+++ b/src/ff8/battle/monsters.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    Copyright (C) 2026 Julian Xhokaxhiu                                    //
+//    Copyright (C) 2026 Julian Xhokaxhiu                                   //
 //    Copyright (C) 2026 HobbitDur                                          //
 //                                                                          //
 //    This file is part of FFNx                                             //

--- a/src/ff8/battle/monsters.h
+++ b/src/ff8/battle/monsters.h
@@ -1,0 +1,21 @@
+/****************************************************************************/
+//    Copyright (C) 2026 Julian Xhokaxhiu                                    //
+//                                                                          //
+//    This file is part of FFNx                                             //
+//                                                                          //
+//    FFNx is free software: you can redistribute it and/or modify          //
+//    it under the terms of the GNU General Public License as published by  //
+//    the Free Software Foundation, either version 3 of the License         //
+//                                                                          //
+//    FFNx is distributed in the hope that it will be useful,               //
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of        //
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         //
+//    GNU General Public License for more details.                          //
+/****************************************************************************/
+
+#pragma once
+
+// Unlock the unused battle monster models c0m144..c0m199 so encounters can
+// reference them. Call once from ff8_init_hooks(), after ff8_externals is
+// resolved.
+void ff8_battle_monsters_init();

--- a/src/ff8/battle/monsters.h
+++ b/src/ff8/battle/monsters.h
@@ -1,5 +1,6 @@
 /****************************************************************************/
-//    Copyright (C) 2026 Julian Xhokaxhiu, HobbitDur                        //
+//    Copyright (C) 2026 Julian Xhokaxhiu                                    //
+//    Copyright (C) 2026 HobbitDur                                          //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //

--- a/src/ff8/battle/monsters.h
+++ b/src/ff8/battle/monsters.h
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    Copyright (C) 2026 Julian Xhokaxhiu                                    //
+//    Copyright (C) 2026 Julian Xhokaxhiu, HobbitDur                        //
 //                                                                          //
 //    This file is part of FFNx                                             //
 //                                                                          //

--- a/src/ff8/battle/monsters.h
+++ b/src/ff8/battle/monsters.h
@@ -1,5 +1,5 @@
 /****************************************************************************/
-//    Copyright (C) 2026 Julian Xhokaxhiu                                    //
+//    Copyright (C) 2026 Julian Xhokaxhiu                                   //
 //    Copyright (C) 2026 HobbitDur                                          //
 //                                                                          //
 //    This file is part of FFNx                                             //

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -239,58 +239,6 @@ void ff8_find_externals()
 	ff8_externals.battle_open_file = get_relative_call(ff8_externals.battle_open_file_wrapper, 0x14);
 	ff8_externals.battle_filenames = (char **)get_absolute_value(ff8_externals.battle_open_file, 0x11);
 
-	// battle_monster_dat_loader's "add eax, 96h" (com_id + 150) index computation.
-	// battle_monster_dat_loader itself is only ever invoked through a
-	// function-pointer task dispatch (never a direct call/jmp instruction), so
-	// it can't be reached via get_relative_call. Its caller,
-	// BattleTask_DispatchComEntityLoad, embeds battle_monster_dat_loader's
-	// address as a plain "mov eax, offset battle_monster_dat_loader" (opcode
-	// at dispatcher+0x4A, imm32 at +0x4B), which get_absolute_value can read;
-	// this holds identically across all seven retail 1.2 exe files
-	// (EN/FR/DE/IT/SP/JP/JP_NV), as does the com_id+150 add site sitting at a
-	// fixed +0x23A into battle_monster_dat_loader. BattleTask_DispatchComEntityLoad
-	// itself has no static caller anywhere in the exe either (same
-	// function-pointer-only dispatch), so its address remains a per-version
-	// absolute literal, like sub_54A0D0 above; 0 (unmapped) for any other version.
-	uint32_t battle_task_dispatch_com_entity_load = 0;
-	switch (version)
-	{
-	case VERSION_FF8_12_US:
-	case VERSION_FF8_12_US_NV:
-	case VERSION_FF8_12_US_EIDOS:
-	case VERSION_FF8_12_US_EIDOS_NV:
-		battle_task_dispatch_com_entity_load = 0x507080;
-		break;
-	case VERSION_FF8_12_FR:
-	case VERSION_FF8_12_FR_NV:
-		battle_task_dispatch_com_entity_load = 0x506BE0;
-		break;
-	case VERSION_FF8_12_DE:
-	case VERSION_FF8_12_DE_NV:
-	case VERSION_FF8_12_IT:
-	case VERSION_FF8_12_IT_NV:
-		battle_task_dispatch_com_entity_load = 0x506C50;
-		break;
-	case VERSION_FF8_12_SP:
-	case VERSION_FF8_12_SP_NV:
-		battle_task_dispatch_com_entity_load = 0x506C80;
-		break;
-	case VERSION_FF8_12_JP:
-		battle_task_dispatch_com_entity_load = 0x50AD30;
-		break;
-	case VERSION_FF8_12_JP_NV:
-		battle_task_dispatch_com_entity_load = 0x50AF40;
-		break;
-	}
-
-	if (battle_task_dispatch_com_entity_load)
-	{
-		uint32_t battle_monster_dat_loader = get_absolute_value(battle_task_dispatch_com_entity_load, 0x4B);
-		ff8_externals.battle_monster_dat_loader_com_id_add_site = battle_monster_dat_loader + 0x23A;
-	}
-	else
-		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0;
-
 	ff8_externals.sub_47D890 = get_relative_call(ff8_externals.sub_506CF0, 0x59);
 	ff8_externals.sub_505DF0 = get_relative_call(ff8_externals.sub_506CF0, 0xAA);
 	ff8_externals.sub_4A94D0 = get_relative_call(ff8_externals.sub_47D890, 0x9);
@@ -966,6 +914,20 @@ void ff8_find_externals()
 
 	ff8_externals.sub_502380 = get_relative_call(ff8_externals.sub_500CC0, 0x69);
 	ff8_externals.sub_50A790 = get_relative_call(ff8_externals.sub_502380, 0x51);
+
+	// battle_monster_dat_loader's "add eax, 96h" (com_id + 150) index computation.
+	// sub_50A790 embeds sub_50B830's address as a plain "mov eax, offset ..."
+	// (opcode at +0x82, imm32 at +0x83). sub_50B830 in turn calls
+	// battle_task_dispatch_com_entity_load directly at +0x1B3. That dispatcher
+	// embeds battle_monster_dat_loader's address the same way (opcode at
+	// +0x4A, imm32 at +0x4B), and the com_id+150 add site sits at a fixed
+	// +0x23A into battle_monster_dat_loader. All four offsets confirmed
+	// identical across all seven retail 1.2 exe files (EN/FR/DE/IT/SP/JP/JP_NV).
+	ff8_externals.sub_50B830 = get_absolute_value(ff8_externals.sub_50A790, 0x83);
+	ff8_externals.battle_task_dispatch_com_entity_load = get_relative_call(ff8_externals.sub_50B830, 0x1B3);
+	ff8_externals.battle_monster_dat_loader = get_absolute_value(ff8_externals.battle_task_dispatch_com_entity_load, 0x4B);
+	ff8_externals.battle_monster_dat_loader_com_id_add_site = ff8_externals.battle_monster_dat_loader + 0x23A;
+
 	ff8_externals.sub_50A9A0 = get_absolute_value(ff8_externals.sub_50A790, 0x7C);
 	ff8_externals.battle_read_effect_sub_50AF20 = get_relative_call(ff8_externals.sub_50A9A0, 0xF4);
 	ff8_externals.func_off_battle_effects_C81774 = (DWORD*)get_absolute_value(ff8_externals.battle_read_effect_sub_50AF20, 0x2C);

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -914,14 +914,6 @@ void ff8_find_externals()
 
 	ff8_externals.sub_502380 = get_relative_call(ff8_externals.sub_500CC0, 0x69);
 	ff8_externals.sub_50A790 = get_relative_call(ff8_externals.sub_502380, 0x51);
-
-	// battle_monster_dat_loader's "load battle file (com_id + 150)" call, hooked
-	// to unlock c0m144-199 (see src/ff8/battle/monsters.cpp).
-	// sub_502380 pushes sub_502670 as a plain "push offset ..." (opcode at +0x21,
-	// imm32 at +0x22). sub_502670 calls the battle entity task dispatcher at
-	// +0x110. That dispatcher embeds battle_monster_dat_loader as a
-	// "mov eax, offset ..." (opcode at +0x4A, imm32 at +0x4B), and the file-load
-	// call sits at a fixed +0x240 into battle_monster_dat_loader.
 	ff8_externals.sub_502670 = get_absolute_value(ff8_externals.sub_502380, 0x22);
 	ff8_externals.battle_entity_task_dispatch_sub_507080 = get_relative_call(ff8_externals.sub_502670, 0x110);
 	ff8_externals.battle_monster_dat_loader = get_absolute_value(ff8_externals.battle_entity_task_dispatch_sub_507080, 0x4B);
@@ -983,17 +975,6 @@ void ff8_find_externals()
 	ff8_externals.battle_sub_494410 = get_relative_call(ff8_externals.battle_sub_48FE20, FF8_US_VERSION ? 0x139C : (JP_VERSION ? 0x1300 : (FF8_SP_VERSION ? 0x130B : 0x1301)));
 	ff8_externals.battle_sub_494AF0 = (void(*)(int, int, int, int))get_relative_call(ff8_externals.battle_sub_494410, 0x525);
 
-	// The two instructions that index SG_ENEMY_SCANNED_ONCE by com_id / 32,
-	// relocated to a larger field when c0m144-199 are in use (see
-	// src/ff8/battle/monsters.cpp). battle_sub_48FE20 is the only caller of
-	// Damage_DispatchByAttackType, which in turn is the only caller of the
-	// "mark this com_id scanned" setter. What we want is each instruction's
-	// disp32 operand, so the offsets below land 3 bytes into a
-	// "test [reg*4 + disp32], reg" and an "or [reg*4 + disp32], reg"
-	// respectively. All four offsets verified identical on every retail 1.2
-	// build (EN, ES, FR, IT, DE, JP), so they need no version branching;
-	// monsters.cpp re-checks both operands before writing to them, so any
-	// build that does not match is left untouched rather than corrupted.
 	uint32_t battle_damage_dispatch = get_relative_call(ff8_externals.battle_sub_48FE20, 0x858);
 	uint32_t battle_mark_enemy_scanned = get_relative_call(battle_damage_dispatch, 0x311);
 	ff8_externals.battle_enemy_scanned_read_operand = battle_damage_dispatch + 0x2F2;

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -915,18 +915,20 @@ void ff8_find_externals()
 	ff8_externals.sub_502380 = get_relative_call(ff8_externals.sub_500CC0, 0x69);
 	ff8_externals.sub_50A790 = get_relative_call(ff8_externals.sub_502380, 0x51);
 
-	// battle_monster_dat_loader's "add eax, 96h" (com_id + 150) index computation.
+	// battle_monster_dat_loader's BattleFile_CharacterLoad(com_id + 150, dst) call,
+	// hooked to unlock c0m144-199 (see src/ff8/battle/monsters.cpp).
 	// sub_50A790 embeds sub_50B830's address as a plain "mov eax, offset ..."
 	// (opcode at +0x82, imm32 at +0x83). sub_50B830 in turn calls
 	// battle_task_dispatch_com_entity_load directly at +0x1B3. That dispatcher
 	// embeds battle_monster_dat_loader's address the same way (opcode at
-	// +0x4A, imm32 at +0x4B), and the com_id+150 add site sits at a fixed
-	// +0x23A into battle_monster_dat_loader. All four offsets confirmed
+	// +0x4A, imm32 at +0x4B), and the BattleFile_CharacterLoad call sits at a
+	// fixed +0x240 into battle_monster_dat_loader. All offsets confirmed
 	// identical across all seven retail 1.2 exe files (EN/FR/DE/IT/SP/JP/JP_NV).
 	ff8_externals.sub_50B830 = get_absolute_value(ff8_externals.sub_50A790, 0x83);
 	ff8_externals.battle_task_dispatch_com_entity_load = get_relative_call(ff8_externals.sub_50B830, 0x1B3);
 	ff8_externals.battle_monster_dat_loader = get_absolute_value(ff8_externals.battle_task_dispatch_com_entity_load, 0x4B);
-	ff8_externals.battle_monster_dat_loader_com_id_add_site = ff8_externals.battle_monster_dat_loader + 0x23A;
+	ff8_externals.battle_monster_file_load_call_site = ff8_externals.battle_monster_dat_loader + 0x240;
+	ff8_externals.battle_file_character_load = get_relative_call(ff8_externals.battle_monster_dat_loader, 0x240);
 
 	ff8_externals.sub_50A9A0 = get_absolute_value(ff8_externals.sub_50A790, 0x7C);
 	ff8_externals.battle_read_effect_sub_50AF20 = get_relative_call(ff8_externals.sub_50A9A0, 0xF4);

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -915,20 +915,18 @@ void ff8_find_externals()
 	ff8_externals.sub_502380 = get_relative_call(ff8_externals.sub_500CC0, 0x69);
 	ff8_externals.sub_50A790 = get_relative_call(ff8_externals.sub_502380, 0x51);
 
-	// battle_monster_dat_loader's BattleFile_CharacterLoad(com_id + 150, dst) call,
-	// hooked to unlock c0m144-199 (see src/ff8/battle/monsters.cpp).
-	// sub_50A790 embeds sub_50B830's address as a plain "mov eax, offset ..."
-	// (opcode at +0x82, imm32 at +0x83). sub_50B830 in turn calls
-	// battle_task_dispatch_com_entity_load directly at +0x1B3. That dispatcher
-	// embeds battle_monster_dat_loader's address the same way (opcode at
-	// +0x4A, imm32 at +0x4B), and the BattleFile_CharacterLoad call sits at a
-	// fixed +0x240 into battle_monster_dat_loader. All offsets confirmed
-	// identical across all seven retail 1.2 exe files (EN/FR/DE/IT/SP/JP/JP_NV).
-	ff8_externals.sub_50B830 = get_absolute_value(ff8_externals.sub_50A790, 0x83);
-	ff8_externals.battle_task_dispatch_com_entity_load = get_relative_call(ff8_externals.sub_50B830, 0x1B3);
-	ff8_externals.battle_monster_dat_loader = get_absolute_value(ff8_externals.battle_task_dispatch_com_entity_load, 0x4B);
+	// battle_monster_dat_loader's "load battle file (com_id + 150)" call, hooked
+	// to unlock c0m144-199 (see src/ff8/battle/monsters.cpp).
+	// sub_502380 pushes sub_502670 as a plain "push offset ..." (opcode at +0x21,
+	// imm32 at +0x22). sub_502670 calls the battle entity task dispatcher at
+	// +0x110. That dispatcher embeds battle_monster_dat_loader as a
+	// "mov eax, offset ..." (opcode at +0x4A, imm32 at +0x4B), and the file-load
+	// call sits at a fixed +0x240 into battle_monster_dat_loader.
+	ff8_externals.sub_502670 = get_absolute_value(ff8_externals.sub_502380, 0x22);
+	ff8_externals.battle_entity_task_dispatch_sub_507080 = get_relative_call(ff8_externals.sub_502670, 0x110);
+	ff8_externals.battle_monster_dat_loader = get_absolute_value(ff8_externals.battle_entity_task_dispatch_sub_507080, 0x4B);
 	ff8_externals.battle_monster_file_load_call_site = ff8_externals.battle_monster_dat_loader + 0x240;
-	ff8_externals.battle_file_character_load = get_relative_call(ff8_externals.battle_monster_dat_loader, 0x240);
+	ff8_externals.battle_load_file_sub_508480 = get_relative_call(ff8_externals.battle_monster_file_load_call_site, 0);
 
 	ff8_externals.sub_50A9A0 = get_absolute_value(ff8_externals.sub_50A790, 0x7C);
 	ff8_externals.battle_read_effect_sub_50AF20 = get_relative_call(ff8_externals.sub_50A9A0, 0xF4);
@@ -984,6 +982,22 @@ void ff8_find_externals()
 	ff8_externals.battle_sub_48FE20 = get_relative_call(ff8_externals.battle_sub_485160, 0x91);
 	ff8_externals.battle_sub_494410 = get_relative_call(ff8_externals.battle_sub_48FE20, FF8_US_VERSION ? 0x139C : (JP_VERSION ? 0x1300 : (FF8_SP_VERSION ? 0x130B : 0x1301)));
 	ff8_externals.battle_sub_494AF0 = (void(*)(int, int, int, int))get_relative_call(ff8_externals.battle_sub_494410, 0x525);
+
+	// The two instructions that index SG_ENEMY_SCANNED_ONCE by com_id / 32,
+	// relocated to a larger field when c0m144-199 are in use (see
+	// src/ff8/battle/monsters.cpp). battle_sub_48FE20 is the only caller of
+	// Damage_DispatchByAttackType, which in turn is the only caller of the
+	// "mark this com_id scanned" setter. What we want is each instruction's
+	// disp32 operand, so the offsets below land 3 bytes into a
+	// "test [reg*4 + disp32], reg" and an "or [reg*4 + disp32], reg"
+	// respectively. All four offsets verified identical on every retail 1.2
+	// build (EN, ES, FR, IT, DE, JP), so they need no version branching;
+	// monsters.cpp re-checks both operands before writing to them, so any
+	// build that does not match is left untouched rather than corrupted.
+	uint32_t battle_damage_dispatch = get_relative_call(ff8_externals.battle_sub_48FE20, 0x858);
+	uint32_t battle_mark_enemy_scanned = get_relative_call(battle_damage_dispatch, 0x311);
+	ff8_externals.battle_enemy_scanned_read_operand = battle_damage_dispatch + 0x2F2;
+	ff8_externals.battle_enemy_scanned_write_operand = battle_mark_enemy_scanned + 0x26;
 
 	ff8_externals.fps_limiter = get_relative_call(ff8_externals.field_main_loop, 0x261);
 	if (JP_VERSION)

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -253,20 +253,35 @@ void ff8_find_externals()
 	// function-pointer-only dispatch), so its address remains a per-version
 	// absolute literal, like sub_54A0D0 above; 0 (unmapped) for any other version.
 	uint32_t battle_task_dispatch_com_entity_load = 0;
-	if (FF8_US_VERSION)
+	switch (version)
+	{
+	case VERSION_FF8_12_US:
+	case VERSION_FF8_12_US_NV:
+	case VERSION_FF8_12_US_EIDOS:
+	case VERSION_FF8_12_US_EIDOS_NV:
 		battle_task_dispatch_com_entity_load = 0x507080;
-	else if (version == VERSION_FF8_12_FR || version == VERSION_FF8_12_FR_NV)
+		break;
+	case VERSION_FF8_12_FR:
+	case VERSION_FF8_12_FR_NV:
 		battle_task_dispatch_com_entity_load = 0x506BE0;
-	else if (version == VERSION_FF8_12_DE || version == VERSION_FF8_12_DE_NV)
+		break;
+	case VERSION_FF8_12_DE:
+	case VERSION_FF8_12_DE_NV:
+	case VERSION_FF8_12_IT:
+	case VERSION_FF8_12_IT_NV:
 		battle_task_dispatch_com_entity_load = 0x506C50;
-	else if (FF8_IT_VERSION)
-		battle_task_dispatch_com_entity_load = 0x506C50;
-	else if (FF8_SP_VERSION)
+		break;
+	case VERSION_FF8_12_SP:
+	case VERSION_FF8_12_SP_NV:
 		battle_task_dispatch_com_entity_load = 0x506C80;
-	else if (version == VERSION_FF8_12_JP)
+		break;
+	case VERSION_FF8_12_JP:
 		battle_task_dispatch_com_entity_load = 0x50AD30;
-	else if (version == VERSION_FF8_12_JP_NV)
+		break;
+	case VERSION_FF8_12_JP_NV:
 		battle_task_dispatch_com_entity_load = 0x50AF40;
+		break;
+	}
 
 	if (battle_task_dispatch_com_entity_load)
 	{

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -240,25 +240,39 @@ void ff8_find_externals()
 	ff8_externals.battle_filenames = (char **)get_absolute_value(ff8_externals.battle_open_file, 0x11);
 
 	// battle_monster_dat_loader's "add eax, 96h" (com_id + 150) index computation.
-	// Not reachable via a relative-call chain (battle_monster_dat_loader is only
-	// ever invoked through a function-pointer task dispatch, never a direct
-	// call/jmp instruction), so this is a per-version absolute address like
-	// sub_54A0D0 above. Verified by signature-scanning all six retail 1.2 exe
-	// files (EN/FR/DE/IT/SP/JP); 0 (unmapped) for any other version.
+	// battle_monster_dat_loader itself is only ever invoked through a
+	// function-pointer task dispatch (never a direct call/jmp instruction), so
+	// it can't be reached via get_relative_call. Its caller,
+	// BattleTask_DispatchComEntityLoad, embeds battle_monster_dat_loader's
+	// address as a plain "mov eax, offset battle_monster_dat_loader" (opcode
+	// at dispatcher+0x4A, imm32 at +0x4B), which get_absolute_value can read;
+	// this holds identically across all seven retail 1.2 exe files
+	// (EN/FR/DE/IT/SP/JP/JP_NV), as does the com_id+150 add site sitting at a
+	// fixed +0x23A into battle_monster_dat_loader. BattleTask_DispatchComEntityLoad
+	// itself has no static caller anywhere in the exe either (same
+	// function-pointer-only dispatch), so its address remains a per-version
+	// absolute literal, like sub_54A0D0 above; 0 (unmapped) for any other version.
+	uint32_t battle_task_dispatch_com_entity_load = 0;
 	if (FF8_US_VERSION)
-		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x50735A;
+		battle_task_dispatch_com_entity_load = 0x507080;
 	else if (version == VERSION_FF8_12_FR || version == VERSION_FF8_12_FR_NV)
-		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x506EBA;
+		battle_task_dispatch_com_entity_load = 0x506BE0;
 	else if (version == VERSION_FF8_12_DE || version == VERSION_FF8_12_DE_NV)
-		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x506F2A;
+		battle_task_dispatch_com_entity_load = 0x506C50;
 	else if (FF8_IT_VERSION)
-		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x506F2A;
+		battle_task_dispatch_com_entity_load = 0x506C50;
 	else if (FF8_SP_VERSION)
-		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x506F5A;
+		battle_task_dispatch_com_entity_load = 0x506C80;
 	else if (version == VERSION_FF8_12_JP)
-		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x50B00A;
+		battle_task_dispatch_com_entity_load = 0x50AD30;
 	else if (version == VERSION_FF8_12_JP_NV)
-		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x50B21A;
+		battle_task_dispatch_com_entity_load = 0x50AF40;
+
+	if (battle_task_dispatch_com_entity_load)
+	{
+		uint32_t battle_monster_dat_loader = get_absolute_value(battle_task_dispatch_com_entity_load, 0x4B);
+		ff8_externals.battle_monster_dat_loader_com_id_add_site = battle_monster_dat_loader + 0x23A;
+	}
 	else
 		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0;
 

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -239,6 +239,29 @@ void ff8_find_externals()
 	ff8_externals.battle_open_file = get_relative_call(ff8_externals.battle_open_file_wrapper, 0x14);
 	ff8_externals.battle_filenames = (char **)get_absolute_value(ff8_externals.battle_open_file, 0x11);
 
+	// battle_monster_dat_loader's "add eax, 96h" (com_id + 150) index computation.
+	// Not reachable via a relative-call chain (battle_monster_dat_loader is only
+	// ever invoked through a function-pointer task dispatch, never a direct
+	// call/jmp instruction), so this is a per-version absolute address like
+	// sub_54A0D0 above. Verified by signature-scanning all six retail 1.2 exe
+	// files (EN/FR/DE/IT/SP/JP); 0 (unmapped) for any other version.
+	if (FF8_US_VERSION)
+		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x50735A;
+	else if (version == VERSION_FF8_12_FR || version == VERSION_FF8_12_FR_NV)
+		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x506EBA;
+	else if (version == VERSION_FF8_12_DE || version == VERSION_FF8_12_DE_NV)
+		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x506F2A;
+	else if (FF8_IT_VERSION)
+		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x506F2A;
+	else if (FF8_SP_VERSION)
+		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x506F5A;
+	else if (version == VERSION_FF8_12_JP)
+		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x50B00A;
+	else if (version == VERSION_FF8_12_JP_NV)
+		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0x50B21A;
+	else
+		ff8_externals.battle_monster_dat_loader_com_id_add_site = 0;
+
 	ff8_externals.sub_47D890 = get_relative_call(ff8_externals.sub_506CF0, 0x59);
 	ff8_externals.sub_505DF0 = get_relative_call(ff8_externals.sub_506CF0, 0xAA);
 	ff8_externals.sub_4A94D0 = get_relative_call(ff8_externals.sub_47D890, 0x9);

--- a/src/ff8_opengl.cpp
+++ b/src/ff8_opengl.cpp
@@ -37,6 +37,7 @@
 #include "ff8/file.h"
 #include "ff8/vram.h"
 #include "ff8/save_data.h"
+#include "ff8/battle/monsters.h"
 #include "metadata.h"
 #include "achievement.h"
 #include "widescreen.h"
@@ -1975,6 +1976,11 @@ void ff8_init_hooks(struct game_obj *_game_object)
 	// #####################
 	replace_call(ff8_externals.sub_530C30 + 0x46A, ff8_field_3d_models_push_rects);
 	replace_call(uint32_t(ff8_externals.field_push_mch_vertices_rect_sub_533A90) + 0x4D, ff8_field_calc_triangle_condition);
+
+	// #####################
+	// Unlock unused battle monster models c0m144-c0m199
+	// #####################
+	ff8_battle_monsters_init();
 
 }
 


### PR DESCRIPTION
## Summary

Allow to load all the monster files c0mXXX.dat after 144 up to 199 (the files already there but they are blank and not used. So it works on vanilla, but allow modders to add new one)

### Motivation

To be able to add new monsters on a mod.
### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
