### PR TITLE
FF8R: Simplify and optimize model divisor accessor

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@
 
 ## FF8
 
-- Core: Add support for remastered version, [see manual](https://github.com/julianxhokaxhiu/FFNx/blob/master/docs/how_to_install.md#remastered-release) for more informations ( https://github.com/julianxhokaxhiu/FFNx/pull/887 https://github.com/julianxhokaxhiu/FFNx/pull/977 )
+- Core: Add support for remastered version, [see manual](https://github.com/julianxhokaxhiu/FFNx/blob/master/docs/how_to_install.md#remastered-release) for more informations ( https://github.com/julianxhokaxhiu/FFNx/pull/887 https://github.com/julianxhokaxhiu/FFNx/pull/977 https://github.com/julianxhokaxhiu/FFNx/pull/979 )
 - Core: Fix IT and DE versions crashing on launch ( https://github.com/julianxhokaxhiu/FFNx/pull/957 )
 - Core: Unlock unused battle monster models c0m144-c0m199 (EN/FR/DE/IT/SP/JP), selectable via `enemy_com_value` 160-215 in scene.out ( https://github.com/julianxhokaxhiu/FFNx/pull/955 )
 - Direct mode: Optionally add the language prefix to the path for multi-language mods ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )

--- a/src/ff8/remaster.cpp
+++ b/src/ff8/remaster.cpp
@@ -37,7 +37,7 @@ struct ff8_remastered_model_divisor {
     uint16_t divisor;
 };
 
-std::unordered_map<uint32_t, CharaOneModel> field_model_map;
+std::unordered_map<uint32_t, double> field_model_divisor_map;
 double next_field_model_divisor = 0.0;
 constexpr int model_divisors_size = 142;
 ff8_remastered_model_divisor model_divisors[model_divisors_size] = {
@@ -313,16 +313,22 @@ void field_model_vertices_scale()
 
 double get_model_divisor(uint32_t addr)
 {
-    auto it = field_model_map.find(addr);
-    if (it == field_model_map.end() || it->second.isDirect) {
+    auto it = field_model_divisor_map.find(addr);
+    if (it == field_model_divisor_map.end()) {
         return 1.0;
     }
 
-    for (int i = 0; i < model_divisors_size; ++i) {
-        char *modelId = model_divisors[i].modelId;
+    return it->second;
+}
 
-        if (*(uint32_t *)modelId == *(uint32_t *)it->second.name) {
-            return double(model_divisors[i].divisor);
+double ff8_remaster_get_model_divisor_by_name(const char *name)
+{
+    for (int i = 0; i < model_divisors_size; ++i) {
+        const ff8_remastered_model_divisor &model_divisor = model_divisors[i];
+        const char *modelId = model_divisor.modelId;
+
+        if (*(const uint32_t *)modelId == *(const uint32_t *)name) {
+            return double(model_divisor.divisor);
         }
     }
 
@@ -356,13 +362,21 @@ int field_open_chara_one(
         models_ordered.insert(std::pair<uint32_t, CharaOneModel>(model.second.modelId, model.second));
     }
 
-    field_model_map.clear();
+    field_model_divisor_map.clear();
 
     for (int i = 0; i < *ff8_externals.field_state_other_count; ++i) {
         int16_t model_id = (*ff8_externals.field_state_others)[i].model_id;
 
         if (model_id >= 0) {
-            field_model_map.insert(std::pair<uint32_t, CharaOneModel>(((uint32_t *)ff8_externals.dword_1DCB340)[i], models_ordered.at(model_id)));
+            const CharaOneModel &model = models_ordered.at(model_id);
+
+            if (! model.isDirect) {
+                const double divisor = ff8_remaster_get_model_divisor_by_name(model.name);
+
+                if (divisor != 1.0) {
+                    field_model_divisor_map.insert(std::pair<uint32_t, double>(((uint32_t *)ff8_externals.dword_1DCB340)[i], divisor));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Move some model divisor code to model loading part to not do the lookup on every frames

### Motivation

Simpler and faster code

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
