### PR TITLE
Common: change SDL3 Subsystems to prevent potential CMake build conflicts during maintenance/version updating

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,18 @@ find_package(CMakeRC CONFIG REQUIRED)
 find_package(lfreist-hwinfo CONFIG REQUIRED)
 find_package(cryptopp CONFIG REQUIRED)
 find_package(tomlplusplus CONFIG REQUIRED)
+
+# SDL3 subsystem configurations:
+set(SDL_AUDIO        OFF CACHE BOOL "" FORCE)
+set(SDL_VIDEO        OFF CACHE BOOL "" FORCE)
+set(SDL_GPU          OFF CACHE BOOL "" FORCE)
+set(SDL_RENDER       OFF CACHE BOOL "" FORCE)
+set(SDL_CAMERA       OFF CACHE BOOL "" FORCE)
+set(SDL_POWER        OFF CACHE BOOL "" FORCE)
+set(SDL_DIALOG       OFF CACHE BOOL "" FORCE)
+set(SDL_TRAY         OFF CACHE BOOL "" FORCE)
+set(SDL_NOTIFICATION OFF CACHE BOOL "" FORCE)
+
 find_package(SDL3 CONFIG REQUIRED)
 
 set(RELEASE_NAME "FFNx")


### PR DESCRIPTION
## Summary

While SDL3 itself is ABI Stable as hell, there can be external factors that are beyond SDL's control, such as upgrading or downgrading Windows SDK versions.

I personally faced this issue from a different community patch when they upgraded their Windows SDK that broke SDL completely. While those issues have been addressed by SDL maintainers (after I reported the bug myself), it'll be a while for those issues to get rolled out into the next monthly bug fix release candidate, and FFNx is no exception. Thus: this PR is made as a simple maintenance change backported from a different project (although it'll apply to CMakeLists only).

### Motivation

To prevent any potential issues whenever the maintainer upgrades SDL versions, vcpkg, or the Windows SDK: a portion of SDL subsystems **that isn't about Game Controllers** (HIDAPI, JOYSTICK, SENSOR, HAPTICS) has been disabled. We're using SDL's Gamepad API, so it make sense for the rest of the subsystems to be disabled. 

of course, if anyone plans to upgrade FFNx's audio/windowing/gpu to leverage SDL APIs, they can always head over to `CMakeLists.txt` and remove one of the subsystems at anytime.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [X] I did test my code on FF7
- [ ] I did test my code on FF8
