### PR TITLE
FF8R: Fix direct paths for field and world archives

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,7 +15,7 @@
 
 ## FF8
 
-- Core: Add support for remastered version, [see manual](https://github.com/julianxhokaxhiu/FFNx/blob/master/docs/how_to_install.md#remastered-release) for more informations ( https://github.com/julianxhokaxhiu/FFNx/pull/887 )
+- Core: Add support for remastered version, [see manual](https://github.com/julianxhokaxhiu/FFNx/blob/master/docs/how_to_install.md#remastered-release) for more informations ( https://github.com/julianxhokaxhiu/FFNx/pull/887 https://github.com/julianxhokaxhiu/FFNx/pull/977 )
 - Core: Fix IT and DE versions crashing on launch ( https://github.com/julianxhokaxhiu/FFNx/pull/957 )
 - Core: Unlock unused battle monster models c0m144-c0m199 (EN/FR/DE/IT/SP/JP), selectable via `enemy_com_value` 160-215 in scene.out ( https://github.com/julianxhokaxhiu/FFNx/pull/955 )
 - Direct mode: Optionally add the language prefix to the path for multi-language mods ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )

--- a/src/ff8/file.cpp
+++ b/src/ff8/file.cpp
@@ -68,22 +68,49 @@ bool set_direct_path(const char *fullpath, char *output, size_t output_size)
 		return true;
 	}
 
-	if (strnicmp(fullpath + 2, ff8_externals.archive_path_prefix, strlen(ff8_externals.archive_path_prefix)) != 0)
+	char fullpath_copy[MAX_PATH] = {};
+
+	if (ff8_remastered_edition && strnicmp(fullpath + 2, "\\ff8\\data\\x\\", strlen("\\ff8\\data\\x\\")) == 0)
 	{
-		if (trace_all || trace_direct) ffnx_warning("%s: file ignored for direct path %s (should match %s)\n", __func__, fullpath, ff8_externals.archive_path_prefix);
+		/* For field and world, the lang part may be replaced by "x", while archive_path_prefix still contains "c:\\ff8\\data\\eng\\"
+		 * We put back the lang in the prefix instead of "x" to ensure uniformity of the direct layer accross game versions
+		 */
+		char suffix[MAX_PATH] = "_";
+		const char *extension = fullpath + strlen(fullpath) - 4;
+
+		concat_lang_str(suffix);
+		strcat(suffix, extension);
+
+		_snprintf(fullpath_copy, sizeof(fullpath_copy), "c:%s%s", ff8_externals.archive_path_prefix, fullpath + strlen("c:\\ff8\\data\\x\\"));
+
+		// Ends with _{lang}{extension}
+		if (strnicmp(fullpath + strlen(fullpath) - 7, suffix, 7) == 0)
+		{
+			fullpath_copy[strlen(fullpath_copy) - 7] = '\0'; // Remove _{lang}{extension}
+			strcat(fullpath_copy, extension);
+		}
+	}
+	else
+	{
+		strncpy(fullpath_copy, fullpath, sizeof(fullpath_copy));
+	}
+	
+	if (strnicmp(fullpath_copy + 2, ff8_externals.archive_path_prefix, strlen(ff8_externals.archive_path_prefix)) != 0)
+	{
+		if (trace_all || trace_direct) ffnx_warning("%s: file ignored for direct path %s (should match %s)\n", __func__, fullpath_copy, ff8_externals.archive_path_prefix);
 
 		return false;
 	}
 
 	// Try with the lang prefix
-	_snprintf(output, output_size, "%s/%s/%s", basedir, direct_mode_path.c_str(), fullpath + get_fl_prefix_size(false));
+	_snprintf(output, output_size, "%s/%s/%s", basedir, direct_mode_path.c_str(), fullpath_copy + get_fl_prefix_size(false));
 
 	if (!fileExists(output))
 	{
 		if (trace_all || trace_direct) ffnx_warning("Direct file not found %s\n", output);
 
 		// Retry without the lang prefix
-		_snprintf(output, output_size, "%s/%s/%s", basedir, direct_mode_path.c_str(), fullpath + get_fl_prefix_size());
+		_snprintf(output, output_size, "%s/%s/%s", basedir, direct_mode_path.c_str(), fullpath_copy + get_fl_prefix_size());
 
 		if (!fileExists(output))
 		{


### PR DESCRIPTION
## Summary

Fix direct paths for field and world archives

This Pull Request **does not** fix field model mods.

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8 Remastered
