### PR TITLE
FF8R: Add support for multi language switch

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,10 @@
 - External textures: Change texture color for model field external textures, depending on the current map ( https://github.com/julianxhokaxhiu/FFNx/pull/981 )
 - Widescreen: Fix text dialogues in battles when using 16:9 ( https://github.com/julianxhokaxhiu/FFNx/pull/960 )
 
+## FF8 Remastered
+
+- Add support for multi language switch ( https://github.com/julianxhokaxhiu/FFNx/pull/982 )
+
 # 1.24.3
 
 - Full commit list since last stable release: https://github.com/julianxhokaxhiu/FFNx/compare/1.24.2...1.24.3

--- a/misc/FFNx.toml
+++ b/misc/FFNx.toml
@@ -478,6 +478,20 @@ steam_game_userdata = ""
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~
 enable_steam_achievements = false
 
+#[LANGUAGE]
+# Language of the game on multilingual installations
+# FF8 REMASTERED: de, en, es, fr, it, jp (jp is partially supported)
+# Available choices are:
+# - 0: Auto ( default, use the language of the exe )
+# - 1: English
+# - 2: French
+# - 3: German
+# - 4: Spanish
+# - 5: Italian
+# - 6: Japanese
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~
+game_language = 0
+
 ########################
 ## MODDER OPTIONS
 ########################

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -163,6 +163,7 @@ long display_index;
 long ff8_high_res_font;
 long hardware_video_decoding;
 std::vector<std::string> ff8_disable_remastered_hd_textures;
+long game_language;
 
 std::vector<std::string> get_string_or_array_of_strings(const toml::node_view<toml::node> &node)
 {
@@ -337,6 +338,7 @@ void read_cfg()
 	ff8_high_res_font = config["ff8_high_res_font"].value_or(-1);
 	hardware_video_decoding = config["hardware_video_decoding"].value_or(HWVA_NONE);
 	ff8_disable_remastered_hd_textures = get_string_or_array_of_strings(config["ff8_disable_remastered_hd_textures"]);
+	game_language = config["game_language"].value_or(GAME_LANGUAGE_AUTO);
 
 	// Windows x or y size can't be less then 0
 	if (window_size_x < 0) window_size_x = 0;

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -53,6 +53,14 @@
 #define HWVA_AMF 8
 #define HWVA_QSV 9
 
+#define GAME_LANGUAGE_AUTO 0
+#define GAME_LANGUAGE_EN 1
+#define GAME_LANGUAGE_FR 2
+#define GAME_LANGUAGE_DE 3
+#define GAME_LANGUAGE_SP 4
+#define GAME_LANGUAGE_IT 5
+#define GAME_LANGUAGE_JP 6
+
 extern std::string mod_path;
 extern std::vector<std::string> mod_ext;
 extern long enable_ffmpeg_videos;
@@ -186,6 +194,7 @@ extern long display_index;
 extern long ff8_high_res_font;
 extern long hardware_video_decoding;
 extern std::vector<std::string> ff8_disable_remastered_hd_textures;
+extern long game_language;
 
 void read_cfg();
 bool is_remastered_hd_textures_disabled(const std::string &module);

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -2893,7 +2893,20 @@ uint32_t get_version()
 
 void concat_lang_str(PCHAR buffer)
 {
-	switch (version)
+	int v = version;
+
+	if (ff8_remastered_edition) {
+		switch (game_language) {
+			case GAME_LANGUAGE_EN: v = VERSION_FF8_12_US; break;
+			case GAME_LANGUAGE_FR: v = VERSION_FF8_12_FR; break;
+			case GAME_LANGUAGE_DE: v = VERSION_FF8_12_DE; break;
+			case GAME_LANGUAGE_SP: v = VERSION_FF8_12_SP; break;
+			case GAME_LANGUAGE_IT: v = VERSION_FF8_12_IT; break;
+			case GAME_LANGUAGE_JP: v = VERSION_FF8_12_JP; break;
+		}
+	}
+
+	switch (v)
 	{
 	case VERSION_FF7_102_US:
 	case VERSION_FF8_12_US:
@@ -2928,6 +2941,20 @@ void concat_lang_str(PCHAR buffer)
 		strcat(buffer, "jp");
 		break;
 	}
+}
+
+bool ff8_language_paths(char *fs_lang, char *wmset_lang)
+{
+	switch (game_language) {
+		case GAME_LANGUAGE_EN: strcpy(fs_lang, "eng");strcpy(wmset_lang, "us"); return true;
+		case GAME_LANGUAGE_FR: strcpy(fs_lang, "fre");strcpy(wmset_lang, "fr"); return true;
+		case GAME_LANGUAGE_DE: strcpy(fs_lang, "ger");strcpy(wmset_lang, "gr"); return true;
+		case GAME_LANGUAGE_SP: strcpy(fs_lang, "spa");strcpy(wmset_lang, "sp"); return true;
+		case GAME_LANGUAGE_IT: strcpy(fs_lang, "ita");strcpy(wmset_lang, "it"); return true;
+		case GAME_LANGUAGE_JP: strcpy(fs_lang, "jp"); strcpy(wmset_lang, "jp"); return true;
+	}
+
+	return false;
 }
 
 void get_data_lang_path(PCHAR buffer, bool absolute)
@@ -3332,6 +3359,23 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 				patch_code_byte(uint32_t(ff8_externals.set_game_paths) + 0x1F0, DRIVE_NO_ROOT_DIR);
 				memcpy_code(uint32_t(ff8_externals.archive_path_prefix_field), "\\ff8\\data\\x\\field\\", sizeof("\\ff8\\data\\x\\field\\"));
 				memcpy_code(uint32_t(ff8_externals.archive_path_prefix_world), "\\ff8\\data\\x\\world\\", sizeof("\\ff8\\data\\x\\world\\"));
+				if (game_language > GAME_LANGUAGE_AUTO) {
+					char fs_lang[4] = {}, wmset_lang[3] = {};
+					ff8_language_paths(fs_lang, wmset_lang);
+					char archive_path_prefix[MAX_PATH] = {};
+					snprintf(archive_path_prefix, sizeof(archive_path_prefix), "\\ff8\\data\\%s\\", fs_lang);
+					memcpy_code(uint32_t(ff8_externals.archive_path_prefix), archive_path_prefix, strlen(archive_path_prefix) + 1);
+					snprintf(archive_path_prefix, sizeof(archive_path_prefix), "\\ff8\\data\\%s\\menu\\", fs_lang);
+					memcpy_code(uint32_t(ff8_externals.archive_path_prefix_menu), archive_path_prefix, strlen(archive_path_prefix) + 1);
+					snprintf(archive_path_prefix, sizeof(archive_path_prefix), "\\ff8\\data\\%s\\battle\\", fs_lang);
+					memcpy_code(uint32_t(ff8_externals.archive_path_prefix_battle), archive_path_prefix, strlen(archive_path_prefix) + 1);
+					// Update lookup for main.fs
+					_strupr(fs_lang);
+					snprintf(archive_path_prefix, sizeof(archive_path_prefix), "\\DATA\\%s\\", fs_lang);
+					memcpy_code(ff8_externals.moriya_filesystem_archives_lookup + 800 * 5 + sizeof(uint32_t), archive_path_prefix, strlen(archive_path_prefix) + 1);
+					// Set wmsetxx.dat path
+					memcpy_code(uint32_t(*ff8_externals.worldmap_wmset_path) + 9, wmset_lang, 2);
+				}
 			}
 			else if (strstr(dllName, "af3dn.p") != NULL)
 			{

--- a/src/crashdump.cpp
+++ b/src/crashdump.cpp
@@ -89,7 +89,7 @@ LONG WINAPI ExceptionHandler(EXCEPTION_POINTERS *ep)
 
 	if (create_crash_dump)
 	{
-		if (steam_edition) get_userdata_path(filePath, sizeof(filePath), false);
+		if (steam_edition || ff8_remastered_edition) get_userdata_path(filePath, sizeof(filePath), false);
 		PathAppendA(filePath, "crash.dmp");
 
 		HANDLE file = CreateFile(filePath, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, 0);

--- a/src/exe_data.cpp
+++ b/src/exe_data.cpp
@@ -19,12 +19,19 @@
 //    GNU General Public License for more details.                          //
 /****************************************************************************/
 
+#include <shlwapi.h>
+
 #include "common.h"
 #include "log.h"
 #include "utils.h"
 #include "patch.h"
 #include "saveload.h"
 #include "ff8/file.h"
+
+constexpr char *FF8_EXE_BATTLE_SCANS = "battle_scans";
+constexpr char *FF8_EXE_CARD_NAMES = "card_names";
+constexpr char *FF8_EXE_DRAW_POINT = "draw_point";
+constexpr char *FF8_EXE_CARD_TEXTS = "card_texts";
 
 uint8_t *ff8_exe_scan_texts = nullptr;
 bool ff8_exe_scan_texts_file_absent = false;
@@ -34,6 +41,11 @@ uint8_t *ff8_exe_draw_point = nullptr;
 bool ff8_exe_draw_point_file_absent = false;
 uint8_t *ff8_exe_card_texts = nullptr;
 bool ff8_exe_card_texts_file_absent = false;
+
+uint8_t *ff8_remastered_scan_texts = nullptr;
+uint8_t *ff8_remastered_card_names = nullptr;
+uint8_t *ff8_remastered_draw_point = nullptr;
+uint8_t *ff8_remastered_card_texts = nullptr;
 
 bool ff8_get_exe_path(const char *name, char *target_filename)
 {
@@ -62,24 +74,25 @@ bool ff8_get_exe_path(const char *name, char *target_filename)
     return false;
 }
 
-bool ff8_get_battle_scan_texts_filename(char *filename)
+uint8_t *ff8_remastered_open_exe_file(const char *name, int32_t *out_size = nullptr)
 {
-    return ff8_get_exe_path("battle_scans", filename);
-}
+    char target_filename[MAX_PATH] = {};
+    get_data_lang_path(target_filename, false);
+    PathAppendA(target_filename, name);
+    strcat(target_filename, "_");
+    concat_lang_str(target_filename);
+    strcat(target_filename, ".dat");
 
-bool ff8_get_card_names_filename(char *filename)
-{
-    return ff8_get_exe_path("card_names", filename);
-}
+    ff8_file_context context = ff8_file_context();
+    int32_t file_size = 0;
+    // Use FF8 filesystem
+    uint8_t *buffer = ff8_externals.open_read_close_file(&context, 0, &file_size, target_filename);
 
-bool ff8_get_draw_point_filename(char *filename)
-{
-    return ff8_get_exe_path("draw_point", filename);
-}
+    if (out_size != nullptr) {
+        *out_size = file_size;
+    }
 
-bool ff8_get_card_texts_filename(char *filename)
-{
-    return ff8_get_exe_path("card_texts", filename);
+    return buffer;
 }
 
 void ff8_dump_msd(const char *filename, uint8_t *data)
@@ -136,7 +149,7 @@ void ff8_dump_battle_scan_texts()
     }
 
     char filename[MAX_PATH] = {};
-    if (ff8_get_battle_scan_texts_filename(filename)) {
+    if (ff8_get_exe_path(FF8_EXE_BATTLE_SCANS, filename)) {
         ffnx_warning("Save exe file skipped because the file [ %s ] already exists.\n", filename);
 
         return;
@@ -177,7 +190,7 @@ void ff8_dump_card_names()
     }
 
     char filename[MAX_PATH] = {};
-    if (ff8_get_card_names_filename(filename)) {
+    if (ff8_get_exe_path(FF8_EXE_CARD_NAMES, filename)) {
         ffnx_warning("Save exe file skipped because the file [ %s ] already exists.\n", filename);
 
         return;
@@ -218,7 +231,7 @@ void ff8_dump_card_texts()
     }
 
     char filename[MAX_PATH] = {};
-    if (ff8_get_card_texts_filename(filename)) {
+    if (ff8_get_exe_path(FF8_EXE_CARD_TEXTS, filename)) {
         ffnx_warning("Save exe file skipped because the file [ %s ] already exists.\n", filename);
 
         return;
@@ -269,75 +282,29 @@ uint8_t *ff8_open_msd(char *filename, int *data_size = nullptr)
     return target_data;
 }
 
-uint8_t *ff8_override_battle_scans()
+uint8_t *ff8_override_msd_data(const char *name, uint8_t *&msd_texts, bool &file_is_absent, int *data_size = nullptr)
 {
-    if (ff8_exe_scan_texts != nullptr || ff8_exe_scan_texts_file_absent) {
-        return ff8_exe_scan_texts;
+    if (msd_texts != nullptr || file_is_absent) {
+        return msd_texts;
     }
 
     char filename[MAX_PATH] = {};
-    if (! ff8_get_battle_scan_texts_filename(filename)) {
-        ff8_exe_scan_texts_file_absent = true;
+    if (! ff8_get_exe_path(name, filename)) {
+        file_is_absent = true;
 
         return nullptr;
     }
 
-    ff8_exe_scan_texts = ff8_open_msd(filename);
+    msd_texts = ff8_open_msd(filename, data_size);
 
-    return ff8_exe_scan_texts;
-}
-
-uint8_t *ff8_override_card_names()
-{
-    if (ff8_exe_card_names != nullptr || ff8_exe_card_names_file_absent) {
-        return ff8_exe_card_names;
-    }
-
-    char filename[MAX_PATH] = {};
-    if (! ff8_get_card_names_filename(filename)) {
-        ff8_exe_card_names_file_absent = true;
-
-        return nullptr;
-    }
-
-    ff8_exe_card_names = ff8_open_msd(filename);
-
-    return ff8_exe_card_names;
-}
-
-uint8_t *ff8_override_draw_point()
-{
-    if (ff8_exe_draw_point != nullptr || ff8_exe_draw_point_file_absent) {
-        return ff8_exe_draw_point;
-    }
-
-    char filename[MAX_PATH] = {};
-    if (! ff8_get_draw_point_filename(filename)) {
-        ff8_exe_draw_point_file_absent = true;
-
-        return nullptr;
-    }
-
-    ff8_exe_draw_point = ff8_open_msd(filename);
-
-    return ff8_exe_draw_point;
+    return msd_texts;
 }
 
 uint8_t *ff8_override_card_texts()
 {
-    if (ff8_exe_card_texts != nullptr || ff8_exe_card_texts_file_absent) {
-        return ff8_exe_card_texts;
-    }
-
-    char filename[MAX_PATH] = {};
-    if (! ff8_get_card_texts_filename(filename)) {
-        ff8_exe_card_texts_file_absent = true;
-
-        return nullptr;
-    }
-
     int data_size = 0;
-    uint8_t *ff8_exe_card_texts_msd = ff8_open_msd(filename, &data_size);
+    uint8_t *ff8_exe_card_texts_msd = nullptr;
+    ff8_exe_card_texts_msd = ff8_override_msd_data(FF8_EXE_CARD_TEXTS, ff8_exe_card_texts_msd, ff8_exe_card_texts_file_absent, &data_size);
 
     if (ff8_exe_card_texts_msd == nullptr) {
         return nullptr;
@@ -373,15 +340,26 @@ uint8_t *ff8_override_card_texts()
 
 uint8_t *ff8_battle_get_scan_text(uint8_t target_id)
 {
-    uint8_t *direct_data_msd = ff8_override_battle_scans();
+    uint8_t *direct_data_msd = ff8_override_msd_data(FF8_EXE_BATTLE_SCANS, ff8_exe_scan_texts, ff8_exe_scan_texts_file_absent);
+    uint8_t *entities = (uint8_t *)ff8_externals.battle_entities_1D27BCB;
 
     if (direct_data_msd != nullptr) {
         uint32_t *positions = (uint32_t *)direct_data_msd;
-        uint8_t *entities = (uint8_t *)ff8_externals.battle_entities_1D27BCB;
 
         if (trace_all) ffnx_trace("%s: get scan text target_id=%d entity_id=%d\n", __func__, target_id, entities[208 * target_id]);
 
         return direct_data_msd + positions[entities[208 * target_id]];
+    }
+
+    if (ff8_remastered_edition) {
+        if (ff8_remastered_scan_texts == nullptr) {
+            ff8_remastered_scan_texts = ff8_remastered_open_exe_file("desc_scan");
+        }
+        if (ff8_remastered_scan_texts != nullptr) {
+            uint16_t *positions = (uint16_t *)ff8_remastered_scan_texts;
+
+            return ff8_remastered_scan_texts + 320 + positions[entities[208 * target_id]];
+        }
     }
 
     return ((uint8_t*(*)(uint8_t))ff8_externals.scan_get_text_sub_B687C0)(target_id);
@@ -393,13 +371,24 @@ char *ff8_get_card_name(int32_t card_id)
         return nullptr;
     }
 
-    uint8_t *direct_data_msd = ff8_override_card_names();
+    uint8_t *direct_data_msd = ff8_override_msd_data(FF8_EXE_CARD_NAMES, ff8_exe_card_names, ff8_exe_card_names_file_absent);
     if (direct_data_msd != nullptr) {
         uint32_t *positions = (uint32_t *)direct_data_msd;
 
         if (trace_all) ffnx_trace("%s: get card name card_id=%d\n", __func__, card_id);
 
         return (char *)direct_data_msd + positions[card_id];
+    }
+
+    if (ff8_remastered_edition) {
+        if (ff8_remastered_card_names == nullptr) {
+            ff8_remastered_card_names = ff8_remastered_open_exe_file("off_cards_names");
+        }
+        if (ff8_remastered_card_names != nullptr) {
+            uint16_t *positions = (uint16_t *)ff8_remastered_card_names;
+
+            return (char *)ff8_remastered_card_names + positions[card_id + 1];
+        }
     }
 
     uint16_t *positions = *(uint16_t **)ff8_externals.card_name_positions;
@@ -420,7 +409,7 @@ void dump_exe_data()
         ff8_dump_battle_scan_texts();
         ff8_dump_card_names();
 
-        if (!ff8_get_draw_point_filename(dirname)) {
+        if (!ff8_get_exe_path(FF8_EXE_DRAW_POINT, dirname)) {
             ff8_dump_msd(dirname, *(uint8_t **)ff8_externals.drawpoint_messages);
         }
 
@@ -439,11 +428,17 @@ void exe_data_init()
     {
         replace_call(ff8_externals.sub_84F8D0 + 0x88, ff8_battle_get_scan_text);
         replace_function(ff8_externals.get_card_name, ff8_get_card_name);
-        uint8_t *msd = ff8_override_draw_point();
+        uint8_t *msd = ff8_override_msd_data(FF8_EXE_DRAW_POINT, ff8_exe_draw_point, ff8_exe_draw_point_file_absent);
+        if (msd == nullptr && ff8_remastered_edition) {
+            msd = ff8_remastered_open_exe_file("off_text_draw_point");
+        }
         if (msd != nullptr) {
             patch_code_uint(ff8_externals.drawpoint_messages, uint32_t(msd));
         }
         msd = ff8_override_card_texts();
+        if (msd == nullptr && ff8_remastered_edition) {
+            msd = ff8_remastered_open_exe_file("byte_card_texts");
+        }
         if (msd != nullptr) {
             patch_code_uint(uint32_t(ff8_externals.card_texts_off_B96504), uint32_t(msd));
             patch_code_uint(uint32_t(ff8_externals.card_texts_off_B96968), uint32_t(msd));

--- a/src/ff8.h
+++ b/src/ff8.h
@@ -1323,6 +1323,7 @@ struct ff8_externals
 	uint32_t worldmap_main_loop;
 	uint32_t worldmap_enter_main;
 	uint32_t worldmap_sub_53F310;
+	char **worldmap_wmset_path;
 	uint32_t worldmap_sub_53F310_call_24D;
 	uint32_t worldmap_sub_53F310_call_2A9;
 	uint32_t worldmap_sub_53F310_call_30D;
@@ -1560,10 +1561,14 @@ struct ff8_externals
 	uint32_t moriya_filesystem_seek;
 	uint32_t moriya_filesystem_read;
 	uint32_t moriya_filesystem_close;
+	uint32_t moriya_filesystem_archives_lookup;
 	uint32_t read_or_uncompress_fs_data;
 	uint32_t lzs_uncompress;
 	void(*free_file_container)(ff8_file_container *);
 	ff8_file_container*(*archive_open)(char*,char*,char*);
+	uint32_t archive_open_fi;
+	uint32_t archive_open_fi_2;
+	uint8_t*(*open_read_close_file)(ff8_file_context*,int,int32_t*,const char*);
 	void(*sub_archive_get_filename)(const char*,char*);
 	char *temp_fs_path_cache;
 	uint32_t field_get_dialog_string;

--- a/src/ff8/vram.cpp
+++ b/src/ff8/vram.cpp
@@ -436,9 +436,7 @@ const std::string &tex_name_special_cases_remastered(std::string &filename, cons
 		}
 	} else if (vram_id >= 20 && full_filename.starts_with("ff8logo\\")) {
 		// Add lang
-		char langPath[16] = {};
-		concat_lang_str(langPath);
-		if (JP_VERSION) {
+		if (JP_VERSION || game_language == GAME_LANGUAGE_JP) {
 			filename.append("_jp");
 		} else {
 			filename.append("_efigs");

--- a/src/ff8_data.cpp
+++ b/src/ff8_data.cpp
@@ -182,6 +182,7 @@ void ff8_find_externals()
 	ff8_externals.moriya_filesystem_read = get_relative_call(uint32_t(ff8_externals.sm_pc_read), 0xB7);
 	ff8_externals._read = (int (*)(int,void*,unsigned int))get_relative_call(uint32_t(ff8_externals.sm_pc_read), 0xC7);
 	ff8_externals._read_lk = (unsigned int (*)(int,LPVOID,DWORD))get_relative_call(uint32_t(ff8_externals._read), 0x38);
+	ff8_externals.moriya_filesystem_archives_lookup = get_absolute_value(ff8_externals.moriya_filesystem_open, 0x90);
 	ff8_externals.open_and_write_to_archive = get_relative_call(ff8_externals.moriya_filesystem_open, 0x3E1);
 	ff8_externals.write_to_archive = get_relative_call(ff8_externals.open_and_write_to_archive, 0x30);
 	ff8_externals._write = (int (*)(int,void*,unsigned int))get_relative_call(ff8_externals.write_to_archive, 0x44);
@@ -193,6 +194,9 @@ void ff8_find_externals()
 	ff8_externals.sub_archive_get_filename = (void(*)(const char*,char*))get_relative_call(ff8_externals.moriya_filesystem_open, 0x126);
 	ff8_externals.temp_fs_path_cache = (char *)get_absolute_value(ff8_externals.moriya_filesystem_open, 0x161);
 	ff8_externals.archive_open = (ff8_file_container*(*)(char*,char*,char*))get_relative_call(ff8_externals.moriya_filesystem_open, 0x27D);
+	ff8_externals.archive_open_fi = get_relative_call(uint32_t(ff8_externals.archive_open), 0x27);
+	ff8_externals.archive_open_fi_2 = get_relative_call(ff8_externals.archive_open_fi, 0xD);
+	ff8_externals.open_read_close_file = (uint8_t*(*)(ff8_file_context*,int,int32_t*,const char*))get_relative_call(ff8_externals.archive_open_fi_2, 0x24);
 
 	ff8_externals.cdcheck_sub_52F9E0 = get_relative_call(ff8_externals.cdcheck_main_loop, 0x95);
 
@@ -707,6 +711,7 @@ void ff8_find_externals()
 
 	if(FF8_US_VERSION)
 	{
+		ff8_externals.worldmap_wmset_path = (char **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x51);
 		ff8_externals.worldmap_sub_53F310_call_24D = ff8_externals.worldmap_sub_53F310 + 0x24D;
 		ff8_externals.worldmap_wmset_set_pointers_sub_542DA0 = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x24D);
 		ff8_externals.worldmap_section17_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_wmset_set_pointers_sub_542DA0, 0x1ED);
@@ -784,6 +789,7 @@ void ff8_find_externals()
 	}
 	else
 	{
+		ff8_externals.worldmap_wmset_path = (char **)get_absolute_value(ff8_externals.worldmap_sub_53F310, 0x4E);
 		ff8_externals.worldmap_sub_53F310_call_24D = ff8_externals.worldmap_sub_53F310 + 0x249;
 		ff8_externals.worldmap_wmset_set_pointers_sub_542DA0 = get_relative_call(ff8_externals.worldmap_sub_53F310, 0x249);
 		ff8_externals.worldmap_section17_position = (uint32_t **)get_absolute_value(ff8_externals.worldmap_wmset_set_pointers_sub_542DA0, 0x21C);


### PR DESCRIPTION
## Summary

Add multilingual support for the remastered
<img width="1026" height="800" alt="2026-09-02 23_15_55-Final Fantasy VIII (Direct3D11) devel" src="https://github.com/user-attachments/assets/6bece224-6347-4844-9ad4-b3c34ab6cce9" />
<img width="1026" height="800" alt="2026-09-02 23_19_25-Final Fantasy VIII (Direct3D11) devel" src="https://github.com/user-attachments/assets/154635a0-f628-4261-a0f8-ddb792f38d1f" />
<img width="1026" height="800" alt="2026-09-02 23_20_18-Final Fantasy VIII (Direct3D11) devel" src="https://github.com/user-attachments/assets/8a381142-484b-4372-91d1-e0bd0e5537cb" />
<img width="1026" height="800" alt="2026-09-02 23_21_34-Final Fantasy VIII (Direct3D11) devel" src="https://github.com/user-attachments/assets/c75f38b0-6735-4e88-b18b-0e2acc4f2b54" />

### Motivation

The remastered edition is the only one to contains all the languages, meaning that FFNx can natively support multi language without using mods.

### Thoughts

We add a new parameter to FFNx, if it is not set, the game lang is the one that comes from the exe.
The official launcher sets a language entry in {DOCUMENTS}\My Games\FINAL FANTASY VIII Remastered\Steam\{USER_ID}\config.txt

```
width			1920
height			1080
language		FR
mastervol		100
bgmvol			100
screenmode		0
display			0
cameraspeed		4
brightness		50
antialiaslevel	1
firstboot	1
```

We could parse this file and use this language if available

### ACKs

- [X] I have updated the [Changelog.md](https://github.com/julianxhokaxhiu/FFNx/blob/master/Changelog.md) file
- N/A I did test my code on FF7
- [X] I did test my code on FF8
