### PR TITLE
FF8: Fix text dialogues in battles when using 16:9

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,7 +19,7 @@
 - Direct mode: Add the chunk feature for c0mXXX.dat files ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
 - Exe data: Ensure files loaded only once ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
 - External textures: Disable texture filtering in worldmap when filtering is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/954 )
-- Fixing widescreen text in battle
+- Widescreen: Fixing widescreen text in battle (https://github.com/julianxhokaxhiu/FFNx/pull/960)
 
 # 1.24.3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,7 +19,7 @@
 - Direct mode: Add the chunk feature for c0mXXX.dat files ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
 - Exe data: Ensure files loaded only once ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
 - External textures: Disable texture filtering in worldmap when filtering is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/954 )
-- Widescreen: Fixing widescreen text in battle (https://github.com/julianxhokaxhiu/FFNx/pull/960)
+- Widescreen: Fixing widescreen text in battle ( https://github.com/julianxhokaxhiu/FFNx/pull/960 )
 
 # 1.24.3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,7 +19,7 @@
 - Direct mode: Add the chunk feature for c0mXXX.dat files ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
 - Exe data: Ensure files loaded only once ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
 - External textures: Disable texture filtering in worldmap when filtering is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/954 )
-- Widescreen: Fixing widescreen text in battle ( https://github.com/julianxhokaxhiu/FFNx/pull/960 )
+- Widescreen: Fix text dialogues in battles when using 16:9 ( https://github.com/julianxhokaxhiu/FFNx/pull/960 )
 
 # 1.24.3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
 - Direct mode: Add the chunk feature for c0mXXX.dat files ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
 - Exe data: Ensure files loaded only once ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
 - External textures: Disable texture filtering in worldmap when filtering is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/954 )
+- Fixing widescreen text in battle
 
 # 1.24.3
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1725,7 +1725,7 @@ void Renderer::setScissor(uint16_t x, uint16_t y, uint16_t width, uint16_t heigh
             {
                 if(x == 0 && width == game_width)
                     scissorWidth = getInternalCoordX(wide_viewport_width);
-                else if(internalState.bIsTLVertex)
+                else if(ff8 || internalState.bIsTLVertex)
                     scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));
 
                 if (ff8)


### PR DESCRIPTION
## Summary
The idea is to apply widescreen X offset to battle sub-rect scissors

<img width="1360" height="624" alt="image" src="https://github.com/user-attachments/assets/fa446fe7-da6a-4079-88e0-384470160637" />

So the problem is that FFNx moves the viewport by -107 to move it to the center due to width change on 16:9
But the draw of the text is actually not moved. So it should also moved.
The idea would be to applied a generic move, like `scissorOffsetX = getInternalCoordX(x + abs(wide_viewport_x));` which is applied in all mods except Battle.

For reason probably specific to FF7, it check internalState.bIsTLVertex. If I understand correctly, it's to keep if there is something beeing draw in 2D. But for ff8, the "scissor" is called on the viewport, before any text (glyph) printed.

So I propose to just add the FF8 flag to just bypass this check and move also the text.

### Motivation
Fix  #835
### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
