### PR TITLE
FF8R: Add color modification to external field textures

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,7 @@
 - Direct mode: Add the chunk feature for c0mXXX.dat files ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
 - Exe data: Ensure files loaded only once ( https://github.com/julianxhokaxhiu/FFNx/pull/898 )
 - External textures: Disable texture filtering in worldmap when filtering is enabled ( https://github.com/julianxhokaxhiu/FFNx/pull/954 )
+- External textures: Change texture color for model field external textures, depending on the current map ( https://github.com/julianxhokaxhiu/FFNx/pull/981 )
 - Widescreen: Fix text dialogues in battles when using 16:9 ( https://github.com/julianxhokaxhiu/FFNx/pull/960 )
 
 # 1.24.3

--- a/src/ff8/field/chara_one.cpp
+++ b/src/ff8/field/chara_one.cpp
@@ -107,6 +107,54 @@ std::unordered_map<uint32_t, CharaOneModel> ff8_chara_one_parse_models(const uin
 	return models;
 }
 
+void ff8_parse_pcb(const uint8_t *pcb_data, int pcb_data_size, std::unordered_map<uint32_t, CharaOneModel> &models)
+{
+	int count = std::min(pcb_data_size / 8, 64);
+	std::unordered_map<uint32_t, uint32_t> model_light_colors;
+	uint32_t default_light_color = 0x80808080;
+
+	for (int i = 0; i < count; ++i)
+	{
+		char name[5] = "";
+		for (uint8_t j = 0; j < 4; ++j)
+		{
+			name[j] = pcb_data[i * 8 + j];
+
+			if (name[j] > 'z' || name[j] < '0')
+			{
+				name[j] = '\0';
+				break;
+			}
+		}
+
+		model_light_colors[*(uint32_t *)name] = *(uint32_t *)(pcb_data + i * 8 + 4);
+
+		if (i == 0) {
+			default_light_color = *(uint32_t *)(pcb_data + i * 8 + 4);
+		}
+	}
+
+	// Set color modifiers to models
+	std::unordered_map<uint32_t, CharaOneModel> ret;
+
+	for (const auto pair: models)
+	{
+		CharaOneModel model = pair.second;
+		auto it = model_light_colors.find(*(uint32_t *)model.name);
+		uint32_t raw_color = it == model_light_colors.end() ? default_light_color : (*it).second;
+		uint8_t *color_modifier = (uint8_t *)&raw_color;
+
+		model.rgbaModifier[0] = int(color_modifier[1]) - 128;
+		model.rgbaModifier[1] = int(color_modifier[2]) - 128;
+		model.rgbaModifier[2] = int(color_modifier[3]) - 128;
+		model.rgbaModifier[3] = 0;
+
+		ret[pair.first] = model;
+	}
+
+	models = ret;
+}
+
 void ff8_mch_parse_model(CharaOneModel &model, const uint8_t *mch_data, size_t size)
 {
 	if(size < 0x100) {

--- a/src/ff8/field/chara_one.h
+++ b/src/ff8/field/chara_one.h
@@ -32,8 +32,10 @@ struct CharaOneModel {
 	bool isDirect;
 	std::vector<uint32_t> texturesData;
 	uint32_t modelId;
+	int8_t rgbaModifier[4];
 };
 
 std::unordered_map<uint32_t, CharaOneModel> ff8_chara_one_parse_models(const uint8_t *chara_one_data, size_t size);
 void ff8_mch_parse_model(CharaOneModel &model, const uint8_t *mch_data, size_t size);
+void ff8_parse_pcb(const uint8_t *pcb_data, int pcb_data_size, std::unordered_map<uint32_t, CharaOneModel> &models);
 bool ff8_chara_one_model_save_textures(const CharaOneModel &models, const uint8_t *chara_one_model_data, const char *dirname);

--- a/src/ff8/mod.cpp
+++ b/src/ff8/mod.cpp
@@ -37,7 +37,7 @@ TextureImage::TextureImage() :
 {
 }
 
-bool TextureImage::createImage(const char *filename, int originalTexturePixelWidth, int originalTextureHeight, int internalLodScale)
+bool TextureImage::createImage(const char *filename, int originalTexturePixelWidth, int originalTextureHeight, int internalLodScale, int8_t *rgbaModifier)
 {
 	if (_image != nullptr)
 	{
@@ -110,6 +110,8 @@ bool TextureImage::createImage(const char *filename, int originalTexturePixelWid
 
 	_scale = scale;
 
+	alterColors(rgbaModifier);
+
 	return true;
 }
 
@@ -127,6 +129,35 @@ void TextureImage::setLod(uint8_t lod)
 	if (_image != nullptr)
 	{
 		bimg::imageGetRawData(*_image, 0, lod, _image->m_data, _image->m_size, _mip);
+	}
+}
+
+void TextureImage::alterColors(int8_t *rgbaModifier)
+{
+	if (rgbaModifier == nullptr || rgbaModifier[0] == 0 && rgbaModifier[1] == 0 && rgbaModifier[2] == 0 && rgbaModifier[3] == 0)
+	{
+		return;
+	}
+
+	if (trace_all || trace_vram) ffnx_info("%s: rgbaModifier=(%d, %d, %d, %d)\n", __func__, rgbaModifier[0], rgbaModifier[1], rgbaModifier[2], rgbaModifier[3]);
+
+	uint32_t *bgra = const_cast<uint32_t *>(reinterpret_cast<const uint32_t *>(_mip.m_data));
+
+	for (int i = 0; i < _mip.m_width * _mip.m_height; ++i)
+	{
+		int32_t b = (bgra[i] & 0xFF) + rgbaModifier[2],
+			g = ((bgra[i] >> 8) & 0xFF) + rgbaModifier[1],
+			r = ((bgra[i] >> 16) & 0xFF) + rgbaModifier[0],
+			a = ((bgra[i] >> 24) & 0xFF) + rgbaModifier[3];
+		if (r < 0) r = 0;
+		if (g < 0) g = 0;
+		if (b < 0) b = 0;
+		if (a < 0) a = 0;
+		if (r > 255) r = 255;
+		if (g > 255) g = 255;
+		if (b > 255) b = 255;
+		if (a > 255) a = 255;
+		bgra[i] = (b & 0xFF) | ((g & 0xFF) << 8) | ((r & 0xFF) << 16) | ((a & 0xFF) << 24);
 	}
 }
 
@@ -393,7 +424,7 @@ TextureModStandard::~TextureModStandard()
 	}
 }
 
-bool TextureModStandard::createImages(int paletteCount, int internalLodScale)
+bool TextureModStandard::createImages(int paletteCount, int internalLodScale, int8_t *rgbaModifier)
 {
 	paletteCount = paletteCount >= 0 ? paletteCount : originalTexture().palette().h(); // Works most of the time
 
@@ -412,7 +443,7 @@ bool TextureModStandard::createImages(int paletteCount, int internalLodScale)
 		extension = found_extension;
 
 		TextureImage externalTexture;
-		if (!externalTexture.createImage(filename, originalTexture().texture().pixelW(), originalTexture().texture().h(), internalLodScale))
+		if (!externalTexture.createImage(filename, originalTexture().texture().pixelW(), originalTexture().texture().h(), internalLodScale, rgbaModifier))
 		{
 			continue;
 		}
@@ -530,9 +561,10 @@ void TextureModStandard::copyRect(
 
 	for (const std::pair<uint8_t, TextureImage> &image: _textures)
 	{
+		const bimg::ImageMip &mip = image.second.mip();
+
 		for (const std::pair<uint8_t, TextureImage> &targetImage: targetTexture._textures)
 		{
-			const bimg::ImageMip &mip = image.second.mip();
 			const bimg::ImageMip &targetMip = targetImage.second.mip();
 
 			if (image.second.scale() != targetImage.second.scale()) {

--- a/src/ff8/mod.h
+++ b/src/ff8/mod.h
@@ -34,7 +34,7 @@
 class TextureImage {
 public:
 	TextureImage();
-	bool createImage(const char *filename, int originalTexturePixelWidth, int originalTextureHeight, int internalLodScale = 1);
+	bool createImage(const char *filename, int originalTexturePixelWidth, int originalTextureHeight, int internalLodScale = 1, int8_t *rgbaModifier = nullptr);
 	void destroyImage();
 	inline uint8_t scale() const {
 		return _scale;
@@ -51,6 +51,7 @@ public:
 	static int computeMaxScale();
 private:
 	void setLod(uint8_t lod);
+	void alterColors(int8_t *rgbaModifier);
 	uint8_t computeLod(int originalTexturePixelWidth, int imageWidth, int numMips, int internalScale = 1, const char *filename = "") const;
 	uint8_t computeScale(int originalTexturePixelWidth, int originalTextureHeight, const char *filename = "") const;
 	bimg::ImageContainer *_image;
@@ -111,7 +112,7 @@ public:
 	inline bool canCopyRect() const override {
 		return true;
 	}
-	bool createImages(int paletteCount, int internalLodScale = 1);
+	bool createImages(int paletteCount, int internalLodScale = 1, int8_t *rgbaModifier = nullptr);
 	uint8_t scale(int vramPalXBpp2, int vramPalY) const override;
 	TexturePacker::TextureTypes drawToImage(
 		int offsetX, int offsetY,

--- a/src/ff8/remaster.cpp
+++ b/src/ff8/remaster.cpp
@@ -26,7 +26,6 @@
 #include "../log.h"
 #include "../patch.h"
 #include "remaster.h"
-#include "vram.h"
 
 Zzz g_FF8ZzzArchiveMain;
 Zzz g_FF8ZzzArchiveOther;
@@ -344,18 +343,8 @@ void field_sub_530C30(int a1, int a2, int **a3)
     next_field_model_divisor = 1.0;
 }
 
-int field_open_chara_one(
-    int current_data_pointer,
-    void *models_infos,
-    void *palette_vram_positions,
-    void *texture_vram_positions,
-    const char *dir_name,
-    int field_data_pointer,
-    int allocated_size,
-    int pcb_data_size
-) {
-    int ret = ((int(*)(int,void*,void*,void*,const char*,int,int,int))ff8_externals.load_field_models)(current_data_pointer, models_infos, palette_vram_positions, texture_vram_positions, dir_name, field_data_pointer, allocated_size, pcb_data_size);
-
+void ff8_remaster_set_field_model_scaling(const std::unordered_map<uint32_t, CharaOneModel> &chara_one_models)
+{
     std::map<uint32_t, CharaOneModel> models_ordered;
 
     for (auto model: chara_one_models) {
@@ -379,15 +368,12 @@ int field_open_chara_one(
             }
         }
     }
-
-    return ret;
 }
 
 void ff8_remaster_init()
 {
     replace_call(ff8_externals.sub_533C30 + 0x44, field_model_vertices_scale);
     replace_call(ff8_externals.sub_533CD0 + 0x28E, field_sub_530C30);
-    replace_call(ff8_externals.read_field_data + (JP_VERSION ? 0xFA2 : 0xF0F), field_open_chara_one);
 
     char fullpath[MAX_PATH];
 

--- a/src/ff8/remaster.h
+++ b/src/ff8/remaster.h
@@ -24,9 +24,11 @@
 
 #include <memory>
 
+#include "field/chara_one.h"
 #include "zzz_archive.h"
 
 void ff8_remaster_init();
+void ff8_remaster_set_field_model_scaling(const std::unordered_map<uint32_t, CharaOneModel> &chara_one_models);
 
 extern Zzz g_FF8ZzzArchiveMain;
 extern Zzz g_FF8ZzzArchiveOther;

--- a/src/ff8/texture_packer.cpp
+++ b/src/ff8/texture_packer.cpp
@@ -147,7 +147,7 @@ void TexturePacker::setVramTextureId(ModdedTextureId textureId, int xBpp2, int y
 	}
 }
 
-bool TexturePacker::setTexture(const char *name, const char *remasteredName, const TextureInfos &texture, const TextureInfos &palette, int textureCount, bool clearOldTexture)
+bool TexturePacker::setTexture(const char *name, const char *remasteredName, const TextureInfos &texture, const TextureInfos &palette, int textureCount, int8_t *rgbaModifier, bool clearOldTexture)
 {
 	bool hasNamedTexture = name != nullptr && *name != '\0',
 		hasRemasteredNamedTexture = remasteredName != nullptr && *remasteredName != '\0';
@@ -172,7 +172,7 @@ bool TexturePacker::setTexture(const char *name, const char *remasteredName, con
 	{
 		TextureModStandard *mod = new TextureModStandard(tex);
 
-		if (mod->createImages(textureCount))
+		if (mod->createImages(textureCount, 1, rgbaModifier))
 		{
 			tex.setMod(mod);
 		}

--- a/src/ff8/texture_packer.h
+++ b/src/ff8/texture_packer.h
@@ -159,7 +159,7 @@ public:
 	};
 
 	explicit TexturePacker();
-	bool setTexture(const char *name, const char *remasteredName, const TextureInfos &texture, const TextureInfos &palette = TextureInfos(), int textureCount = -1, bool clearOldTexture = true);
+	bool setTexture(const char *name, const char *remasteredName, const TextureInfos &texture, const TextureInfos &palette = TextureInfos(), int textureCount = -1, int8_t *rgbaModifier = nullptr, bool clearOldTexture = true);
 	bool setTextureBackground(const char *name, int x, int y, int w, int h, int maxW, const std::vector<Tile> &mapTiles, const char *extension = nullptr, char *found_extension = nullptr);
 	// Override a part of the VRAM from another part of the VRAM, typically with biggest textures (Worldmap)
 	bool setTextureRedirection(const char *name, const TextureInfos &oldTexture, const TextureInfos &newTexture, const Tim &tim);

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -34,6 +34,7 @@
 #include "world/chara_one.h"
 #include "world/wmset.h"
 #include "battle/stage.h"
+#include "remaster.h"
 #include "./file.h"
 
 #include <shlwapi.h>
@@ -57,6 +58,7 @@ int next_texture_count = -1;
 int next_do_not_clear_old_texture = false;
 Tim::Bpp next_bpp = Tim::Bpp16;
 int last_CLUT = 0;
+int8_t *next_rgba_modifier = nullptr;
 
 // Field background
 uint8_t *mim_texture_buffer = nullptr;
@@ -70,6 +72,8 @@ int chara_one_current_pos = 0;
 uint32_t chara_one_current_model = 0;
 uint32_t chara_one_current_mch = 0;
 uint32_t chara_one_current_texture = 0;
+const uint8_t *chara_one_pcb_data = 0;
+int chara_one_pcb_size = 0;
 // World
 std::vector<CharaOneModelTextures> chara_one_world_texture_offsets;
 uint8_t *chara_one_world_data;
@@ -219,7 +223,8 @@ void ff8_upload_vram(int16_t *pos_and_size, uint8_t *texture_buffer)
 	bool isPal = (next_pal_data != nullptr && (uint8_t *)next_pal_data == texture_buffer)
 		|| (palette_infos.isValid() && palette_infos.x() == x && palette_infos.y() == y && palette_infos.w() == w && palette_infos.h() == h);
 
-	if (trace_all || trace_vram) ffnx_trace("%s x=%d y=%d w=%d h=%d bpp=%d isPal=%d texture_buffer=0x%X\n", __func__, x, y, w, h, next_bpp, isPal, texture_buffer);
+	if (trace_all || trace_vram) ffnx_trace("%s x=%d y=%d w=%d h=%d bpp=%d isPal=%d texture_buffer=0x%X rgba_modifier=(%d, %d, %d, %d)\n", __func__, x, y, w, h, next_bpp, isPal, texture_buffer,
+		next_rgba_modifier ? next_rgba_modifier[0] : 0, next_rgba_modifier ? next_rgba_modifier[1] : 0, next_rgba_modifier ? next_rgba_modifier[2] : 0, next_rgba_modifier ? next_rgba_modifier[3] : 0);
 
 	uint8_t *vram = ff8_vram_seek(x, y);
 	const int vramLineWidth = VRAM_DEPTH * VRAM_WIDTH;
@@ -233,12 +238,12 @@ void ff8_upload_vram(int16_t *pos_and_size, uint8_t *texture_buffer)
 	}
 
 	if (texture_infos.isValid() && palette_infos.isValid()) {
-		texturePacker.setTexture(next_texture_name, next_remastered_texture_name, texture_infos, palette_infos, next_texture_count, !next_do_not_clear_old_texture);
+		texturePacker.setTexture(next_texture_name, next_remastered_texture_name, texture_infos, palette_infos, next_texture_count, next_rgba_modifier, !next_do_not_clear_old_texture);
 
 		texture_infos = TexturePacker::TextureInfos();
 		palette_infos = TexturePacker::TextureInfos();
 	} else if (!texture_infos.isValid() && !palette_infos.isValid() && !isPal) {
-		texturePacker.setTexture(next_texture_name, next_remastered_texture_name, TexturePacker::TextureInfos(x, y, w, h, next_bpp), TexturePacker::TextureInfos(), next_texture_count, !next_do_not_clear_old_texture);
+		texturePacker.setTexture(next_texture_name, next_remastered_texture_name, TexturePacker::TextureInfos(x, y, w, h, next_bpp), TexturePacker::TextureInfos(), next_texture_count, next_rgba_modifier, !next_do_not_clear_old_texture);
 	}
 
 	ff8_externals.sub_464850(x, y, x + w - 1, h + y - 1);
@@ -247,6 +252,7 @@ void ff8_upload_vram(int16_t *pos_and_size, uint8_t *texture_buffer)
 	*next_remastered_texture_name = '\0';
 	next_do_not_clear_old_texture = false;
 	next_texture_count = -1;
+	next_rgba_modifier = nullptr;
 }
 
 void ff8_vram_copy_part(int x, int y, int w, int h, int target_x, int target_y)
@@ -822,7 +828,7 @@ void ff8_wm_section_17_set_texture(int texture_id)
 
 	snprintf(texture_name, sizeof(texture_name), "world/dat/wmset/section17/texture%d", texture_id);
 
-	texturePacker.setTexture(texture_name, nullptr, texture_infos, palette_infos, tex.textureFramePositions.size(), true);
+	texturePacker.setTexture(texture_name, nullptr, texture_infos, palette_infos, tex.textureFramePositions.size(), nullptr, true);
 }
 
 uint32_t ff8_wm_section_38_prepare_texture_for_upload(uint8_t *tim_file_data, ff8_tim *tim_infos)
@@ -1356,6 +1362,52 @@ uint32_t ff8_field_read_map_data(char *filename, uint8_t *map_data)
 	return ret;
 }
 
+int ff8_field_open_chara_one(
+	int current_data_pointer,
+	void *models_infos,
+	VramPos *palette_vram_positions,
+	VramPos *texture_vram_positions,
+	const char *dir_name,
+	const uint8_t *pcb_data,
+	int allocated_size,
+	int pcb_data_size
+) {
+	if (trace_all || trace_vram) ffnx_trace("%s\n", __func__);
+
+	chara_one_pcb_data = pcb_data;
+	chara_one_pcb_size = pcb_data_size;
+
+	VramPos tex_vram_pos[FIELD_VRAM_POS_LENGTH] = {}, pal_vram_pos[FIELD_VRAM_POS_LENGTH] = {};
+
+	// Maximize texture positioning by eliminating taken spots
+	int j = 0;
+	for (int i = 0; i < FIELD_VRAM_POS_LENGTH; ++i) {
+		VramPos pos = i < FIELD_MODEL_TEX_VRAM_POS_ORIGINAL_LENGTH ? texture_vram_positions[i] : field_model_tex_vram_pos[i - FIELD_MODEL_TEX_VRAM_POS_ORIGINAL_LENGTH];
+		// Background is at (0, 256, mim_real_width, 256)
+		if (pos.y >= 256 && pos.x < mim_real_width) {
+			if (trace_all || trace_vram) ffnx_warning("%s: (%d, %d) cell taken by mim, continue\n", __func__, pos.x, pos.y);
+			continue;
+		}
+		// Effects can be positionned anywhere, depending on the pmp file content
+		if (pos.x >= field_effect_texture_infos.x() && pos.x < field_effect_texture_infos.x() + field_effect_texture_infos.w()
+			&& pos.y >= field_effect_texture_infos.y() && pos.y < field_effect_texture_infos.y() + field_effect_texture_infos.h()) {
+			if (trace_all || trace_vram) ffnx_warning("%s: (%d, %d) cell taken by pmp, continue\n", __func__, pos.x, pos.y);
+			continue;
+		}
+		pal_vram_pos[j] = {0, uint16_t(i + 128u)}; // Relocate palettes on (0, 128) instead of (512, 240)
+		tex_vram_pos[j] = pos;
+		j += 1;
+	}
+
+	int ret = ((int(*)(int,void*,VramPos*,VramPos*,const char*,const uint8_t*,int,int))ff8_externals.load_field_models)(current_data_pointer, models_infos, palette_vram_positions, texture_vram_positions, dir_name, pcb_data, allocated_size, pcb_data_size);
+
+	if (ff8_remastered_edition) {
+		ff8_remaster_set_field_model_scaling(chara_one_models);
+	}
+	
+	return ret;
+}
+
 int ff8_field_chara_one_read_file_header(int fd, uint8_t *const data, size_t size)
 {
 	int read = ((int(*)(int,uint8_t*const,size_t))ff8_externals.chara_one_read_file)(fd, data, size);
@@ -1363,6 +1415,8 @@ int ff8_field_chara_one_read_file_header(int fd, uint8_t *const data, size_t siz
 	if (trace_all || trace_vram) ffnx_trace("%s: size=%d\n", __func__, size);
 
 	chara_one_models = ff8_chara_one_parse_models(data, size);
+	ff8_parse_pcb(chara_one_pcb_data, chara_one_pcb_size, chara_one_models);
+
 	chara_one_loaded_models.clear();
 	chara_one_current_model = 0;
 	chara_one_current_mch = 0;
@@ -1438,6 +1492,7 @@ int ff8_field_texture_upload_one(char *image_buffer, char bpp, char a3, int x, i
 		CharaOneModel model = chara_one_models[chara_one_loaded_models.at(chara_one_current_model)];
 
 		if (chara_one_current_texture < model.texturesData.size()) {
+			next_rgba_modifier = model.rgbaModifier;
 			next_bpp = Tim::Bpp(bpp);
 			if (!model.isDirect && !is_remastered_hd_textures_disabled("field")) {
 				snprintf(next_remastered_texture_name, MAX_PATH, "field.fs\\field_hd_new\\%s_%d", model.name, chara_one_current_texture);
@@ -1954,50 +2009,6 @@ void ff8_battle_upload_texture_palette(int16_t *pos_and_size, uint8_t *texture_b
 	}
 }
 
-int ff8_load_field_models(
-	int current_data_pointer,
-	void *models_infos,
-	VramPos *palette_vram_positions,
-	VramPos *texture_vram_positions,
-	const char *dirName,
-	int field_data_pointer,
-	int field_data_max_pointer,
-	int pcb_data_size)
-{
-	VramPos tex_vram_pos[FIELD_VRAM_POS_LENGTH] = {}, pal_vram_pos[FIELD_VRAM_POS_LENGTH] = {};
-
-	// Maximize texture positioning by eliminating taken spots
-	int j = 0;
-	for (int i = 0; i < FIELD_VRAM_POS_LENGTH; ++i) {
-		VramPos pos = i < FIELD_MODEL_TEX_VRAM_POS_ORIGINAL_LENGTH ? texture_vram_positions[i] : field_model_tex_vram_pos[i - FIELD_MODEL_TEX_VRAM_POS_ORIGINAL_LENGTH];
-		// Background is at (0, 256, mim_real_width, 256)
-		if (pos.y >= 256 && pos.x < mim_real_width) {
-			if (trace_all || trace_vram) ffnx_warning("%s: (%d, %d) cell taken by mim, continue\n", __func__, pos.x, pos.y);
-			continue;
-		}
-		// Effects can be positionned anywhere, depending on the pmp file content
-		if (pos.x >= field_effect_texture_infos.x() && pos.x < field_effect_texture_infos.x() + field_effect_texture_infos.w()
-			&& pos.y >= field_effect_texture_infos.y() && pos.y < field_effect_texture_infos.y() + field_effect_texture_infos.h()) {
-			if (trace_all || trace_vram) ffnx_warning("%s: (%d, %d) cell taken by pmp, continue\n", __func__, pos.x, pos.y);
-			continue;
-		}
-		pal_vram_pos[j] = {0, uint16_t(i + 128u)}; // Relocate palettes on (0, 128) instead of (512, 240)
-		tex_vram_pos[j] = pos;
-		j += 1;
-	}
-
-	return ((int(*)(int,void*,VramPos*,VramPos*,const char*,int,int,int))ff8_externals.load_field_models)(
-		current_data_pointer,
-		models_infos,
-		pal_vram_pos,
-		tex_vram_pos,
-		dirName,
-		field_data_pointer,
-		field_data_max_pointer,
-		pcb_data_size
-	);
-}
-
 void engine_set_init_time(double fps_adjust)
 {
 	texturePacker.clearTextures();
@@ -2054,6 +2065,7 @@ void vram_init()
 	replace_call(ff8_externals.upload_mim_file + 0x2E, ff8_field_mim_palette_upload_vram);
 	replace_call(ff8_externals.read_field_data + (JP_VERSION ? 0x990 : 0x915), ff8_field_read_map_data);
 	// field: characters
+	replace_call(ff8_externals.read_field_data + (JP_VERSION ? 0xFA2 : 0xF0F), ff8_field_open_chara_one);
 	replace_call(ff8_externals.load_field_models + 0x15F, ff8_field_chara_one_read_file_header);
 	replace_call(ff8_externals.load_field_models + 0x582, ff8_field_chara_one_seek_to_model);
 	replace_call(ff8_externals.load_field_models + 0x594, ff8_field_chara_one_read_model);
@@ -2111,11 +2123,6 @@ void vram_init()
 	// Read palette from VRAM to Graphic driver
 	replace_call(ff8_externals.write_palette_texture_set_sub_466190 + 0x2C, ff8_read_vram_palette);
 	replace_call(ff8_externals.write_palette_texture_set_sub_466190 + 0x7E, ff8_write_palette_to_driver);
-
-	//---- Field VRAM arrangement
-
-	// Change texture positions in VRAM
-	replace_call(ff8_externals.read_field_data + (JP_VERSION ? 0xFA2 : 0xF0F), ff8_load_field_models);
 
 	//---- Misc
 

--- a/src/ff8/vram.h
+++ b/src/ff8/vram.h
@@ -27,7 +27,6 @@
 #include <unordered_map>
 
 extern TexturePacker texturePacker;
-extern std::unordered_map<uint32_t, CharaOneModel> chara_one_models;
 
 void vram_init();
 bool ff8_vram_save(const char *fileName, Tim::Bpp bpp);


### PR DESCRIPTION
## Summary

Add color modification to external field textures
<img width="1040" height="807" alt="2026-08-30 17_39_49-Final Fantasy VIII (Direct3D11) devel" src="https://github.com/user-attachments/assets/bf7d7563-e7a5-404e-8697-c8a5a3cc4f7e" />
<img width="1026" height="800" alt="2026-08-30 18_18_37-Final Fantasy VIII (Direct3D11) devel" src="https://github.com/user-attachments/assets/f43b6320-b116-45c1-9e02-9f9afaea2a07" />


### Motivation

The original game modify the palette color on loading chara.one using the pcb file info.
This was not reproduced on external texture

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- [ ] I did test my code on FF7
- [X] I did test my code on FF8
