### PR TITLE
FF7: Gate 0xD9 heart redirect to the Japanese edition

### DIFF
--- a/docs/ff7/multibyte_font.md
+++ b/docs/ff7/multibyte_font.md
@@ -34,9 +34,9 @@ at which codes — FFNx does not impose any particular character set. Practical 
 - Control codes of the game's text format (`0xE0`+ range in kernel/field text: names, colors,
   new-line, new-page, variables...) keep their engine meaning. Don't place glyphs on bytes your
   target text sections use as control codes.
-- `0xDE` in battle window D is redirected to a heart icon by the Japanese text support
-  (a vanilla JP quirk). Treat `0xDE` as reserved if your translation may run with JP text
-  features enabled.
+- `0xD9` is redirected to a heart icon from battle window D by the Japanese text support
+  (a vanilla JP quirk). That redirect only applies to the Japanese edition; in multibyte mode
+  `0xD9` is an ordinary glyph cell your translation may use.
 - Bytes drawn through the multibyte path are recolored via the palette/color data. Mods that
   repaint icon cells expecting NOT to be recolored (button prompts, item icons) can conflict
   with glyphs you place in those cells; prefer free cells.
@@ -110,7 +110,8 @@ icons, button prompts) rather than letters:
 ## Quick checklist for a new translation
 
 1. Design your charmap: assign characters to sheet/code slots, avoiding engine control codes
-   (and `0xDE`, see above).
+   (see the note above for the JP-edition `0xD9` heart quirk — usable as a glyph cell in
+   multibyte mode).
 2. Paint `jafont_1..6` textures (16×16 grid per sheet).
 3. Re-encode game text (kernel, field, battle, world, exe strings) to your charmap.
 4. Generate `multibyte_widths.bin` from your glyph metrics.

--- a/src/ff7/japanese_text.cpp
+++ b/src/ff7/japanese_text.cpp
@@ -702,7 +702,7 @@ __int16 field_submit_draw_text_640x480_6E706D_jp(
             break;
           }
         default:
-          if ((*buffer_text != 0xd9u) && (*buffer_text < 0xF6u || *buffer_text > 0xF9u)) // not a button prompt or heart.
+          if ((*buffer_text != 0xd9u || ff7_multibyte_font) && (*buffer_text < 0xF6u || *buffer_text > 0xF9u)) // not a button prompt or heart (heart redirect is JP-edition only; multibyte owns 0xD9 as a glyph cell).
           {
             text_offset_spacing = 0;
             graphics_object_v_in_byte = 0;
@@ -1150,12 +1150,21 @@ int common_submit_draw_char_from_buffer_6F564E_jp(int x, int vertex_y, int n_sha
   switch ((byte)letter)
   {
   case 0xD9: // heart
-    character_graphics_object = *ff7_externals.menu_win_d_blend_4_graphics_object_DC0FD4;
-    offset_image_u = 144; // heart is here
-    offset_image_v = 208; // heart is here
-    charWidth = 0x1f;     // max width
-    leftPadding = 0;
-    goto LABEL_9;
+    // The heart redirect is a JP-edition feature. In multibyte mode this byte is a normal
+    // jafont_1 glyph cell — translations may map real glyphs here (e.g. Arabic medial qaf).
+    if (!ff7_multibyte_font)
+    {
+      character_graphics_object = *ff7_externals.menu_win_d_blend_4_graphics_object_DC0FD4;
+      offset_image_u = 144; // heart is here
+      offset_image_v = 208; // heart is here
+      charWidth = 0x1f;     // max width
+      leftPadding = 0;
+      goto LABEL_9;
+    }
+    character_graphics_object = ff7_externals.menu_jafont_1_graphics_object;
+    charWidth = charWidthData[0][*p_letter] & 0x1F;
+    leftPadding = charWidthData[0][*p_letter] >> 5;
+    break;
   case 0xF8:
     return x;
   case 0xFA:


### PR DESCRIPTION
## Summary

Follow-up to #948 (found via runtime testing of the Arabic translation after that PR merged).

Byte `0xD9` is hard-wired to the heart-icon redirect in the **shared** multibyte text paths, not just the Japanese edition:

- `field_submit_draw_text_640x480_6E706D_jp`: the "not a button prompt or heart" guard excludes `0xD9` from the glyph block, so the byte draws nothing.
- `common_submit_draw_char_from_buffer_6F564E_jp`: `case 0xD9` always goes to the `menu_win_d` heart sprite.

Any translation using `ff7_multibyte_font` that places a glyph on cell `0xD9` silently loses it (found with Arabic medial qaf — invisible in field text). As @zaphod77 noted on #948, the heart redirect is a JP-edition feature.

## Fix

The redirect now only applies when `ff7_multibyte_font` is off; in multibyte mode `0xD9` is an ordinary `jafont_1` glyph cell in both paths. JP-edition behavior unchanged. The doc is also corrected: the heart byte is `0xD9` (it said `0xDE`).

## Verification

- Arabic medial qaf (which encodes to `0xD9` in that charmap) renders correctly in-game with this change's semantics — confirmed on the 2026 Steam re-release (field + menu).
- JP-edition text path untouched (heart code still executes when `ff7_multibyte_font` is off).