### PR TITLE
FF7: Fix battle square crash regression caused by #948

### DIFF
--- a/src/ff7/japanese_text.cpp
+++ b/src/ff7/japanese_text.cpp
@@ -2578,7 +2578,7 @@ void field_text_box_window_opening_6317A9_jp(short WINDOW_ID)
   // stalling the open. Instead, compute the target once here while the window is still small,
   // then hold width/height fixed so the animation converges normally, matching vanilla behavior.
   // Field files already ship with correctly sized windows, so this only fixes the animation target.
-  if ( ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].current_window_width < 8 )
+  if ( ff7_japanese_edition || (ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].current_window_width < 8) ) // must run every frame as before to properly handle japanese edition.
   {
     auto_resize_text_box(WINDOW_ID, &W, &H);
     if (ff7_externals.text_box_window_data_array_CFF5B8[WINDOW_ID].window_pos_x < 0)


### PR DESCRIPTION
… as it's required to avoid a crash after battle square.

## Summary

Without calling the resizer every frame and rewriting the values, the battle square dialog fails to expand to it's full height, and this causes the dialog to wedge.  I had to restore the old behavior from my original patch, and i do it by running it every frame if it's the japanese edition.  

### Motivation

Fixing the regression introduced by the english ver multibyte support.

### ACKs

- [ ] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [x] I did test my code on FF7
- [ ] I did test my code on FF8
